### PR TITLE
Compile fix for multiworld

### DIFF
--- a/src/main/java/org/dynmap/DynmapPlugin.java
+++ b/src/main/java/org/dynmap/DynmapPlugin.java
@@ -40,7 +40,7 @@ public class DynmapPlugin extends JavaPlugin {
     }
 
     public World getWorld() {
-        return getServer().getWorlds()[0];
+        return getServer().getWorlds().get(0);
     }
 
     public MapManager getMapManager() {


### PR DESCRIPTION
Updated getWorlds()[0] to getWorlds().get(0)

Fixes #31
