### PR TITLE
Fix focuschatballoons

### DIFF
--- a/web/map.js
+++ b/web/map.js
@@ -419,7 +419,7 @@ DynMap.prototype = {
 			popup.popupTime = now.getTime();
 			if (!popup.infoWindow) {
 				popup.infoWindow = new google.maps.InfoWindow({
-					disableAutoPan: me.options.focuschatballoons || false,
+					disableAutoPan: !me.options.focuschatballoons || false,
 				    content: htmlMessage
 				});
 			} else {


### PR DESCRIPTION
Hi,

I fix focuschatballoons, I think if focuschatballoons properties are at false, disableAutoPan in map.js code should be at true. For me, focuschatballoons at false significates that I don't want focus on chat balloons. I hope I'm not misunderstand.
