### PR TITLE
Minor pom.xml update for UTF-8. Good stuff. :)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,9 @@
   <artifactId>dynmap</artifactId>
   <version>0.15</version>
   <name>dynmap</name>
+    <properties>
+       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
   <url>http://github.com/FrozenCow/dynmap/</url>
   <issueManagement>
   	<system>GitHub</system>


### PR DESCRIPTION
Force maven to treat everything as UTF-8. Removed a warning at compile time.
