### PR TITLE
Add support for WorldGuard on built-in server

### DIFF
--- a/src/main/java/org/dynmap/ConfigurationNode.java
+++ b/src/main/java/org/dynmap/ConfigurationNode.java
@@ -132,10 +132,11 @@ public class ConfigurationNode implements Map<String, Object> {
     }
     
     public List<ConfigurationNode> getNodes(String path) {
-        Object o = getObject(path);
-        if (!(o instanceof List<?>)) {
+        List<Object> o = getList(path);
+
+        if(o == null)
             return new ArrayList<ConfigurationNode>();
-        }
+        
         ArrayList<ConfigurationNode> nodes = new ArrayList<ConfigurationNode>();
         for(Object i : (List<?>)o) {
             if (i instanceof Map<?, ?>) {

--- a/src/main/java/org/dynmap/DynmapPlugin.java
+++ b/src/main/java/org/dynmap/DynmapPlugin.java
@@ -46,6 +46,7 @@ import org.dynmap.web.handlers.ClientConfigurationHandler;
 import org.dynmap.web.handlers.ClientUpdateHandler;
 import org.dynmap.web.handlers.FilesystemHandler;
 import org.dynmap.web.handlers.SendMessageHandler;
+import org.dynmap.web.handlers.RegionHandler;
 
 public class DynmapPlugin extends JavaPlugin {
     public HttpServer webServer = null;
@@ -141,7 +142,15 @@ public class DynmapPlugin extends JavaPlugin {
         webServer.handlers.put("/tiles/", new FilesystemHandler(tilesDirectory));
         webServer.handlers.put("/up/", new ClientUpdateHandler(mapManager, playerList, getServer(), configuration.getBoolean("health-in-json", false)));
         webServer.handlers.put("/up/configuration", new ClientConfigurationHandler(configuration.getNode("web")));
-
+        /* See if regions configuration branch is present */
+        for(ConfigurationNode type : configuration.getNode("web").getNodes("components")) {
+            if(type.getString("type").equalsIgnoreCase("regions")) {
+                String fname = type.getString("filename", "regions.yml");
+                fname = "/standalone/" + fname.substring(0, fname.lastIndexOf('.')) + "_"; /* Find our path base */
+                webServer.handlers.put(fname + "*", new RegionHandler(type));
+            }
+        }
+        
         if (configuration.getNode("web").getBoolean("allowwebchat", false)) {
             SendMessageHandler messageHandler = new SendMessageHandler() {{
                 maximumMessageInterval = (configuration.getNode("web").getInteger("webchat-interval", 1) * 1000);

--- a/src/main/java/org/dynmap/JsonTimerTask.java
+++ b/src/main/java/org/dynmap/JsonTimerTask.java
@@ -33,7 +33,7 @@ class JsonTimerTask extends TimerTask {
         this.server = this.plugin.getServer();
         this.mapManager = this.plugin.getMapManager();
         this.configuration = config;
-        for(ConfigurationNode type : configuration.getNodes("web/components"))
+        for(ConfigurationNode type : configuration.getNode("web").getNodes("components"))
             if(type.getString("type").equalsIgnoreCase("regions")) {
                 this.regions = type;
                 break;

--- a/src/main/java/org/dynmap/web/HttpServerConnection.java
+++ b/src/main/java/org/dynmap/web/HttpServerConnection.java
@@ -161,6 +161,13 @@ public class HttpServerConnection extends Thread {
                         handler = entry.getValue();
                         break;
                     }
+                    /* Wildcard handler for non-directory matches */
+                    else if(key.endsWith("*") && request.path.startsWith(key.substring(0, key.length()-1))) {                        relativePath = request.path.substring(entry.getKey().length());
+                        relativePath = request.path.substring(entry.getKey().length()-1);
+                        relativePath = URLDecoder.decode(relativePath,"utf-8");
+                        handler = entry.getValue();
+                        break;
+                    }
                 }
 
                 if (handler == null) {

--- a/src/main/java/org/dynmap/web/handlers/RegionHandler.java
+++ b/src/main/java/org/dynmap/web/handlers/RegionHandler.java
@@ -1,0 +1,73 @@
+package org.dynmap.web.handlers;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.logging.Level;
+import org.bukkit.util.config.Configuration;
+import org.dynmap.ConfigurationNode;
+import org.dynmap.web.HttpRequest;
+import org.dynmap.web.HttpResponse;
+import org.dynmap.web.Json;
+import java.io.ByteArrayOutputStream;
+import java.io.ByteArrayInputStream;
+
+public class RegionHandler extends FileHandler {
+    private ConfigurationNode regions;
+    public RegionHandler(ConfigurationNode regions) {
+        this.regions = regions;
+    }
+    @Override
+    protected InputStream getFileInput(String path, HttpRequest request, HttpResponse response) {
+        if(regions == null)
+            return null;
+        /* Right path? */
+        if(path.endsWith(".json") == false)
+            return null;
+
+        String worldname = path.substring(0, path.lastIndexOf(".json"));
+        Configuration regionConfig = null;
+        File infile;
+        String regionFile;
+        
+        /* If using worldpath, format is either plugins/<plugin>/<worldname>/<filename> OR 
+         * plugins/<plugin>/worlds/<worldname>/<filename>
+         */
+        File basepath = new File("plugins", regions.getString("name", "WorldGuard"));
+        if(basepath.exists() == false)
+            return null;
+        if(regions.getBoolean("useworldpath", false)) {
+            regionFile = worldname + "/" + regions.getString("filename", "regions.yml");
+            infile = new File(basepath, regionFile);
+            if(!infile.exists()) {
+                infile = new File(basepath, "worlds/" + regionFile);
+            }
+        }
+        else {  /* Else, its plugins/<plugin>/<filename> */
+            regionFile = regions.getString("filename", "regions.yml");
+            infile = new File(basepath, regionFile);
+        }
+        if(infile.exists()) {
+            regionConfig = new Configuration(infile);
+        }
+        //File didn't exist
+        if(regionConfig == null)
+            return null;
+        regionConfig.load();
+        /* Parse region data and store in MemoryInputStream */
+        Map<?, ?> regionData = (Map<?, ?>) regionConfig.getProperty(regions.getString("basenode", "regions"));
+        try {
+            ByteArrayOutputStream fos = new ByteArrayOutputStream();
+            fos.write(Json.stringifyJson(regionData).getBytes());
+            fos.close();
+            return new ByteArrayInputStream(fos.toByteArray());
+        } catch (FileNotFoundException ex) {
+            log.log(Level.SEVERE, "Exception while writing JSON-file.", ex);
+        } catch (IOException ioe) {
+            log.log(Level.SEVERE, "Exception while writing JSON-file.", ioe);
+        }        
+        return null;
+    }
+}


### PR DESCRIPTION
This consisted principally of reproducing the code used for generating the mappings of the regions.yml files under the standalone code so that a similar function was provided by a new web content handler.  For simplicity's sake, it attaches under the same relative path as the standalone files would be (I added support for a wild card terminated registration path for a handler - /standalone/regions_\* would be the path used typically by this handler.  In any case, it seems to work at least as well as the existing support (looks like there are still some issues with the clickable area on the zoomed tiles and on the flat map....will take a peek at those).  Also, hit some problems with getNodes() on the new ConfigurationNode replacement - made fix that seems to work (problem would also have impacted standalone worldguard support).
