### PR TITLE
Add support for world-type-specific templates in configuration.txt - automatically configure worlds

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -108,10 +108,12 @@ spammessage: "You may only chat once every %interval% seconds."
 defaultzoom: 0
 defaultworld: world
 
-# The maptypes Dynmap will use to render.
-worlds:
-  - name: world
-    title: "World"
+# template world - this is used for worlds that exist but aren't defined in the worlds section.
+# Also, it supplies the "maps" section for worlds lacking a maps section, and the "center"
+# for worlds lacking a "center" section.
+template:
+  # Template for normal world
+  normal:
     center:
       x: 0
       y: 64
@@ -147,8 +149,8 @@ worlds:
             title: "Cave"
             prefix: ct
             maximumheight: 127
-  - name: nether
-    title: "Nether"
+  # Nether world template
+  nether:
     center:
       x: 0
       y: 64
@@ -167,6 +169,76 @@ worlds:
             prefix: nt
             maximumheight: 127
             colorscheme: default
+
+
+# The maptypes Dynmap will use to render.
+worlds:
+  # Worlds can be handled by templates, based on world type
+  # To override, provide name and title here.  Any other sections that are provided will
+  #   be used instead of the template's value (center, maps).
+  #- name: world
+  #  title: "World"
+  #   Rest of comes from template - uncomment to tailor for world specifically
+  #  center:
+  #    x: 0
+  #    y: 64
+  #    z: 0
+  #  maps:
+  #    - class: org.dynmap.flat.FlatMap
+  #      name: flat
+  #      title: "Flat"
+  #      prefix: flat
+  #      colorscheme: default
+  #    - class: org.dynmap.kzedmap.KzedMap
+  #      renderers:
+  #        - class: org.dynmap.kzedmap.DefaultTileRenderer
+  #          name: surface
+  #          title: "Surface"
+  #          prefix: t
+  #          maximumheight: 127
+  #          colorscheme: default
+  #          # Add shadows to world (based on top-down shadows from chunk data)
+  #          # shadowstrength: 1.0
+  #          # Sets the icon to 'images/block_custom.png'
+  #          # icon: custom
+  #        #- class: org.dynmap.kzedmap.HighlightTileRenderer
+  #        #  prefix: ht
+  #        #  maximumheight: 127
+  #        #  colorscheme: default
+  #        #  highlight: # For highlighting multiple block-types.
+  #        #    - 56 # Highlight diamond-ore
+  #        #    - 66 # Highlight minecart track
+  #        #  highlight: 56 # For highlighting a single block-type.
+  #        - class: org.dynmap.kzedmap.CaveTileRenderer
+  #          name: cave
+  #          title: "Cave"
+  #          prefix: ct
+  #          maximumheight: 127
+  #
+  # To just label world, and inherit rest from template, just provide name and title
+  #-name: world2
+  # title: "Second World"
+  #
+  #- name: nether
+  #  title: "Nether"
+  #  center:
+  #    x: 0
+  #    y: 64
+  #    z: 0
+  #  maps:
+  #    - class: org.dynmap.flat.FlatMap
+  #      name: flat
+  #      title: "Flat"
+  #      prefix: flat
+  #      colorscheme: default
+  #    - class: org.dynmap.kzedmap.KzedMap
+  #      renderers:
+  #        - class: org.dynmap.kzedmap.DefaultTileRenderer
+  #          name: nether
+  #          title: "Surface"
+  #          prefix: nt
+  #          maximumheight: 127
+  #          colorscheme: default
 
 # Enables debugging.
 #debuggers:


### PR DESCRIPTION
Per our discussion, this feature adds support for a template section in the configuration.txt.  The template section, if defined, contains one subsection for each world type (currently, normal and nether - figured we should plan for the "sky-world" thing if that pans out...).  The format of each of these is the same as for any world, with the exception of not including the "name" and "title" attributes.  The behavior for this is to do the following:
1) If a world exists, but has no definition, and their is a template section matching the type of world it is, use the template to run-time generate the configuration for that world, and with the right 'name' and with "title" set to the name.
2) If a world exists, and has a definition that lacks one of the key fields (center, maps, title), and an appropriate template exists, add the missing sections using the template (or, for label, generate it from the name).
For folks wanting to tailor the maps, things work same as always.  Also, if folks don't want the automatic configuration, they can simply delete the template section (or the appropriate subsection to disable automatic initialization for a given world type).

The default configuration.txt is updated to exploit this - the idea here is that probably 80% of our users (maybe more for the ones that fight with our configuration), the default out-of-the-box configuration will work, and work reasonably well.  From there, they are free to tailor the configuration (add just a name and title attributes for worlds where the template is good, but they want to tailor the title string; add those and the 'center' section to just control the default focus).

If you guys think it'd be good, we could add a "disabledworlds" attribute, if we want folks to have template initialized worlds while being able to "turn off" one or more of them from being declared.
