### PR TITLE
Fix debugger loading, and handle height field boundary condition at zero

### DIFF
--- a/src/main/java/org/dynmap/CraftChunkSnapshot.java
+++ b/src/main/java/org/dynmap/CraftChunkSnapshot.java
@@ -20,6 +20,9 @@ public class CraftChunkSnapshot implements ChunkSnapshot {
 		this.z = z;
 		this.buf = buf;
 		this.hmap = hmap;
+		for(int i = 0; i < 256; i++)
+		    if(hmap[i] < 1)
+		        hmap[i] = 1;
 	}
 	
 	/**
@@ -95,6 +98,6 @@ public class CraftChunkSnapshot implements ChunkSnapshot {
     }
     
     public int getHighestBlockYAt(int x, int z) {
-        return hmap[z << 4 | x] & 255;        
+        return hmap[z << 4 | x] & 255;
     }
 }

--- a/src/main/java/org/dynmap/DynmapPlugin.java
+++ b/src/main/java/org/dynmap/DynmapPlugin.java
@@ -261,7 +261,7 @@ public class DynmapPlugin extends JavaPlugin {
         for (ConfigurationNode debuggerConfiguration : debuggersConfiguration) {
             try {
                 Class<?> debuggerClass = Class.forName((String) debuggerConfiguration.getString("class"));
-                Constructor<?> constructor = debuggerClass.getConstructor(JavaPlugin.class, Map.class);
+                Constructor<?> constructor = debuggerClass.getConstructor(JavaPlugin.class, ConfigurationNode.class);
                 Debugger debugger = (Debugger) constructor.newInstance(this, debuggerConfiguration);
                 Debug.addDebugger(debugger);
             } catch (Exception e) {

--- a/src/main/java/org/dynmap/flat/FlatMap.java
+++ b/src/main/java/org/dynmap/flat/FlatMap.java
@@ -122,6 +122,7 @@ public class FlatMap extends MapType {
             mapiter.initialize(t.x * t.size + x, 127, t.y * t.size);
             for (int y = 0; y < t.size; y++, mapiter.incrementZ()) {
                 int blockType;
+                mapiter.setY(127);
                 if(isnether) {
                     while((blockType = mapiter.getBlockTypeID()) != 0) {
                         mapiter.decrementY();


### PR DESCRIPTION
Constructor change on debugger (switch from Map to ConfigurationNode) broke debugger loading, so needed small fix on reflection code.

Raw height map apparently doesn't respect same range as getMaximumYAt(), in that it can be zero (while that never returns less than 1).  Adjust loaded heightmap to match function.
