### PR TITLE
Rework BufferedImage handling to improve CPU performance

### DIFF
--- a/src/main/java/org/dynmap/CraftChunkSnapshot.java
+++ b/src/main/java/org/dynmap/CraftChunkSnapshot.java
@@ -20,9 +20,6 @@ public class CraftChunkSnapshot implements ChunkSnapshot {
 		this.z = z;
 		this.buf = buf;
 		this.hmap = hmap;
-		for(int i = 0; i < 256; i++)
-		    if(hmap[i] < 1)
-		        hmap[i] = 1;
 	}
 	
 	/**


### PR DESCRIPTION
Change BufferedImage handling to use externally allocated buffer, so that we can populate pixels directly, with minimum access overhead, and avoid needing to translate or copy the pixels before being encoded for writing to file.
