### PR TITLE
FIx snow rendering in flat map

### DIFF
--- a/src/main/java/org/dynmap/flat/FlatMap.java
+++ b/src/main/java/org/dynmap/flat/FlatMap.java
@@ -149,12 +149,17 @@ public class FlatMap extends MapType {
                     }
                 }
                 else {
-                    int my = mapiter.getHighestBlockYAt() - 1;
-                    if(my < 0)  /* If hole to bottom, all air */
-                        continue;
+                    int my = mapiter.getHighestBlockYAt();
                     if(my > maximumHeight) my = maximumHeight;
                     mapiter.setY(my);
                     blockType = mapiter.getBlockTypeID();
+                    if(blockType == 0) {    /* If air, go down one - fixes ice */
+                        my--;
+                        if(my < 0)
+                            continue;
+                        mapiter.setY(my);
+                        blockType = mapiter.getBlockTypeID();
+                    }
                 }
                 int data = 0;
                 Color[] colors = colorScheme.colors[blockType];


### PR DESCRIPTION
Turn out getMaximumYAt() value points to the surface snow, versus the air block above the surface (like for every other block type).  Fix to recognize this, so we see snow now.
