### PR TITLE
Add meta tags for Apple mobile devices - puts page in full screen mode

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,6 +8,10 @@
 	<meta name="keywords" content="minecraft, map, dynamic" />
 	<meta name="description" content="Minecraft Dynamic Map" />
 	<meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
+	<!-- These 2 lines make us fullscreen on apple mobile products - remove if you don't like that -->
+	<meta name="apple-mobile-web-app-capable" content="yes" />
+	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />	
+
 	<link rel="icon" href="images/dynmap.ico" type="image/ico" />
 
 	<!--<link rel="stylesheet" type="text/css" href="css/embedded.css" media="screen" />-->


### PR DESCRIPTION
This came in from an enhancement request, and seems to work nicely.  It causes the page to be treated as full-screen by the iPhone/iPad browser, so that all our controls are visible, versus having issues between their panning and our panning.  In any case, give it a look, if you can.  I added a comment to the index.html, so that anyone that doesn't like it can remove it easily enough.
