### PR TITLE
Add render statistics, support for tile hashcodes to reduce unneeded tile updates

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -65,6 +65,9 @@ display-whitelist: false
 # How often a tile gets rendered (in seconds).
 renderinterval: 1
 
+# Tile hashing is used to minimize tile file updates when no changes have occurred - set to false to disable
+enabletilehash: true
+
 render-triggers:
 #  - chunkloaded
 #  - playermove

--- a/src/main/java/org/dynmap/DynmapPlugin.java
+++ b/src/main/java/org/dynmap/DynmapPlugin.java
@@ -277,7 +277,9 @@ public class DynmapPlugin extends JavaPlugin {
         "hide",
         "show",
         "fullrender",
-        "reload" }));
+        "reload",
+        "stats",
+        "resetstats" }));
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String commandLabel, String[] args) {
@@ -343,6 +345,16 @@ public class DynmapPlugin extends JavaPlugin {
                 sender.sendMessage("Reloading Dynmap...");
                 reload();
                 sender.sendMessage("Dynmap reloaded");
+            } else if (c.equals("stats") && checkPlayerPermission(sender, "stats")) {
+                if(args.length == 1)
+                    mapManager.printStats(sender, null);
+                else
+                    mapManager.printStats(sender, args[1]);
+            } else if (c.equals("resetstats") && checkPlayerPermission(sender, "resetstats")) {
+                if(args.length == 1)
+                    mapManager.resetStats(sender, null);
+                else
+                    mapManager.resetStats(sender, args[1]);
             }
             return true;
         }

--- a/src/main/java/org/dynmap/MapTile.java
+++ b/src/main/java/org/dynmap/MapTile.java
@@ -36,4 +36,8 @@ public abstract class MapTile {
         }
         return super.equals(obj);
     }
+    
+    public String getKey() {
+        return world.getName() + "." + map.getName();
+    }
 }

--- a/src/main/java/org/dynmap/MapType.java
+++ b/src/main/java/org/dynmap/MapType.java
@@ -18,4 +18,6 @@ public abstract class MapType {
     
     public void buildClientConfiguration(JSONObject worldObject) {
     }
+    
+    public abstract String getName();
 }

--- a/src/main/java/org/dynmap/TileHashManager.java
+++ b/src/main/java/org/dynmap/TileHashManager.java
@@ -1,0 +1,152 @@
+package org.dynmap;
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.io.IOException;
+import java.util.zip.CRC32;
+
+/**
+ * Image hash code manager - used to reduce compression and notification of updated tiles that do not actually yield new content
+ *
+ */
+public class TileHashManager {
+    private File    tiledir;    /* Base tile directory */    
+    private boolean enabled;
+    
+    /**
+     * Each tile hash file is a 32x32 tile grid, with each file having a CRC32 hash code generated from its pre-compression frame buffer
+     */
+    private static class TileHashFile {
+        final String key;
+        final String subtype;
+        final int x;  /* minimum tile coordinate / 32 */
+        final int y;  /* minimum tile coordinate / 32 */
+        private File hf;
+        TileHashFile(String key, String subtype, int x, int y) {
+            this.key = key;
+            if(subtype != null)
+                this.subtype = subtype;
+            else
+                this.subtype = "";
+            this.x = x;
+            this.y = y;
+        }
+        @Override
+        public boolean equals(Object o) {
+            if(!(o instanceof TileHashFile))
+                return false;
+            TileHashFile fo = (TileHashFile)o;
+            return (x == fo.x) && (y == fo.y) && key.equals(fo.key) && (subtype.equals(fo.subtype)); 
+        }
+        @Override
+        public int hashCode() {
+            return key.hashCode() ^ subtype.hashCode() ^ (x << 16) ^ y;
+        }
+        
+        public File getHashFile(File tiledir) {
+            if(hf == null)
+                hf = new File(tiledir, key + (subtype.equals("")?"":("." + subtype)) + "_" + x + "_" + y + ".hash");
+            return hf;
+        }
+        /* Write to file */
+        public void writeToFile(File tiledir, byte[] crcbuf) {
+            try {
+                RandomAccessFile fd = new RandomAccessFile(getHashFile(tiledir), "rw");
+                fd.seek(0);
+                fd.write(crcbuf);
+                fd.close();
+            } catch (IOException iox) {
+                Log.severe("Error writing hash file - " + getHashFile(tiledir).getPath());
+            }
+        }
+        
+        /* Read from file */
+        public void readFromFile(File tiledir, byte[] crcbuf) {
+            try {
+                RandomAccessFile fd = new RandomAccessFile(getHashFile(tiledir), "r");
+                fd.seek(0);
+                fd.read(crcbuf);
+                fd.close();
+            } catch (IOException iox) {
+                Arrays.fill(crcbuf, (byte)0xFF);
+                writeToFile(tiledir, crcbuf);
+            }
+        }
+        /* Read CRC */
+        public long getCRC(int tx, int ty, byte[] crcbuf) {
+            int off = (128 * (ty & 0x1F)) + (4 * (tx & 0x1F));
+            long crc = 0;
+            for(int i = 0; i < 4; i++)
+                crc = (crc << 8) + (0xFF & (int)crcbuf[off+i]);
+            return crc;
+        }
+        /* Set CRC */
+        public void setCRC(int tx, int ty, byte[] crcbuf, long crc) {
+            int off = (128 * (ty & 0x1F)) + (4 * (tx & 0x1F));
+            for(int i = 0; i < 4; i++)
+                crcbuf[off+i] = (byte)((crc >> ((3-i)*8)) & 0xFF);
+        }
+    }
+    private Object lock = new Object();
+    private LinkedHashMap<TileHashFile, byte[]> tilehash = new LinkedHashMap<TileHashFile, byte[]>(16, (float) 0.75, true);
+    private CRC32 crc32 = new CRC32();
+    
+    public TileHashManager(File tileroot, boolean enabled) {
+        tiledir = tileroot;
+        this.enabled = enabled;
+    }
+    
+    /* Read cached hashcode for given tile */
+    public long getImageHashCode(String key, String subtype, int tx, int ty) {
+        if(!enabled) {
+            return -1;  /* Return value that never matches */
+        }
+        TileHashFile thf = new TileHashFile(key, subtype, tx >> 5, ty >> 5);
+        synchronized(lock) {
+            byte[] crcbuf = tilehash.get(thf);  /* See if we have it cached */
+            if(crcbuf == null) {    /* If not in cache, load it */
+                crcbuf = new byte[32*32*4]; /* Get our space */
+                Arrays.fill(crcbuf, (byte)0xFF);    /* Fill with -1 */
+                tilehash.put(thf, crcbuf);  /* Add to cache */
+                thf.readFromFile(tiledir, crcbuf);
+            }
+            return thf.getCRC(tx & 0x1F, ty & 0x1F, crcbuf);
+        }
+    }
+    /* Calculate hash code for given buffer */
+    public long calculateTileHash(int[] newbuf) {
+        if(!enabled) {
+            return 0;   /* Return value that doesn't match */
+        }
+        synchronized(lock) {
+            /* Calculate CRC-32 for buffer */
+            crc32.reset();
+            for(int i = 0; i < newbuf.length; i++) {
+                int v = newbuf[i];
+                crc32.update(0xFF & v);
+                crc32.update(0xFF & (v >> 8));
+                crc32.update(0xFF & (v >> 16));
+                crc32.update(0xFF & (v >> 24));
+            }
+            return crc32.getValue();
+        }
+    }
+    /* Update hashcode for given tile */
+    public void updateHashCode(String key, String subtype, int tx, int ty, long newcrc) {
+        if(!enabled)
+            return;
+        synchronized(lock) {
+            /* Now, find and check existing value */
+            TileHashFile thf = new TileHashFile(key, subtype, tx >> 5, ty >> 5);
+            byte[] crcbuf = tilehash.get(thf);  /* See if we have it cached */
+            if(crcbuf == null) {    /* If not in cache, load it */
+                crcbuf = new byte[32*32*4]; /* Get our space */
+                tilehash.put(thf, crcbuf);  /* Add to cache */
+                thf.readFromFile(tiledir, crcbuf);
+            }
+            thf.setCRC(tx & 0x1F, ty & 0x1F, crcbuf, newcrc);   /* Update field */
+            thf.writeToFile(tiledir, crcbuf);   /* And write it out */
+        }
+    }    
+}

--- a/src/main/java/org/dynmap/kzedmap/KzedMap.java
+++ b/src/main/java/org/dynmap/kzedmap/KzedMap.java
@@ -317,7 +317,11 @@ public class KzedMap extends MapType {
             }
         }
     }    
-    
+
+    public String getName() {
+        return "KzedMap";
+    }
+
     @Override
     public void buildClientConfiguration(JSONObject worldObject) {
         for(MapTileRenderer renderer : renderers) {

--- a/src/main/java/org/dynmap/kzedmap/KzedMapTile.java
+++ b/src/main/java/org/dynmap/kzedmap/KzedMapTile.java
@@ -48,6 +48,10 @@ public class KzedMapTile extends MapTile {
         return o.px == px && o.py == py && o.getWorld().equals(getWorld());
     }
 
+    public String getKey() {
+        return getWorld().getName() + "." + renderer.getName();
+    }
+
     public String toString() {
         return getWorld().getName() + ":" + getFilename();
     }

--- a/src/main/java/org/dynmap/kzedmap/KzedZoomedMapTile.java
+++ b/src/main/java/org/dynmap/kzedmap/KzedZoomedMapTile.java
@@ -56,4 +56,10 @@ public class KzedZoomedMapTile extends MapTile {
         }
         return super.equals(obj);
     }
+    
+
+    public String getKey() {
+        return getWorld().getName() + ".z" + originalTile.renderer.getName();
+    }
+
 }


### PR DESCRIPTION
This adds two new commands:
   /dynmap  stats - lists render statistics, by tile population and in total
   /dynmap stats <name> - limits statistics to those populations starting with the given name
   /dynmap resetstats - clears all render statistics
   /dynmap resetstats <name> - resets all statistics for tile populations starting with given name

Also, support for generating and maintaining hash codes for each tile has been added, as well as support to use those hash codes to avoid re-encoding and notifying web clients of tile updates that result in no change in tile content.  Hashcodes are generated from the uncompressed frame buffers, so rendering isn't avoided, but unneeded client churn and regeneration of zoomed tiles is.  Feature is enabled by default, and hashes will be lazy generated as tiles need rendering.  A flag is available in configuration.txt, enabletilehash, to disable the feature.

Plan for the hashing is to help support more efficient recalculation of zoomed tiles for N level zoom out feature.

Also, added exception handler to thread pool - exceptions in render were not being reported previously. 
