### PR TITLE
Add file access read/write locking to avoid conflicting tile updates, dirty reads by internal web server

### DIFF
--- a/src/main/java/org/dynmap/utils/FileLockManager.java
+++ b/src/main/java/org/dynmap/utils/FileLockManager.java
@@ -1,0 +1,105 @@
+package org.dynmap.utils;
+import java.io.File;
+import java.util.HashMap;
+
+import org.dynmap.Log;
+/**
+ * Implements soft-locks for prevent concurrency issues with file updates
+ */
+public class FileLockManager {
+    private static Object lock = new Object();
+    private static HashMap<String, Integer> filelocks = new HashMap<String, Integer>();
+    private static final Integer WRITELOCK = new Integer(-1);
+    /**
+     * Get write lock on file - exclusive lock, no other writers or readers
+     * @throws InterruptedException
+     */
+    public static void getWriteLock(File f) {
+        String fn = f.getPath();
+        synchronized(lock) {
+            boolean got_lock = false;
+            while(!got_lock) {
+                Integer lockcnt = filelocks.get(fn);    /* Get lock count */
+                if(lockcnt != null) {   /* If any locks, can't get write lock */
+                    try {
+                        lock.wait(); 
+                    } catch (InterruptedException ix) {
+                        Log.severe("getWriteLock(" + fn + ") interrupted");
+                    }
+                }
+                else {
+                    filelocks.put(fn, WRITELOCK);
+                    got_lock = true;
+                }
+            }
+        }
+        //Log.info("getWriteLock(" + f + ")");
+    }
+    /**
+     * Release write lock
+     */
+    public static void releaseWriteLock(File f) {
+        String fn = f.getPath();
+        synchronized(lock) {
+            Integer lockcnt = filelocks.get(fn);    /* Get lock count */
+            if(lockcnt == null)
+                Log.severe("releaseWriteLock(" + fn + ") on unlocked file");
+            else if(lockcnt.equals(WRITELOCK)) {
+                filelocks.remove(fn);   /* Remove lock */
+                lock.notifyAll();   /* Wake up folks waiting for locks */
+            }
+            else
+                Log.severe("releaseWriteLock(" + fn + ") on read-locked file");
+        }
+        //Log.info("releaseWriteLock(" + f + ")");
+    }
+    /**
+     * Get read lock on file - multiple readers allowed, blocks writers
+     */
+    public static void getReadLock(File f) {
+        String fn = f.getPath();
+        synchronized(lock) {
+            boolean got_lock = false;
+            while(!got_lock) {
+                Integer lockcnt = filelocks.get(fn);    /* Get lock count */
+                if(lockcnt == null) {
+                    filelocks.put(fn, Integer.valueOf(1));  /* First lock */
+                    got_lock = true;
+                }
+                else if(!lockcnt.equals(WRITELOCK)) {   /* Other read locks */
+                    filelocks.put(fn, Integer.valueOf(lockcnt+1));
+                    got_lock = true;
+                }
+                else {  /* Write lock in place */
+                    try {
+                        lock.wait(); 
+                    } catch (InterruptedException ix) {
+                        Log.severe("getReadLock(" + fn + ") interrupted");
+                    }
+                }
+            }
+        }        
+        //Log.info("getReadLock(" + f + ")");
+    }
+    /**
+     * Release read lock
+     */
+    public static void releaseReadLock(File f) {
+        String fn = f.getPath();
+        synchronized(lock) {
+            Integer lockcnt = filelocks.get(fn);    /* Get lock count */
+            if(lockcnt == null)
+                Log.severe("releaseReadLock(" + fn + ") on unlocked file");
+            else if(lockcnt.equals(WRITELOCK))
+                Log.severe("releaseReadLock(" + fn + ") on write-locked file");
+            else if(lockcnt > 1) {
+                filelocks.put(fn, Integer.valueOf(lockcnt-1));
+            }
+            else {
+                filelocks.remove(fn);   /* Remove lock */
+                lock.notifyAll();   /* Wake up folks waiting for locks */
+            }
+        }
+        //Log.info("releaseReadLock(" + f + ")");
+    }
+}

--- a/src/main/java/org/dynmap/web/handlers/FileHandler.java
+++ b/src/main/java/org/dynmap/web/handlers/FileHandler.java
@@ -13,6 +13,7 @@ import org.dynmap.web.HttpHandler;
 import org.dynmap.web.HttpRequest;
 import org.dynmap.web.HttpResponse;
 import org.dynmap.web.HttpStatus;
+import org.dynmap.utils.FileLockManager;
 
 public abstract class FileHandler implements HttpHandler {
     protected static final Logger log = Logger.getLogger("Minecraft");
@@ -42,6 +43,10 @@ public abstract class FileHandler implements HttpHandler {
     }
 
     protected abstract InputStream getFileInput(String path, HttpRequest request, HttpResponse response);
+    
+    protected void closeFileInput(String path, InputStream in) throws IOException {
+        in.close();
+    }
 
     protected String getExtension(String path) {
         int dotindex = path.lastIndexOf('.');
@@ -113,7 +118,7 @@ public abstract class FileHandler implements HttpHandler {
             } finally {
                 freeReadBuffer(readBuffer);
             }
-            fileInput.close();
+            closeFileInput(path, fileInput);
         } catch (Exception e) {
             if (fileInput != null) {
                 try { fileInput.close(); } catch (IOException ex) { }

--- a/src/main/java/org/dynmap/web/handlers/FilesystemHandler.java
+++ b/src/main/java/org/dynmap/web/handlers/FilesystemHandler.java
@@ -3,8 +3,10 @@ package org.dynmap.web.handlers;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 
+import org.dynmap.utils.FileLockManager;
 import org.dynmap.web.HttpField;
 import org.dynmap.web.HttpRequest;
 import org.dynmap.web.HttpResponse;
@@ -20,6 +22,7 @@ public class FilesystemHandler extends FileHandler {
     @Override
     protected InputStream getFileInput(String path, HttpRequest request, HttpResponse response) {
         File file = new File(root, path);
+        FileLockManager.getReadLock(file);
         if (file.getAbsolutePath().startsWith(root.getAbsolutePath()) && file.isFile()) {
             FileInputStream result;
             try {
@@ -30,6 +33,13 @@ public class FilesystemHandler extends FileHandler {
             response.fields.put(HttpField.ContentLength, Long.toString(file.length()));
             return result;
         }
+        FileLockManager.releaseReadLock(file);
         return null;
     }
+    protected void closeFileInput(String path, InputStream in) throws IOException {
+        super.closeFileInput(path, in);
+        File file = new File(root, path);
+        FileLockManager.releaseReadLock(file);
+    }
+
 }


### PR DESCRIPTION
This is to address some issues seen on servers with high tile update rates (such as flames' playermove-enabled server), where fullrenders can collide with single tile updates.  The locking will also prevent internal web server reads while files are being written.
