### PR TITLE
Make sure JSON/Web text communications are either escaped or UTF-8 encoded (non-Latin character set support)

### DIFF
--- a/src/main/java/org/dynmap/JsonFileClientUpdateComponent.java
+++ b/src/main/java/org/dynmap/JsonFileClientUpdateComponent.java
@@ -4,6 +4,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
+import java.io.InputStreamReader;
+import java.io.FileInputStream;
+import java.io.Reader;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Timer;
@@ -18,7 +21,7 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import static org.dynmap.JSONUtils.*;
-
+import java.nio.charset.Charset;
 
 public class JsonFileClientUpdateComponent extends ClientUpdateComponent {
     protected TimerTask task;
@@ -27,6 +30,7 @@ public class JsonFileClientUpdateComponent extends ClientUpdateComponent {
     protected long currentTimestamp = 0;
     protected long lastTimestamp = 0;
     protected JSONParser parser = new JSONParser();
+    private Charset cs_utf8 = Charset.forName("UTF-8");
     public JsonFileClientUpdateComponent(final DynmapPlugin plugin, final ConfigurationNode configuration) {
         super(plugin, configuration);
         final boolean allowwebchat = configuration.getBoolean("allowwebchat", false);
@@ -83,7 +87,7 @@ public class JsonFileClientUpdateComponent extends ClientUpdateComponent {
 
         try {
             FileOutputStream fos = new FileOutputStream(outputTempFile);
-            fos.write(clientConfiguration.toJSONString().getBytes());
+            fos.write(clientConfiguration.toJSONString().getBytes("UTF-8"));
             fos.close();
             outputFile.delete();
             outputTempFile.renameTo(outputFile);
@@ -110,7 +114,7 @@ public class JsonFileClientUpdateComponent extends ClientUpdateComponent {
             outputTempFile = getStandaloneFile("dynmap_" + world.getName() + ".json.new");
             try {
                 FileOutputStream fos = new FileOutputStream(outputTempFile);
-                fos.write(Json.stringifyJson(update).getBytes());
+                fos.write(Json.stringifyJson(update).getBytes("UTF-8"));
                 fos.close();
                 outputFile.delete();
                 outputTempFile.renameTo(outputFile);
@@ -130,7 +134,7 @@ public class JsonFileClientUpdateComponent extends ClientUpdateComponent {
         if (webchatFile.exists() && lastTimestamp != 0) {
             JSONArray jsonMsgs = null;
             try {
-                FileReader inputFileReader = new FileReader(webchatFile);
+                Reader inputFileReader = new InputStreamReader(new FileInputStream(webchatFile), cs_utf8);
                 jsonMsgs = (JSONArray) parser.parse(inputFileReader);
                 inputFileReader.close();
             } catch (IOException ex) {

--- a/src/main/java/org/dynmap/web/Json.java
+++ b/src/main/java/org/dynmap/web/Json.java
@@ -6,6 +6,8 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
 
+import org.json.simple.JSONObject;
+
 public class Json {
     public static String stringifyJson(Object o) {
         StringBuilder sb = new StringBuilder();
@@ -19,7 +21,7 @@ public class Json {
         } else if (o instanceof Boolean) {
             s.append(((Boolean) o) ? "true" : "false");
         } else if (o instanceof String) {
-            s.append("\"" + ((String)o).replace("\"", "\\\"") + "\"");
+            s.append("\"" + JSONObject.escape((String)o) + "\"");
         } else if (o instanceof Integer || o instanceof Long || o instanceof Float || o instanceof Double) {
             s.append(o.toString());
         } else if (o instanceof Map<?, ?>) {

--- a/src/main/java/org/dynmap/web/handlers/ClientConfigurationHandler.java
+++ b/src/main/java/org/dynmap/web/handlers/ClientConfigurationHandler.java
@@ -33,12 +33,12 @@ public class ClientConfigurationHandler implements HttpHandler {
             
             String s = configurationObject.toJSONString();
 
-            cachedConfiguration = s.getBytes();
+            cachedConfiguration = s.getBytes("UTF-8");
         }
         String dateStr = new Date().toString();
 
         response.fields.put("Date", dateStr);
-        response.fields.put("Content-Type", "text/plain");
+        response.fields.put("Content-Type", "text/plain; charset=utf-8");
         response.fields.put("Expires", "Thu, 01 Dec 1994 16:00:00 GMT");
         response.fields.put("Last-modified", dateStr);
         response.fields.put("Content-Length", Integer.toString(cachedConfiguration.length));

--- a/src/main/java/org/dynmap/web/handlers/ClientUpdateHandler.java
+++ b/src/main/java/org/dynmap/web/handlers/ClientUpdateHandler.java
@@ -67,11 +67,11 @@ public class ClientUpdateHandler implements HttpHandler {
         s(u, "timestamp", current);
         plugin.events.trigger("buildclientupdate", new ClientUpdateEvent(since, dynmapWorld, u));
 
-        byte[] bytes = u.toJSONString().getBytes();
+        byte[] bytes = u.toJSONString().getBytes("UTF-8");
 
         String dateStr = new Date().toString();
         response.fields.put(HttpField.Date, dateStr);
-        response.fields.put(HttpField.ContentType, "text/plain");
+        response.fields.put(HttpField.ContentType, "text/plain; charset=utf-8");
         response.fields.put(HttpField.Expires, "Thu, 01 Dec 1994 16:00:00 GMT");
         response.fields.put(HttpField.LastModified, dateStr);
         response.fields.put(HttpField.ContentLength, Integer.toString(bytes.length));

--- a/src/main/java/org/dynmap/web/handlers/SendMessageHandler.java
+++ b/src/main/java/org/dynmap/web/handlers/SendMessageHandler.java
@@ -1,6 +1,7 @@
 package org.dynmap.web.handlers;
 
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.logging.Logger;
@@ -21,7 +22,7 @@ public class SendMessageHandler implements HttpHandler {
 
     private static final JSONParser parser = new JSONParser();
     public Event<Message> onMessageReceived = new Event<SendMessageHandler.Message>();
-
+    private Charset cs_utf8 = Charset.forName("UTF-8");
     public int maximumMessageInterval = 1000;
     public String spamMessage = "\"You may only chat once every %interval% seconds.\"";
     private HashMap<String, WebUser> disallowedUsers = new HashMap<String, WebUser>();
@@ -36,7 +37,7 @@ public class SendMessageHandler implements HttpHandler {
             return;
         }
 
-        InputStreamReader reader = new InputStreamReader(request.body);
+        InputStreamReader reader = new InputStreamReader(request.body, cs_utf8);
 
         JSONObject o = (JSONObject)parser.parse(reader);
         final Message message = new Message();


### PR DESCRIPTION
I've checked this out with Japanese and Cyrillic characters, and it looks pretty good so far - character echoed back to web properly, and showed on console log properly (and they didn't previously, so its definitely progress).  Really need some folks with non-Latin OSs and the like to truly verify it
