### PR TITLE
Properly stringify chat inputs - prevents bad JSON input, potential security exposures

### DIFF
--- a/web/js/chat.js
+++ b/web/js/chat.js
@@ -21,7 +21,7 @@ componentconstructors['chat'] = function(dynmap, configuration) {
 	if (dynmap.options.allowwebchat) {
 		// Accepts 'sendchat'-events to send chat messages to the server.
 		$(dynmap).bind('sendchat', function(event, message) {
-			var data = '{"name":"'+ip+'","message":"'+message+'"}';
+			var data = '{"name":'+JSON.stringify(ip)+',"message":'+JSON.stringify(message)+'}';
 			$.ajax({
 				type: 'POST',
 				url: 'up/sendmessage',


### PR DESCRIPTION
Chat input strings are just being double-quote enclosed and being assumed to result in a valid JSON encoding.  In particular, double-quotes will break this, but other control-type characters can be used to both generate broken JSON, or to generate maliciously-modified JSON (falsified message senders, for example).  Using JSON.stringify to encode the input prevents this.
