### PR TITLE
Fix chat.js to work for web->server chat on standalone

### DIFF
--- a/web/js/chat.js
+++ b/web/js/chat.js
@@ -24,7 +24,7 @@ componentconstructors['chat'] = function(dynmap, configuration) {
 			var data = '{"name":'+JSON.stringify(ip)+',"message":'+JSON.stringify(message)+'}';
 			$.ajax({
 				type: 'POST',
-				url: 'up/sendmessage',
+				url: config.url.sendmessage,
 				data: data,
 				dataType: 'json',
 				success: function(response) {


### PR DESCRIPTION
Chat.js is hard-coded to send using 'up/sendmessage' (internal server only), versus using the setting in config.js (config.url.sendmessage).  Change is verified good on internal (by me) and on standalone (by lishid and flames).
