### PR TITLE
Fix player position security problems

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -5,11 +5,13 @@ components:
   
   - class: org.dynmap.InternalClientUpdateComponent
     sendhealth: true
+    sendposition: true
     allowwebchat: true
     webchat-interval: 5
   #- class: org.dynmap.JsonFileClientUpdateComponent
   #  writeinterval: 1
   #  sendhealth: true
+  #  sendposition: true
   #  allowwebchat: false
   
   - class: org.dynmap.SimpleWebChatComponent
@@ -130,6 +132,8 @@ templates:
         # To render a world as a "night view", set shadowstrength and ambientlight
         # shadowstrength: 1.0
         # ambientlight: 4
+        # To render both night and day versions of tiles (when ambientlight is set), set true
+        # night-and-day: true
         # Option to turn on transparency support (off by default) - slows render
         # transparency: true
       - class: org.dynmap.kzedmap.KzedMap
@@ -218,6 +222,8 @@ worlds:
   #      # To render a world as a "night view", set shadowstrength and ambientlight
   #      # shadowstrength: 1.0
   #      # ambientlight: 4
+  #      # To render both night and day versions of tiles (when ambientlight is set), set true
+  #      # night-and-day: true
   #      # Option to turn on transparency support (off by default) - slows render
   #      # transparency: true
   #    - class: org.dynmap.kzedmap.KzedMap

--- a/src/main/java/org/dynmap/ClientUpdateComponent.java
+++ b/src/main/java/org/dynmap/ClientUpdateComponent.java
@@ -40,13 +40,28 @@ public class ClientUpdateComponent extends Component {
             s(jp, "type", "player");
             s(jp, "name", ChatColor.stripColor(p.getDisplayName()));
             s(jp, "account", p.getName());
-            s(jp, "world", p.getWorld().getName());
-            s(jp, "x", pl.getX());
-            s(jp, "y", pl.getY());
-            s(jp, "z", pl.getZ());
-            if (configuration.getBoolean("sendhealth", false)) {
+            /* Don't leak player location for world not visible on maps, or if sendposition disbaled */
+            boolean player_visible = MapManager.mapman.worldsLookup.containsKey(p.getWorld().getName());
+            if(configuration.getBoolean("sendpositon", true) && player_visible) {
+                s(jp, "world", p.getWorld().getName());
+                s(jp, "x", pl.getX());
+                s(jp, "y", pl.getY());
+                s(jp, "z", pl.getZ());
+            }
+            else {
+                s(jp, "world", "-some-other-bogus-world-");
+                s(jp, "x", 0.0);
+                s(jp, "y", 64.0);
+                s(jp, "z", 0.0);
+            }
+            /* Only send health if enabled AND we're on visible world */
+            if (configuration.getBoolean("sendhealth", false) && player_visible) {
                 s(jp, "health", p.getHealth());
                 s(jp, "armor", Armor.getArmorPoints(p));
+            }
+            else {
+                s(jp, "health", 0);
+                s(jp, "armor", 0);
             }
             a(u, "players", jp);
         }

--- a/web/js/map.js
+++ b/web/js/map.js
@@ -7,6 +7,7 @@ var maptypes = {};
 componentconstructors['testcomponent'] = function(dynmap, configuration) {
 	console.log('initialize');
 	$(dynmap).bind('worldchanged', function() { console.log('worldchanged'); });
+	$(dynmap).bind('mapchanging', function() { console.log('mapchanging'); });
 	$(dynmap).bind('mapchanged', function() { console.log('mapchanged'); });
 	$(dynmap).bind('zoomchanged', function() { console.log('zoomchanged'); });
 	$(dynmap).bind('worldupdating', function() { console.log('worldupdating'); });
@@ -327,6 +328,7 @@ DynMap.prototype = {
 		if (me.maptype === map) {
 			return;
 		}
+		$(me).trigger('mapchanging');
 		if (me.maptype) {
 			$('.compass').removeClass('compass_' + me.maptype.name);
 		}
@@ -443,7 +445,7 @@ DynMap.prototype = {
 						me.map.setMapTypeId('none');
 						window.setTimeout(function() {
 							me.map.setMapTypeId(mtid);
-						}, 1);
+						}, 0.1);
 					}
 				}
 				

--- a/web/js/playermarkers.js
+++ b/web/js/playermarkers.js
@@ -58,8 +58,8 @@ componentconstructors['playermarkers'] = function(dynmap, configuration) {
 	$(dynmap).bind('playerupdated', function(event, player) {
 		// Update the marker.
 		var markerPosition = dynmap.map.getProjection().fromWorldToLatLng(player.location.x, player.location.y, player.location.z);
-		player.marker.toggle(dynmap.world === player.location.world);
 		player.marker.setPosition(markerPosition);
+		player.marker.toggle(dynmap.world === player.location.world);
 		// Update health
 		if (configuration.showplayerhealth) {
 			if (player.health !== undefined && player.armor !== undefined) {
@@ -69,6 +69,25 @@ componentconstructors['playermarkers'] = function(dynmap, configuration) {
 			} else {
 				player.healthContainer.css('display','none');
 			}
+		}
+	});
+    // Remove marker on start of map change
+	$(dynmap).bind('mapchanging', function(event) {
+		var name;
+		for(name in dynmap.players) {
+			var player = dynmap.players[name];
+			// Turn off marker - let update turn it back on 
+			player.marker.toggle(false);
+		}
+	});
+    // Remove marker on map change - let update place it again
+	$(dynmap).bind('mapchanged', function(event) {
+		var name;
+		for(name in dynmap.players) {
+			var player = dynmap.players[name];
+			var markerPosition = dynmap.map.getProjection().fromWorldToLatLng(player.location.x, player.location.y, player.location.z);
+			player.marker.setPosition(markerPosition);
+			player.marker.toggle(dynmap.world === player.location.world);
 		}
 	});
 };


### PR DESCRIPTION
This fix addresses several problems:
1) Leaking player position data, even when they are on worlds that are disabled.  Ditto for health/armor.
2) Dealing with the stale marker position for player markers when a map change has just happened (was not corrected until next world update)
3) Providing option to remove player position from update stream entirely (sendposition: false, analogous to sendhealth).  Users may incorrectly believe that not having player markers on means position data isn't being sent...
