### PR TITLE
Add optional background color control per map, including day/night

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -136,6 +136,12 @@ templates:
         # night-and-day: true
         # Option to turn on transparency support (off by default) - slows render
         # transparency: true
+        # Background color for map during the day
+        # backgroundday: "#153E7E"
+        # Background color for map during the night
+        # backgroundnight: "#000000"        
+        # Backgrounc color for map (independent of night/day)
+        # background: "#000000"
       - class: org.dynmap.kzedmap.KzedMap
         renderers:
           - class: org.dynmap.kzedmap.DefaultTileRenderer
@@ -152,6 +158,12 @@ templates:
             # night-and-day: true
             # Option to turn off transparency support (on by default) - speeds render
             # transparency: false
+            # Background color for map during the day
+            # backgroundday: "#153E7E"
+            # Background color for map during the night
+            # backgroundnight: "#000000"        
+            # Backgrounc color for map (independent of night/day)
+            # background: "#000000"
             # Sets the icon to 'images/block_custom.png'
             # icon: custom
           #- class: org.dynmap.kzedmap.HighlightTileRenderer
@@ -180,6 +192,8 @@ templates:
         title: "Flat"
         prefix: flat
         colorscheme: default
+        # Map background color (day or night)
+        background: "#300806"
       - class: org.dynmap.kzedmap.KzedMap
         renderers:
           - class: org.dynmap.kzedmap.DefaultTileRenderer
@@ -188,6 +202,40 @@ templates:
             prefix: nt
             maximumheight: 127
             colorscheme: default
+            # Map background color (day or night)
+            background: "#300806"
+  # Skylands world template
+  skylands:
+    enabled: true
+    center:
+      x: 0
+      y: 64
+      z: 0
+    maps:
+      - class: org.dynmap.flat.FlatMap
+        name: flat
+        title: "Flat"
+        prefix: flat
+        colorscheme: default
+        # Background color for map during the day
+        backgroundday: "#153E7E"
+        # Background color for map during the night
+        backgroundnight: "#000000"        
+      - class: org.dynmap.kzedmap.KzedMap
+        renderers:
+          - class: org.dynmap.kzedmap.DefaultTileRenderer
+            name: skylands
+            title: "Surface"
+            prefix: st
+            maximumheight: 127
+            colorscheme: default
+            # Background color for map during the day
+            backgroundday: "#153E7E"
+            # Background color for map during the night
+            backgroundnight: "#000000"        
+            night-and-day: true
+            shadowstrength: 1.0
+            ambientlight: 4
 
 # The maptypes Dynmap will use to render.
 worlds:
@@ -226,6 +274,12 @@ worlds:
   #      # night-and-day: true
   #      # Option to turn on transparency support (off by default) - slows render
   #      # transparency: true
+  #      # Background color for map during the day
+  #      # backgroundday: "#153E7E"
+  #      # Background color for map during the night
+  #      # backgroundnight: "#000000"        
+  #      # Backgrounc color for map (independent of night/day)
+  #      # background: "#000000"
   #    - class: org.dynmap.kzedmap.KzedMap
   #      renderers:
   #        - class: org.dynmap.kzedmap.DefaultTileRenderer
@@ -242,6 +296,12 @@ worlds:
   #          # night-and-day: true
   #          # Option to turn off transparency support (on by default) - speeds render
   #          # transparency: false
+  #          # Background color for map during the day
+  #          # backgroundday: "#153E7E"
+  #          # Background color for map during the night
+  #          # backgroundnight: "#000000"        
+  #          # Backgrounc color for map (independent of night/day)
+  #          # background: "#000000"
   #          # Sets the icon to 'images/block_custom.png'
   #          # icon: custom
   #        #- class: org.dynmap.kzedmap.HighlightTileRenderer

--- a/src/main/java/org/dynmap/flat/FlatMap.java
+++ b/src/main/java/org/dynmap/flat/FlatMap.java
@@ -418,7 +418,10 @@ public class FlatMap extends MapType {
         s(o, "title", c.getString("title"));
         s(o, "icon", c.getString("icon"));
         s(o, "prefix", c.getString("prefix"));
+        s(o, "background", c.getString("background"));
         s(o, "nightandday", c.getBoolean("night-and-day",false));
+        s(o, "backgroundday", c.getString("backgroundday"));
+        s(o, "backgroundnight", c.getString("backgroundnight"));
         a(worldObject, "maps", o);
     }
 }

--- a/src/main/java/org/dynmap/kzedmap/DefaultTileRenderer.java
+++ b/src/main/java/org/dynmap/kzedmap/DefaultTileRenderer.java
@@ -518,7 +518,10 @@ public class DefaultTileRenderer implements MapTileRenderer {
         s(o, "title", c.getString("title"));
         s(o, "icon", c.getString("icon"));
         s(o, "prefix", c.getString("prefix"));
+        s(o, "background", c.getString("background"));
         s(o, "nightandday", c.getBoolean("night-and-day", false));
+        s(o, "backgroundday", c.getString("backgroundday"));
+        s(o, "backgroundnight", c.getString("backgroundnight"));
         a(worldObject, "maps", o);
     }
 }

--- a/web/js/map.js
+++ b/web/js/map.js
@@ -358,6 +358,7 @@ DynMap.prototype = {
 		}, 1);
 		$('.map', me.worldlist).removeClass('selected');
 		$(map.element).addClass('selected');
+		me.updateBackground();
 	},
 	selectWorld: function(world, completed) {
 		var me = this;
@@ -440,6 +441,7 @@ DynMap.prototype = {
 				});
 
 				if(me.serverday != oldday) {
+					me.updateBackground();				
 					var mtid = me.map.mapTypeId;
 					if(me.map.mapTypes[mtid].nightandday) {
 						me.map.setMapTypeId('none');
@@ -573,7 +575,24 @@ DynMap.prototype = {
 			me.panTo(player.location);
 		}
 		this.followingPlayer = player;
-	}
+	},
+	updateBackground: function() {
+		var me = this;
+		var col = "#000000";
+		if(me.serverday) {
+			if(me.maptype.backgroundday)
+				col = me.maptype.backgroundday;
+			else if(me.maptype.background)
+				col = me.maptype.background;
+		}
+		else {
+			if(me.maptype.backgroundnight)
+				col = me.maptype.backgroundnight;
+			else if(me.maptype.background)
+				col = me.maptype.background;
+		}
+		$('.map').css('background', col);
+	}	
 	// TODO: Enable hash-links.
 /*	updateLink: function() {
 		var me = this;


### PR DESCRIPTION
Add support for a 'background' map attribute (all types), which provides background style info for map when selected.  Alternately, a 'backgroundday' and 'backgroundnight' attribute pair can be used to provide day and night background colors, respectively (independent of whether the map has night and day tile sets, or just one set (nightandday: false).

Also added template for skylands (there is a pending pull to fix environment reporting in CB, so this will not work until that fix is implemented - skyworlds start off as new type, but wind up as normal worlds without it).
