### PR TITLE
Add better HTTP proxy support for webchat, add hidewebchatip option to alias web chat IP addresses

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -8,11 +8,13 @@ components:
     sendposition: true
     allowwebchat: true
     webchat-interval: 5
+    hidewebchatip: false
   #- class: org.dynmap.JsonFileClientUpdateComponent
   #  writeinterval: 1
   #  sendhealth: true
   #  sendposition: true
   #  allowwebchat: false
+  #  hidewebchatip: false
   
   - class: org.dynmap.SimpleWebChatComponent
     allowchat: true

--- a/src/main/java/org/dynmap/InternalClientUpdateComponent.java
+++ b/src/main/java/org/dynmap/InternalClientUpdateComponent.java
@@ -12,6 +12,7 @@ public class InternalClientUpdateComponent extends ClientUpdateComponent {
     public InternalClientUpdateComponent(DynmapPlugin plugin, final ConfigurationNode configuration) {
         super(plugin, configuration);
         final Boolean allowwebchat = configuration.getBoolean("allowwebchat", false);
+        final Boolean hidewebchatip = configuration.getBoolean("hidewebchatip", false);
         final float webchatInterval = configuration.getFloat("webchat-interval", 1);
         final String spammessage = plugin.configuration.getString("spammessage", "You may only chat once every %interval% seconds.");
 
@@ -29,6 +30,7 @@ public class InternalClientUpdateComponent extends ClientUpdateComponent {
             SendMessageHandler messageHandler = new SendMessageHandler() {{
                 maximumMessageInterval = (int)(webchatInterval * 1000);
                 spamMessage = "\""+spammessage+"\"";
+                hideip = hidewebchatip;
                 onMessageReceived.addListener(new Listener<SendMessageHandler.Message>() {
                     @Override
                     public void triggered(Message t) {

--- a/src/main/java/org/dynmap/JsonFileClientUpdateComponent.java
+++ b/src/main/java/org/dynmap/JsonFileClientUpdateComponent.java
@@ -8,6 +8,7 @@ import java.io.InputStreamReader;
 import java.io.FileInputStream;
 import java.io.Reader;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -30,11 +31,17 @@ public class JsonFileClientUpdateComponent extends ClientUpdateComponent {
     protected long currentTimestamp = 0;
     protected long lastTimestamp = 0;
     protected JSONParser parser = new JSONParser();
+    private Boolean hidewebchatip;
+
+    private HashMap<String,String> useralias = new HashMap<String,String>();
+    private int aliasindex = 1;
+    
     private Charset cs_utf8 = Charset.forName("UTF-8");
     public JsonFileClientUpdateComponent(final DynmapPlugin plugin, final ConfigurationNode configuration) {
         super(plugin, configuration);
         final boolean allowwebchat = configuration.getBoolean("allowwebchat", false);
         jsonInterval = (long)(configuration.getFloat("writeinterval", 1) * 1000);
+        hidewebchatip = configuration.getBoolean("hidewebchatip", false);
         task = new TimerTask() {
             @Override
             public void run() {
@@ -151,6 +158,15 @@ public class JsonFileClientUpdateComponent extends ClientUpdateComponent {
                     if(ts.equals("null")) ts = "0";
                     if (Long.parseLong(ts) >= (lastTimestamp)) {
                         String name = String.valueOf(o.get("name"));
+                        if(hidewebchatip) {
+                            String n = useralias.get(name);
+                            if(n == null) { /* Make ID */
+                                n = String.format("web-%03d", aliasindex);
+                                aliasindex++;
+                                useralias.put(name, n);
+                            }
+                            name = n;
+                        }
                         String message = String.valueOf(o.get("message"));
                         webChat(name, message);
                     }


### PR DESCRIPTION
Adds support for using X-Forwarded-From header (passed by most HTTP proxies) to get original client address when a proxy has forwarded a web request (as is the case in our example apache2 configuration).

Also, added option on internal and JSON update handlers to hide IP address of web chat (substituting the IP address with a sequentially generated alias - 'web-###' - based on user request.  IP address is still used as correlator, but is not shown in the reported chat messages.
