### PR TITLE
MAKE IE SUCK LESS!

### DIFF
--- a/web/js/map.js
+++ b/web/js/map.js
@@ -145,7 +145,7 @@ DynMap.prototype = {
 			scaleControl: false,
 			mapTypeControl: false,
 			streetViewControl: false,
-			backgroundColor: 'none'
+			backgroundColor: '#000000'
 		});
 		
 		map.zoom_changed = function() {


### PR DESCRIPTION
Found a solution to the core IE issue - turns out the 'none' value for backgroundColor in the map initialization is not cool with IE.  I've switched it to '#000000', which makes IE happy, and seems to have no other issues with other browsers.  Basic functions seems to be working on IE 8 and IE 9, but we'll need to do some more serious testing before we call it 'IE ready'.
