### PR TITLE
Add 'textured' option to Flat render - when set, causes color dither to match surface map (looks more consistent)

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -136,6 +136,8 @@ templates:
         title: "Flat"
         prefix: flat
         colorscheme: default
+        # The textured setting makes the flat render toning much more consistent with the other maps: set to 'false' for the original flat texture
+        textured: true
   #      # To render a world as a "night view", set shadowstrength and ambientlight
   #      shadowstrength: 1.0
   #      ambientlight: 4
@@ -204,6 +206,8 @@ templates:
         colorscheme: default
         # Map background color (day or night)
         background: "#300806"
+        # The textured setting makes the flat render toning much more consistent with the other maps: set to 'false' for the original flat texture
+        textured: true
       - class: org.dynmap.kzedmap.KzedMap
         renderers:
           - class: org.dynmap.kzedmap.DefaultTileRenderer
@@ -233,6 +237,8 @@ templates:
         backgroundday: "#153E7E"
         # Background color for map during the night
         backgroundnight: "#000000"        
+        # The textured setting makes the flat render toning much more consistent with the other maps: set to 'false' for the original flat texture
+        textured: true
       - class: org.dynmap.kzedmap.KzedMap
         renderers:
           - class: org.dynmap.kzedmap.DefaultTileRenderer
@@ -297,6 +303,8 @@ worlds:
   #      title: "Flat"
   #      prefix: flat
   #      colorscheme: default
+  #      # The textured setting makes the flat render toning much more consistent with the other maps: set to 'false' for the original flat texture
+  #      textured: true
   #      # To render a world as a "night view", set shadowstrength and ambientlight
   #      shadowstrength: 1.0
   #      ambientlight: 4
@@ -364,6 +372,8 @@ worlds:
   #      title: "Flat"
   #      prefix: flat
   #      colorscheme: default
+  #      # The textured setting makes the flat render toning much more consistent with the other maps: set to 'false' for the original flat texture
+  #      textured: true
   #    - class: org.dynmap.kzedmap.KzedMap
   #      renderers:
   #        - class: org.dynmap.kzedmap.DefaultTileRenderer

--- a/src/main/java/org/dynmap/flat/FlatMap.java
+++ b/src/main/java/org/dynmap/flat/FlatMap.java
@@ -37,6 +37,7 @@ public class FlatMap extends MapType {
     private int shadowscale[] = null;
     private boolean night_and_day;    /* If true, render both day (prefix+'-day') and night (prefix) tiles */
     protected boolean transparency;
+    private boolean textured = false;
     
     public FlatMap(ConfigurationNode configuration) {
         this.configuration = configuration;
@@ -69,6 +70,7 @@ public class FlatMap extends MapType {
         }
         night_and_day = configuration.getBoolean("night-and-day", false);
         transparency = configuration.getBoolean("transparency", false);  /* Default off */
+        textured = configuration.getBoolean("textured", false);
     }
 
     @Override
@@ -173,7 +175,13 @@ public class FlatMap extends MapType {
                 }
                 if (colors == null)
                     continue;
-                Color c = colors[0];
+                Color c;
+                if(textured && (((x+y) & 0x01) == 1)) {
+                    c = colors[2];                    
+                }
+                else {
+                    c = colors[0];
+                }
                 if (c == null)
                     continue;
 


### PR DESCRIPTION
This is a simple boolean on the Flat map renderer (textured) that, when set to true, causes the color selection within the flat map renderer to go from always using the index-0 color in the colorscheme, to alternating between using index-0 and index-2 in a checkerboard dither pattern.  This behavior matches that of the surface map render, and results in the tonal quality of the flat map (and the textured appearance) being a much better match with the surface map.  The setting defaults to false, but I set the value in the templates to be enabled and 'true' - this really looks much better, and much more consistent, with the other maps, so I figure its worth a go as a default change (folks will need to re-render to get the map cleaned up).
