### PR TITLE
Alter 'textured' setting on flat map to have 'none'/'smooth'/'dither' choices

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -136,8 +136,8 @@ templates:
         title: "Flat"
         prefix: flat
         colorscheme: default
-        # The textured setting makes the flat render toning much more consistent with the other maps: set to 'false' for the original flat texture
-        textured: true
+        # The textured setting makes the flat render toning much more consistent with the other maps: set to 'none' for the original flat texture, 'smooth' for blended tile top colors, 'dither' for dither pattern
+        textured: smooth
   #      # To render a world as a "night view", set shadowstrength and ambientlight
   #      shadowstrength: 1.0
   #      ambientlight: 4
@@ -206,8 +206,8 @@ templates:
         colorscheme: default
         # Map background color (day or night)
         background: "#300806"
-        # The textured setting makes the flat render toning much more consistent with the other maps: set to 'false' for the original flat texture
-        textured: true
+        # The textured setting makes the flat render toning much more consistent with the other maps: set to 'none' for the original flat texture, 'smooth' for blended tile top colors, 'dither' for dither pattern
+        textured: smooth
       - class: org.dynmap.kzedmap.KzedMap
         renderers:
           - class: org.dynmap.kzedmap.DefaultTileRenderer
@@ -237,8 +237,8 @@ templates:
         backgroundday: "#153E7E"
         # Background color for map during the night
         backgroundnight: "#000000"        
-        # The textured setting makes the flat render toning much more consistent with the other maps: set to 'false' for the original flat texture
-        textured: true
+        # The textured setting makes the flat render toning much more consistent with the other maps: set to 'none' for the original flat texture, 'smooth' for blended tile top colors, 'dither' for dither pattern
+        textured: smooth
       - class: org.dynmap.kzedmap.KzedMap
         renderers:
           - class: org.dynmap.kzedmap.DefaultTileRenderer
@@ -303,8 +303,8 @@ worlds:
   #      title: "Flat"
   #      prefix: flat
   #      colorscheme: default
-  #      # The textured setting makes the flat render toning much more consistent with the other maps: set to 'false' for the original flat texture
-  #      textured: true
+  #      # The textured setting makes the flat render toning much more consistent with the other maps: set to 'none' for the original flat texture, 'smooth' for blended tile top colors, 'dither' for dither pattern
+  #      textured: smooth
   #      # To render a world as a "night view", set shadowstrength and ambientlight
   #      shadowstrength: 1.0
   #      ambientlight: 4
@@ -372,8 +372,8 @@ worlds:
   #      title: "Flat"
   #      prefix: flat
   #      colorscheme: default
-  #      # The textured setting makes the flat render toning much more consistent with the other maps: set to 'false' for the original flat texture
-  #      textured: true
+  #      # The textured setting makes the flat render toning much more consistent with the other maps: set to 'none' for the original flat texture, 'smooth' for blended tile top colors, 'dither' for dither pattern
+  #      textured: smooth
   #    - class: org.dynmap.kzedmap.KzedMap
   #      renderers:
   #        - class: org.dynmap.kzedmap.DefaultTileRenderer

--- a/src/main/java/org/dynmap/ColorScheme.java
+++ b/src/main/java/org/dynmap/ColorScheme.java
@@ -69,14 +69,16 @@ public class ColorScheme {
                 else {
                     id = new Integer(split[0]);
                 }
-                Color[] c = new Color[4];
+                Color[] c = new Color[5];
 
                 /* store colors by raycast sequence number */
                 c[0] = new Color(Integer.parseInt(split[1]), Integer.parseInt(split[2]), Integer.parseInt(split[3]), Integer.parseInt(split[4]));
                 c[3] = new Color(Integer.parseInt(split[5]), Integer.parseInt(split[6]), Integer.parseInt(split[7]), Integer.parseInt(split[8]));
                 c[1] = new Color(Integer.parseInt(split[9]), Integer.parseInt(split[10]), Integer.parseInt(split[11]), Integer.parseInt(split[12]));
                 c[2] = new Color(Integer.parseInt(split[13]), Integer.parseInt(split[14]), Integer.parseInt(split[15]), Integer.parseInt(split[16]));
-
+                /* Blended color - for 'smooth' option on flat map */
+                c[4] = new Color((c[0].getRed()+c[2].getRed())/2, (c[0].getGreen()+c[2].getGreen())/2, (c[0].getBlue()+c[2].getBlue())/2, (c[0].getAlpha()+c[2].getAlpha())/2);
+                
                 if(dat != null) {
                     Color[][] dcolor = datacolors[id];    /* Existing list? */
                     if(dcolor == null) {

--- a/src/main/java/org/dynmap/flat/FlatMap.java
+++ b/src/main/java/org/dynmap/flat/FlatMap.java
@@ -37,7 +37,8 @@ public class FlatMap extends MapType {
     private int shadowscale[] = null;
     private boolean night_and_day;    /* If true, render both day (prefix+'-day') and night (prefix) tiles */
     protected boolean transparency;
-    private boolean textured = false;
+    private enum Texture { NONE, SMOOTH, DITHER };
+    private Texture textured = Texture.NONE;
     
     public FlatMap(ConfigurationNode configuration) {
         this.configuration = configuration;
@@ -70,7 +71,13 @@ public class FlatMap extends MapType {
         }
         night_and_day = configuration.getBoolean("night-and-day", false);
         transparency = configuration.getBoolean("transparency", false);  /* Default off */
-        textured = configuration.getBoolean("textured", false);
+        String tex = configuration.getString("textured", "none");
+        if(tex.equals("none"))
+            textured = Texture.NONE;
+        else if(tex.equals("dither"))
+            textured = Texture.DITHER;
+        else
+            textured = Texture.SMOOTH;
     }
 
     @Override
@@ -176,7 +183,9 @@ public class FlatMap extends MapType {
                 if (colors == null)
                     continue;
                 Color c;
-                if(textured && (((x+y) & 0x01) == 1)) {
+                if(textured == Texture.SMOOTH)
+                    c = colors[4];
+                else if((textured == Texture.DITHER) && (((x+y) & 0x01) == 1)) {
                     c = colors[2];                    
                 }
                 else {


### PR DESCRIPTION
This is an enhancement of the options for the just-added 'textured' choice.  Both 'smooth' and 'dither' use the two top-face colors for coloring the flat map, but 'smooth' uses a blend of the two colors for all pixels, while 'dither' offers a checkerboard dither pattern (more or less the same as is done by the surface renderer).  Both options produce an overall color tone that is a better match with the corresponding surface map (although the visibility of the distinctive side faces, especially for grass, causes a perceived difference).
