### PR TITLE
Add support for throttling chunk load rate, splitting tile loads across multiple server ticks if needed

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -100,6 +100,9 @@ disable-webserver: false
 # Period between tile renders for fullrender, in seconds (non-zero to pace fullrenders, lessen CPU load)
 timesliceinterval: 0.0
 
+# Maximum chunk loads per server tick (1/20th of a second) - reducing this below 90 will impact render performance, but also will reduce server thread load
+maxchunkspertick: 200
+
 # Interval the browser should poll for updates.
 updaterate: 2000
 

--- a/src/main/java/org/dynmap/MapType.java
+++ b/src/main/java/org/dynmap/MapType.java
@@ -1,6 +1,7 @@
 package org.dynmap;
 
 import java.io.File;
+import java.util.List;
 
 import org.bukkit.Location;
 import org.dynmap.utils.MapChunkCache;
@@ -13,7 +14,7 @@ public abstract class MapType {
 
     public abstract MapTile[] getAdjecentTiles(MapTile tile);
 
-    public abstract DynmapChunk[] getRequiredChunks(MapTile tile);
+    public abstract List<DynmapChunk> getRequiredChunks(MapTile tile);
 
     public abstract boolean render(MapChunkCache cache, MapTile tile, File outputFile);
     

--- a/src/main/java/org/dynmap/flat/FlatMap.java
+++ b/src/main/java/org/dynmap/flat/FlatMap.java
@@ -5,6 +5,8 @@ import static org.dynmap.JSONUtils.a;
 import static org.dynmap.JSONUtils.s;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.imageio.ImageIO;
 
@@ -101,18 +103,16 @@ public class FlatMap extends MapType {
     }
 
     @Override
-    public DynmapChunk[] getRequiredChunks(MapTile tile) {
+    public List<DynmapChunk> getRequiredChunks(MapTile tile) {
         FlatMapTile t = (FlatMapTile) tile;
         int chunksPerTile = t.size / 16;
         int sx = t.x * chunksPerTile;
         int sz = t.y * chunksPerTile;
 
-        DynmapChunk[] result = new DynmapChunk[chunksPerTile * chunksPerTile];
-        int index = 0;
+        ArrayList<DynmapChunk> result = new ArrayList<DynmapChunk>(chunksPerTile * chunksPerTile);
         for (int x = 0; x < chunksPerTile; x++)
             for (int z = 0; z < chunksPerTile; z++) {
-                result[index] = new DynmapChunk(sx + x, sz + z);
-                index++;
+                result.add(new DynmapChunk(sx + x, sz + z));
             }
         return result;
     }

--- a/src/main/java/org/dynmap/kzedmap/KzedMap.java
+++ b/src/main/java/org/dynmap/kzedmap/KzedMap.java
@@ -164,7 +164,7 @@ public class KzedMap extends MapType {
         return false;
     }
     @Override
-    public DynmapChunk[] getRequiredChunks(MapTile tile) {
+    public List<DynmapChunk> getRequiredChunks(MapTile tile) {
         if (tile instanceof KzedMapTile) {
             KzedMapTile t = (KzedMapTile) tile;
 
@@ -216,12 +216,9 @@ public class KzedMap extends MapType {
                     chunks.add(chunk);
                 }
             }
-
-            DynmapChunk[] result = new DynmapChunk[chunks.size()];
-            chunks.toArray(result);
-            return result;
+            return chunks;
         } else {
-            return new DynmapChunk[0];
+            return new ArrayList<DynmapChunk>();
         }
     }
 

--- a/src/main/java/org/dynmap/utils/MapChunkCache.java
+++ b/src/main/java/org/dynmap/utils/MapChunkCache.java
@@ -1,5 +1,6 @@
 package org.dynmap.utils;
 import org.bukkit.World;
+import java.util.List;
 import org.dynmap.DynmapChunk;
 
 public interface MapChunkCache {
@@ -12,11 +13,19 @@ public interface MapChunkCache {
         public int x0, x1, z0, z1;
     }
     /**
-     * Load chunks into cache
-     * @param w - world
-     * @param chunks - chunks to be loaded
+     * Set chunks to load, and world to load from
      */
-    void loadChunks(World w, DynmapChunk[] chunks);
+    void setChunks(World w, List<DynmapChunk> chunks);
+    /**
+     * Load chunks into cache
+     * @param maxToLoad - maximum number to load at once
+     * @return number loaded
+     */
+    int loadChunks(int maxToLoad);
+    /**
+     * Test if done loading
+     */
+    boolean isDoneLoading();
     /**
      * Unload chunks
      */


### PR DESCRIPTION
This is likely the last big option for spreading load on the server thread - rather than loading all chunks for a given tile in one action, the chunk loader has a configurable limit that will read a specific maximum number of chunks per server tick, and take as many ticks as needed to finish a chunk load request.  The main point is to offer a means for spreading server thread load, minimizing the chance of load that could impact players.
