### PR TITLE
Add delay-retry on image file writes, to recover from locked file exceptions from external web servers

### DIFF
--- a/src/main/java/org/dynmap/flat/FlatMap.java
+++ b/src/main/java/org/dynmap/flat/FlatMap.java
@@ -281,7 +281,7 @@ public class FlatMap extends MapType {
             if(!outputFile.getParentFile().exists())
                 outputFile.getParentFile().mkdirs();
             try {
-                ImageIO.write(im.buf_img, "png", outputFile);
+                FileLockManager.imageIOWrite(im.buf_img, "png", outputFile);
             } catch (IOException e) {
                 Debug.error("Failed to save image: " + outputFile.getPath(), e);
             } catch (java.lang.NullPointerException e) {
@@ -308,7 +308,7 @@ public class FlatMap extends MapType {
                 if(!dayfile.getParentFile().exists())
                     dayfile.getParentFile().mkdirs();
                 try {
-                    ImageIO.write(im_day.buf_img, "png", dayfile);
+                    FileLockManager.imageIOWrite(im_day.buf_img, "png", dayfile);
                 } catch (IOException e) {
                     Debug.error("Failed to save image: " + dayfile.getPath(), e);
                 } catch (java.lang.NullPointerException e) {

--- a/src/main/java/org/dynmap/kzedmap/DefaultTileRenderer.java
+++ b/src/main/java/org/dynmap/kzedmap/DefaultTileRenderer.java
@@ -265,7 +265,7 @@ public class DefaultTileRenderer implements MapTileRenderer {
             if(!fname.getParentFile().exists())
                 fname.getParentFile().mkdirs();
             try {
-                ImageIO.write(img.buf_img, "png", fname);
+                FileLockManager.imageIOWrite(img.buf_img, "png", fname);
             } catch (IOException e) {
                 Debug.error("Failed to save image: " + fname.getPath(), e);
             } catch (java.lang.NullPointerException e) {
@@ -291,7 +291,7 @@ public class DefaultTileRenderer implements MapTileRenderer {
                 if(!dfname.getParentFile().exists())
                     dfname.getParentFile().mkdirs();
                 try {
-                    ImageIO.write(img_day.buf_img, "png", dfname);
+                    FileLockManager.imageIOWrite(img_day.buf_img, "png", dfname);
                 } catch (IOException e) {
                     Debug.error("Failed to save image: " + dfname.getPath(), e);
                 } catch (java.lang.NullPointerException e) {
@@ -365,7 +365,7 @@ public class DefaultTileRenderer implements MapTileRenderer {
             zoomFile.getParentFile().mkdirs();
 
         try {
-            ImageIO.write(zIm, "png", zoomFile);
+            FileLockManager.imageIOWrite(zIm, "png", zoomFile);
             Debug.debug("Saved zoom-out tile at " + zoomFile.getName());
         } catch (IOException e) {
             Debug.error("Failed to save zoom-out tile: " + zoomFile.getName(), e);


### PR DESCRIPTION
We're seeing occasional exceptions, especially on Windows with Apache, which appear to be due to deny-write locks on the image files during web serving by Apache.  Change adds code to do a delay and retry on those file writes (up to 6 times, with exponential backoff) to better handle these conditions.
