### PR TITLE
Fix reading of webpath by regions component - load from top-level setting, instead of component local config

### DIFF
--- a/src/main/java/org/dynmap/DynmapPlugin.java
+++ b/src/main/java/org/dynmap/DynmapPlugin.java
@@ -466,4 +466,8 @@ public class DynmapPlugin extends JavaPlugin {
         pluginManager.disablePlugin(this);
         pluginManager.enablePlugin(this);
     }
+    
+    public String getWebPath() {
+        return configuration.getString("webpath", "web");
+    }
 }

--- a/src/main/java/org/dynmap/regions/RegionsComponent.java
+++ b/src/main/java/org/dynmap/regions/RegionsComponent.java
@@ -65,7 +65,7 @@ public class RegionsComponent extends ClientComponent {
 
         outputFileName = outputFileName.substring(0, outputFileName.lastIndexOf("."))+".json";
 
-        File webWorldPath = new File(this.configuration.getString("webpath", "web")+"/standalone/", outputFileName);
+        File webWorldPath = new File(plugin.getWebPath()+"/standalone/", outputFileName);
         Map<?, ?> regionData = (Map<?, ?>) regionConfig.getProperty(configuration.getString("basenode", "regions"));
         if (webWorldPath.isAbsolute())
             outputFile = webWorldPath;


### PR DESCRIPTION
Looks like a minor bug introduced during the component restructure - workaround on for 0.18 is to add copy of 'webpath' setting under the settings node for the 'regions' component.
