### PR TITLE
Add support for optional 'visibleregions' list attribute for regions component, to limit visible region population

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -60,6 +60,10 @@ components:
   #    strokeWeight: 3
   #    fillColor: "#FF0000"
   #    fillOpacity: 0.35
+  #  # Optional setting to limit which regions to show, by name - if commented out, all regions are shown
+  #  visibleregions:
+  #    - homebase
+  #    - miningsite
   #- class: org.dynmap.TestComponent
   #  stuff: "This is some configuration-value"
 

--- a/src/main/java/org/dynmap/regions/RegionHandler.java
+++ b/src/main/java/org/dynmap/regions/RegionHandler.java
@@ -1,10 +1,13 @@
 package org.dynmap.regions;
 
 import java.io.File;
+import java.util.List;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.Map;
+import java.util.HashSet;
 import java.util.logging.Level;
 import org.bukkit.util.config.Configuration;
 import org.dynmap.ConfigurationNode;
@@ -60,6 +63,21 @@ public class RegionHandler extends FileHandler {
         regionConfig.load();
         /* Parse region data and store in MemoryInputStream */
         Map<?, ?> regionData = (Map<?, ?>) regionConfig.getProperty(regions.getString("basenode", "regions"));
+        /* See if we have explicit list of regions to report - limit to this list if we do */
+        List<String> idlist = regions.getStrings("visibleregions", null);
+        if(idlist != null) {
+            @SuppressWarnings("unchecked")
+            HashSet<String> ids = new HashSet<String>((Collection<? extends String>) regionData.keySet());
+            for(String id : ids) {
+                /* If not in list, remove it */
+                if(!idlist.contains(id)) {
+                    regionData.remove(id);
+                    log.info("discard " + id);
+                }
+                else
+                    log.info("keep " + id);
+            }
+        }
         try {
             ByteArrayOutputStream fos = new ByteArrayOutputStream();
             fos.write(Json.stringifyJson(regionData).getBytes());


### PR DESCRIPTION
Per user request - some folks have lots of regions in WorldGuard, more than are of interest to display.  When defined, the new 'visibleregions' attribute, a string list, indicated which region IDs to show.  When undefined, all regions are shown, as before.
