### PR TITLE
Per request, add 'trustclientname' option to sendMessage on InternalClientUpdaeComponent

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -9,6 +9,7 @@ components:
     allowwebchat: true
     webchat-interval: 5
     hidewebchatip: false
+    trustclientname: false
   #- class: org.dynmap.JsonFileClientUpdateComponent
   #  writeinterval: 1
   #  sendhealth: true

--- a/src/main/java/org/dynmap/InternalClientUpdateComponent.java
+++ b/src/main/java/org/dynmap/InternalClientUpdateComponent.java
@@ -12,6 +12,7 @@ public class InternalClientUpdateComponent extends ClientUpdateComponent {
         super(plugin, configuration);
         final Boolean allowwebchat = configuration.getBoolean("allowwebchat", false);
         final Boolean hidewebchatip = configuration.getBoolean("hidewebchatip", false);
+        final Boolean trust_client_name = configuration.getBoolean("trustclientname", false);
         final float webchatInterval = configuration.getFloat("webchat-interval", 1);
         final String spammessage = plugin.configuration.getString("spammessage", "You may only chat once every %interval% seconds.");
 
@@ -30,6 +31,7 @@ public class InternalClientUpdateComponent extends ClientUpdateComponent {
                 maximumMessageInterval = (int)(webchatInterval * 1000);
                 spamMessage = "\""+spammessage+"\"";
                 hideip = hidewebchatip;
+                this.trustclientname = trust_client_name;
                 onMessageReceived.addListener(new Listener<SendMessageHandler.Message>() {
                     @Override
                     public void triggered(Message t) {

--- a/src/main/java/org/dynmap/utils/FileLockManager.java
+++ b/src/main/java/org/dynmap/utils/FileLockManager.java
@@ -117,9 +117,8 @@ public class FileLockManager {
         while(!done) {
             try {
                 ImageIO.write(img, type, fname);
-                fname.setLastModified(System.currentTimeMillis());
                 done = true;
-            } catch (FileNotFoundException fnfx) {  /* This seems to be what we get when file is locked by reader */
+            } catch (IOException fnfx) {
                 if(retrycnt < MAX_WRITE_RETRIES) {
                     Log.info("Image file " + fname.getPath() + " - unable to write - retry #" + retrycnt);
                     try { Thread.sleep(50 << retrycnt); } catch (InterruptedException ix) { throw fnfx; }


### PR DESCRIPTION
This allows server operator the option of having a modified web UI script supply us with a 'name' value for their client which we'll use for chat (versus our own detected IP or other more trusted mechanisms).  JSON already works this way, so its just for the internal web server's update component.  Default is false, since this is mostly a bad idea AND the technique we use for client-derived IP is frequently broken (jsonip.appspot.com is over-quota lots of the time.....)
