### PR TITLE
Add invalidate events to zoom out processing - avoids problems with linux file time resolution 

### DIFF
--- a/src/main/java/org/dynmap/ClientConfigurationComponent.java
+++ b/src/main/java/org/dynmap/ClientConfigurationComponent.java
@@ -33,7 +33,7 @@ public class ClientConfigurationComponent extends Component {
                     s(wo, "center/y", wn.getFloat("center/y", 64.0f));
                     s(wo, "center/z", wn.getFloat("center/z", 0.0f));
                     s(wo, "bigworld", world.bigworld);
-                    s(wo, "extrazoomout", world.extrazoomoutlevels);
+                    s(wo, "extrazoomout", world.getExtraZoomOutLevels());
                     a(t, "worlds", wo);
                     
                     for(MapType mt : world.maps) {

--- a/src/main/java/org/dynmap/MapManager.java
+++ b/src/main/java/org/dynmap/MapManager.java
@@ -361,7 +361,7 @@ public class MapManager {
         dynmapWorld.sendposition = worldConfiguration.getBoolean("sendposition", true);
         dynmapWorld.sendhealth = worldConfiguration.getBoolean("sendhealth", true);
         dynmapWorld.bigworld = worldConfiguration.getBoolean("bigworld", false);
-        dynmapWorld.extrazoomoutlevels = worldConfiguration.getInteger("extrazoomout", 0);
+        dynmapWorld.setExtraZoomOutLevels(worldConfiguration.getInteger("extrazoomout", 0));
         dynmapWorld.worldtilepath = new File(plug_in.tilesDirectory, w.getName());
         if(loclist != null) {
             for(ConfigurationNode loc : loclist) {

--- a/src/main/java/org/dynmap/flat/FlatMap.java
+++ b/src/main/java/org/dynmap/flat/FlatMap.java
@@ -289,6 +289,7 @@ public class FlatMap extends MapType {
             }
             MapManager.mapman.pushUpdate(tile.getWorld(), new Client.Tile(tile.getFilename()));
             hashman.updateHashCode(tile.getKey(), null, t.x, t.y, crc);
+            tile.getDynmapWorld().enqueueZoomOutUpdate(outputFile);
             tile_update = true;
         }
         else {
@@ -316,6 +317,7 @@ public class FlatMap extends MapType {
                 }
                 MapManager.mapman.pushUpdate(tile.getWorld(), new Client.Tile(tile.getDayFilename()));   
                 hashman.updateHashCode(tile.getKey(), "day", t.x, t.y, crc);
+                tile.getDynmapWorld().enqueueZoomOutUpdate(dayfile);
                 tile_update = true;
             }
             else {

--- a/src/main/java/org/dynmap/kzedmap/DefaultTileRenderer.java
+++ b/src/main/java/org/dynmap/kzedmap/DefaultTileRenderer.java
@@ -317,6 +317,7 @@ public class DefaultTileRenderer implements MapTileRenderer {
             saveZoomedTile(zmtile, zoomFile, zimg, ox, oy, null);
             MapManager.mapman.pushUpdate(zmtile.getWorld(),
                                          new Client.Tile(zmtile.getFilename()));
+            zmtile.getDynmapWorld().enqueueZoomOutUpdate(zoomFile);
             ztile_updated = true;
         }
         KzedMap.freeBufferedImage(zimg);
@@ -331,6 +332,7 @@ public class DefaultTileRenderer implements MapTileRenderer {
                 saveZoomedTile(zmtile, zoomFile_day, zimg_day, ox, oy, "day");
                 MapManager.mapman.pushUpdate(zmtile.getWorld(),
                                              new Client.Tile(zmtile.getDayFilename()));            
+                zmtile.getDynmapWorld().enqueueZoomOutUpdate(zoomFile_day);
                 ztile_updated = true;
             }
             KzedMap.freeBufferedImage(zimg_day);


### PR DESCRIPTION
Shifting away from being file time centric on the zoom-out processing, due to issues with Linux's 1 second granularity.
