### PR TITLE
Add support for 'chunkgenerated' render trigger, now that CB has functional chunk generate events

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -89,6 +89,7 @@ render-triggers:
   - snowform
   - leavesdecay
   - blockburn
+  - chunkgenerated
 
 # The path where the tile-files are placed.
 tilespath: web/tiles


### PR DESCRIPTION
This is coded to run-time detect if the CB version is new enough to allow the option, and to warn and disable it otherwise.  Also, trigger is set to enabled by default, since its about the lowest bandwidth and most universally useful trigger to have to keep maps in good shape.  Hopefully, we can use this to ultimately deprecate 'playermove' and 'chunkloaded', which are very expensive alternatives that we (and our users) were forced to offer to deal with the lack of the generate detection.
