### PR TITLE
Add option to use visibilitylimits to define area to automatically prime chunk generation

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -302,7 +302,7 @@ worlds:
   #    - x: -15000
   #      y: 64
   #      z: -5000
-  #  # Use visbilitylimits to restrict which areas of maps on your world to render (zero or more rectangles can be defined)
+  #  # Use visibilitylimits to restrict which areas of maps on your world to render (zero or more rectangles can be defined)
   #  visibilitylimits:
   #    - x0: -1000
   #      z0: -1000
@@ -314,6 +314,10 @@ worlds:
   #      z1: -500
   #  # Use hidestyle to control how hidden-but-existing chunks are to be rendered (air=empty air (same as ungenerated), stone=a flat stone plain, ocean=a flat ocean)
   #  hidestyle: stone
+  #  # Use 'autogenerate-to-visibilitylimits: true' to choose to force the generation of ungenerated chunks while rendering maps on this world, for any chunks within the defined
+  #  # visibilitylimits (limits must be set).  This will result in initializing all game world areas within the visible ranges that have not yet been initialized.
+  #  # Note: BE SURE YOU WANT TO DO THIS - there isn't a good way to "ungenerate" terrain chunks once generated (although tools like WorldEdit can regenerate them) 
+  #  autogenerate-to-visibilitylimits: false
   #   Use 'template: mycustomtemplate' to use the properties specified in the template 'mycustomtemplate' to this world. Default it is set to the environment-name (normal or nether).
   #  template: mycustomtemplate
   #   Rest of comes from template - uncomment to tailor for world specifically

--- a/src/main/java/org/dynmap/DynmapWorld.java
+++ b/src/main/java/org/dynmap/DynmapWorld.java
@@ -27,6 +27,7 @@ public class DynmapWorld {
     public ConfigurationNode configuration;
     public List<Location> seedloc;
     public List<MapChunkCache.VisibilityLimit> visibility_limits;
+    public boolean do_autogenerate;
     public MapChunkCache.HiddenChunkStyle hiddenchunkstyle;
     public int servertime;
     public boolean sendposition;

--- a/src/main/java/org/dynmap/utils/MapChunkCache.java
+++ b/src/main/java/org/dynmap/utils/MapChunkCache.java
@@ -38,6 +38,10 @@ public interface MapChunkCache {
      */
     boolean isDoneLoading();
     /**
+     * Test if all empty blocks
+     */
+    boolean isEmpty();
+    /**
      * Unload chunks
      */
     void unloadChunks();
@@ -87,4 +91,8 @@ public interface MapChunkCache {
      * Coordinates are block coordinates
      */
     public void setVisibleRange(VisibilityLimit limit);
+    /**
+     * Set autogenerate - must be done after at least one visible range has been set
+     */
+    public void setAutoGenerateVisbileRanges(boolean do_generate);
 }


### PR DESCRIPTION
This option is a simple opportunity for folks to use us to prime their world map cleanly and automatically, and do so consistent with the visibility bounds they have established.  The option is world specific, and cannot be used without defined visibilitylimits, since maps would otherwise grow unbounded.  When autogenerate-to-visibilitylimits is set true, fullrender or any other tile render activity will generate any chunks that are needed and are within the visbility limits and not yet generated (versus our normal behavior of avoiding the automatic generate-on-load-if-needed behavior typical of player-initiated chunk loads).

Also, pull includes some performance improvements, via avoiding the expensive act of rendering tiles whose chunk sets are known to be all empty (all boundary tiles are this way).  By doing so, we avoid a whole lot of expensive rendering and don't make blank tiles that still need to be loaded and presented by the UIs.
