### PR TITLE
Change autogenerate-to-visbilitylimits to have 3 options: none, map-only, permanent

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -315,9 +315,9 @@ worlds:
   #  # Use hidestyle to control how hidden-but-existing chunks are to be rendered (air=empty air (same as ungenerated), stone=a flat stone plain, ocean=a flat ocean)
   #  hidestyle: stone
   #  # Use 'autogenerate-to-visibilitylimits: true' to choose to force the generation of ungenerated chunks while rendering maps on this world, for any chunks within the defined
-  #  # visibilitylimits (limits must be set).  This will result in initializing all game world areas within the visible ranges that have not yet been initialized.
-  #  # Note: BE SURE YOU WANT TO DO THIS - there isn't a good way to "ungenerate" terrain chunks once generated (although tools like WorldEdit can regenerate them) 
-  #  autogenerate-to-visibilitylimits: false
+  #  # visibilitylimits (limits must be set).  The three options here are: none (default - no autogenerate), map-only (temporarily generate chunks for map, but don't save them (no world change),
+  #  # permanent (generate and save chunks - this permanently adds the chunks to the world, as if a player had visited them - BE SURE THIS IS WHAT YOU WANT)
+  #  autogenerate-to-visibilitylimits: map-only
   #   Use 'template: mycustomtemplate' to use the properties specified in the template 'mycustomtemplate' to this world. Default it is set to the environment-name (normal or nether).
   #  template: mycustomtemplate
   #   Rest of comes from template - uncomment to tailor for world specifically

--- a/src/main/java/org/dynmap/DynmapPlugin.java
+++ b/src/main/java/org/dynmap/DynmapPlugin.java
@@ -53,6 +53,7 @@ public class DynmapPlugin extends JavaPlugin {
     /* Flag to let code know that we're doing reload - make sure we don't double-register event handlers */
     public boolean is_reload = false;
     private boolean generate_only = false;
+    private static boolean ignore_chunk_loads = false; /* Flat to keep us from processing our own chunk loads */
 
     public static File dataDirectory;
     public static File tilesDirectory;
@@ -248,6 +249,8 @@ public class DynmapPlugin extends JavaPlugin {
             WorldListener renderTrigger = new WorldListener() {
                 @Override
                 public void onChunkLoad(ChunkLoadEvent event) {
+                    if(ignore_chunk_loads)
+                        return;
                     if(generate_only) {
                         if(!isNewChunk(event))
                             return;
@@ -493,5 +496,9 @@ public class DynmapPlugin extends JavaPlugin {
     
     public String getWebPath() {
         return configuration.getString("webpath", "web");
+    }
+    
+    public static void setIgnoreChunkLoads(boolean ignore) {
+        ignore_chunk_loads = ignore;
     }
 }

--- a/src/main/java/org/dynmap/DynmapWorld.java
+++ b/src/main/java/org/dynmap/DynmapWorld.java
@@ -21,13 +21,18 @@ import java.util.HashSet;
 import javax.imageio.ImageIO;
 
 public class DynmapWorld {
+    public enum AutoGenerateOption {
+        NONE,
+        FORMAPONLY,
+        PERMANENT
+    }
     public World world;
     public List<MapType> maps = new ArrayList<MapType>();
     public UpdateQueue updates = new UpdateQueue();
     public ConfigurationNode configuration;
     public List<Location> seedloc;
     public List<MapChunkCache.VisibilityLimit> visibility_limits;
-    public boolean do_autogenerate;
+    public AutoGenerateOption do_autogenerate;
     public MapChunkCache.HiddenChunkStyle hiddenchunkstyle;
     public int servertime;
     public boolean sendposition;

--- a/src/main/java/org/dynmap/utils/MapChunkCache.java
+++ b/src/main/java/org/dynmap/utils/MapChunkCache.java
@@ -4,6 +4,7 @@ import org.bukkit.block.Biome;
 
 import java.util.List;
 import org.dynmap.DynmapChunk;
+import org.dynmap.DynmapWorld;
 
 public interface MapChunkCache {
     public enum HiddenChunkStyle {
@@ -94,5 +95,5 @@ public interface MapChunkCache {
     /**
      * Set autogenerate - must be done after at least one visible range has been set
      */
-    public void setAutoGenerateVisbileRanges(boolean do_generate);
+    public void setAutoGenerateVisbileRanges(DynmapWorld.AutoGenerateOption do_generate);
 }

--- a/src/main/java/org/dynmap/utils/NewMapChunkCache.java
+++ b/src/main/java/org/dynmap/utils/NewMapChunkCache.java
@@ -12,7 +12,10 @@ import org.bukkit.block.Biome;
 import org.bukkit.entity.Entity;
 import org.bukkit.ChunkSnapshot;
 import org.dynmap.DynmapChunk;
+import org.dynmap.DynmapPlugin;
+import org.dynmap.DynmapWorld;
 import org.dynmap.Log;
+import org.dynmap.MapManager;
 
 /**
  * Container for managing chunks - dependent upon using chunk snapshots, since rendering is off server thread
@@ -31,7 +34,9 @@ public class NewMapChunkCache implements MapChunkCache {
     private boolean biome, biomeraw, highesty, blockdata;
     private HiddenChunkStyle hidestyle = HiddenChunkStyle.FILL_AIR;
     private List<VisibilityLimit> visible_limits = null;
+    private DynmapWorld.AutoGenerateOption generateopt;
     private boolean do_generate = false;
+    private boolean do_save = false;
     private boolean isempty = true;
 
     private ChunkSnapshot[] snaparray; /* Index = (x-x_min) + ((z-z_min)*x_dim) */
@@ -284,6 +289,7 @@ public class NewMapChunkCache implements MapChunkCache {
         if(iterator == null)
             iterator = chunks.listIterator();
         
+        DynmapPlugin.setIgnoreChunkLoads(true);
         // Load the required chunks.
         while((cnt < max_to_load) && iterator.hasNext()) {
             DynmapChunk chunk = iterator.next();
@@ -298,7 +304,7 @@ public class NewMapChunkCache implements MapChunkCache {
                 }
             }
             boolean wasLoaded = w.isChunkLoaded(chunk.x, chunk.z);
-            boolean didload = w.loadChunk(chunk.x, chunk.z, do_generate && vis);
+            boolean didload = w.loadChunk(chunk.x, chunk.z, false);
             boolean didgenerate = false;
             /* If we didn't load, and we're supposed to generate, do it */
             if((!didload) && do_generate && vis)
@@ -348,7 +354,7 @@ public class NewMapChunkCache implements MapChunkCache {
                  * while the actual in-use chunk area for a player where the chunks are managed
                  * by the MC base server is 21x21 (or about a 160 block radius).
                  * Also, if we did generate it, need to save it */
-                w.unloadChunk(chunk.x, chunk.z, didgenerate, false);
+                w.unloadChunk(chunk.x, chunk.z, didgenerate && do_save, false);
                 /* And pop preserved chunk - this is a bad leak in Bukkit for map traversals like us */
                 try {
                     if(poppreservedchunk != null)
@@ -359,6 +365,8 @@ public class NewMapChunkCache implements MapChunkCache {
             }
             cnt++;
         }
+        DynmapPlugin.setIgnoreChunkLoads(false);
+
         if(iterator.hasNext() == false) {   /* If we're done */
             isempty = true;
             /* Fill missing chunks with empty dummy chunk */
@@ -457,12 +465,14 @@ public class NewMapChunkCache implements MapChunkCache {
     /**
      * Set autogenerate - must be done after at least one visible range has been set
      */
-    public void setAutoGenerateVisbileRanges(boolean do_generate) {
-        if(do_generate && ((visible_limits == null) || (visible_limits.size() == 0))) {
+    public void setAutoGenerateVisbileRanges(DynmapWorld.AutoGenerateOption generateopt) {
+        if((generateopt != DynmapWorld.AutoGenerateOption.NONE) && ((visible_limits == null) || (visible_limits.size() == 0))) {
             Log.severe("Cannot setAutoGenerateVisibleRanges() without visible ranges defined");
             return;
         }
-        this.do_generate = do_generate;
+        this.generateopt = generateopt;
+        this.do_generate = (generateopt != DynmapWorld.AutoGenerateOption.NONE);
+        this.do_save = (generateopt == DynmapWorld.AutoGenerateOption.PERMANENT);
     }
     /**
      * Add visible area limit - can be called more than once 


### PR DESCRIPTION
This option allows us to exploit the fact that a generated chunk is not actually permanently written to the world's data until it is unloaded with the save option set.  This allows us the option to fill in holes and currently ungenerated chunk areas without growing the user's world prematurely - this is the map-only option.  The 'permanent' option results in the generated chunk being saved, as would be normal for a new chunk, which will permanently initialize the chunk and grow the user's world.  Either option may be useful, depending on what the user wants.

Also, pull includes fix for the fact that ScheduledThreadPoolExecutor is pretty stupid about default exception handling - we should be able to see any unhandled exceptions on the thread pool now.
