### PR TITLE
Add support for URL-based parameter overrides for selecting world, map, zoom, and center coordinates

### DIFF
--- a/web/js/map.js
+++ b/web/js/map.js
@@ -123,6 +123,26 @@ DynMap.prototype = {
 			});
 			me.defaultworld = me.defaultworld || world;
 		});
+		var urlarg = me.getParameterByName('worldname');
+		if(urlarg != "") {
+		    me.defaultworld = me.worlds[urlarg] || me.defaultworld;
+		}
+		urlarg = me.getParameterByName('mapname');
+		if(urlarg != "") {
+			me.defaultworld.defaultmap = me.defaultworld.maps[urlarg] || me.defaultworld.defaultmap;
+		}
+		urlarg = parseInt(me.getParameterByName('x'),10);
+		if(urlarg != NaN) {
+			me.defaultworld.center.x = urlarg;
+		}
+		urlarg = parseInt(me.getParameterByName('y'),10);
+		if(urlarg != NaN) {
+			me.defaultworld.center.y = urlarg;
+		}
+		urlarg = parseInt(me.getParameterByName('z'), 10);
+		if(urlarg != NaN) {
+			me.defaultworld.center.z = urlarg;
+		}
 	},
 	initialize: function() {
 		var me = this;
@@ -134,6 +154,9 @@ DynMap.prototype = {
 		(mapContainer = $('<div/>'))
 			.addClass('map')
 			.appendTo(container);
+
+		var urlzoom = parseInt(me.getParameterByName('zoom'),10);
+		if(urlzoom != NaN) { me.options.defaultzoom = urlzoom; }
 		
 		var map = this.map = new google.maps.Map(mapContainer.get(0), {
 			zoom: me.options.defaultzoom || 0,
@@ -592,7 +615,17 @@ DynMap.prototype = {
 				col = me.maptype.background;
 		}
 		$('.map').css('background', col);
-	}	
+	},
+	getParameterByName: function(name) {
+		name = name.replace(/[\[]/,"\\\[").replace(/[\]]/,"\\\]");
+		var regexS = "[\\?&]"+name+"=([^&#]*)";
+		var regex = new RegExp( regexS );
+		var results = regex.exec( window.location.href );
+		if( results == null )
+			return "";
+		else
+			return decodeURIComponent(results[1].replace(/\+/g, " "));
+	}
 	// TODO: Enable hash-links.
 /*	updateLink: function() {
 		var me = this;


### PR DESCRIPTION
Per user request, this provides a way for the URL used to load the map page to provide optional parameters to override the default initial display state.  The parameters are passed as "?arg=val&arg=val" style parameters, and defined arguments include:
worldname: the 'name' attribute of the world to be displayed initially
mapname: the 'name' attribute of the map to be initially displayed
zoom: the initial zoom level to be selected (0-N)
x: the X coordinate (in world coordinates) to be used for the center of the initial display
y: the Y coordinate (in world coordinates) to be used for the center of the initial display
z: the Z coordinate (in world coordinates) to be used for the center of the initial display
Obviously, there are and will be additional options that may be desired - this provides a good approach for supporting user-selected preferences, versus the strictly administrator defined preferences we currently have.
