### PR TITLE
Setting to 0.19.2 for support release for 1.7 related issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.dynmap</groupId>
   <artifactId>dynmap</artifactId>
-  <version>0.20</version>
+  <version>0.19.2</version>
   <name>dynmap</name>
     <properties>
        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: dynmap
 main: org.dynmap.DynmapPlugin
-version: "0.20"
+version: "0.19.2"
 authors: [FrozenCow, mikeprimm, zeeZ]
 softdepend: [Permissions]
 commands:


### PR DESCRIPTION
We've got a couple of 1.7 (CB953) items that this would address:
1) Support for piston blocks in color schemes
2) Workaround for CB exception in furnace blocks (fixed in CB955, but it isn't an RB, and the workaround is actually a cleaner version of another workaround for a CB issue....)
3) Fix for occasional premature timeouts on read-locks for web requests (wasn't handling case of a file being updated twice quickly, with read-waiters not getting their requested access and giving up, despite more time to wait) - can cause black tiles on web until reload/refresh
