### PR TITLE
Add cancelable custom event for reporting of messages received from web

### DIFF
--- a/src/main/java/org/dynmap/DynmapWebChatEvent.java
+++ b/src/main/java/org/dynmap/DynmapWebChatEvent.java
@@ -1,0 +1,31 @@
+package org.dynmap;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+
+/**
+ * Custom bukkit event, corresponding to the receiving of a web-chat message from a web UI user
+ */
+public class DynmapWebChatEvent extends Event implements Cancellable {
+    private String source;
+    private String name;
+    private String message;
+    private boolean cancelled;
+    
+    public DynmapWebChatEvent(String source, String name, String message) {
+        super("org.dynmap.DynmapWebChatEvent");
+        this.source = source;
+        this.name = name;
+        this.message = message;
+        this.cancelled = false;
+    }
+    public boolean isCancelled() { return cancelled; }
+    
+    public void setCancelled(boolean cancel) { cancelled = cancel; }
+
+    public String getSource() { return source; }
+    
+    public String getName() { return name; }
+    
+    public String getMessage() { return message; }
+    
+}

--- a/src/main/java/org/dynmap/SimpleWebChatComponent.java
+++ b/src/main/java/org/dynmap/SimpleWebChatComponent.java
@@ -16,7 +16,10 @@ public class SimpleWebChatComponent extends Component {
         plugin.events.addListener("webchat", new Event.Listener<ChatEvent>() {
             @Override
             public void triggered(ChatEvent t) {
-                plugin.getServer().broadcastMessage(plugin.configuration.getString("webprefix", "\u00A72[WEB] ") + t.name + ": " + plugin.configuration.getString("websuffix", "\u00A7f") + t.message);
+                DynmapWebChatEvent evt = new DynmapWebChatEvent(t.source, t.name, t.message);
+                plugin.getServer().getPluginManager().callEvent(evt);
+                if(evt.isCancelled() == false)
+                    plugin.getServer().broadcastMessage(plugin.configuration.getString("webprefix", "\u00A72[WEB] ") + t.name + ": " + plugin.configuration.getString("websuffix", "\u00A7f") + t.message);
             }
         });
         

--- a/src/main/java/org/dynmap/herochat/HeroWebChatComponent.java
+++ b/src/main/java/org/dynmap/herochat/HeroWebChatComponent.java
@@ -11,6 +11,7 @@ import org.dynmap.Client;
 import org.dynmap.Component;
 import org.dynmap.ConfigurationNode;
 import org.dynmap.DynmapPlugin;
+import org.dynmap.DynmapWebChatEvent;
 import org.dynmap.Event;
 import org.json.simple.JSONObject;
 
@@ -22,9 +23,13 @@ public class HeroWebChatComponent extends Component {
         plugin.events.addListener("webchat", new Event.Listener<ChatEvent>() {
             @Override
             public void triggered(ChatEvent t) {
-                /* Let HeroChat take a look - only broadcast to players if it doesn't handle it */
-                if (!handler.sendWebMessageToHeroChat(t.name, t.message)) {
-                    plugin.getServer().broadcastMessage(plugin.configuration.getString("webprefix", "\u00A72[WEB] ") + t.name + ": " + plugin.configuration.getString("websuffix", "\u00A7f") + t.message);
+                DynmapWebChatEvent evt = new DynmapWebChatEvent(t.source, t.name, t.message);
+                plugin.getServer().getPluginManager().callEvent(evt);
+                if(evt.isCancelled() == false) {
+                    /* Let HeroChat take a look - only broadcast to players if it doesn't handle it */
+                    if (!handler.sendWebMessageToHeroChat(t.name, t.message)) {
+                        plugin.getServer().broadcastMessage(plugin.configuration.getString("webprefix", "\u00A72[WEB] ") + t.name + ": " + plugin.configuration.getString("websuffix", "\u00A7f") + t.message);
+                    }
                 }
             }
         });


### PR DESCRIPTION
Per request - to allow folks interested in integrating with our web chat messages.  Cancellable, in case they want to implement alternate delivery/notification.
