### PR TITLE
Add mapzoomin attribute, to adjust zoom in levels beyond native tile reso

### DIFF
--- a/src/main/java/org/dynmap/flat/FlatMap.java
+++ b/src/main/java/org/dynmap/flat/FlatMap.java
@@ -518,6 +518,7 @@ public class FlatMap extends MapType {
         s(o, "backgroundday", c.getString("backgroundday"));
         s(o, "backgroundnight", c.getString("backgroundnight"));
         s(o, "bigmap", this.isBigWorldMap(world));
+        s(o, "mapzoomin", c.getInteger("mapzoomin", 3));
         s(o, "compassview", "S");   /* Always from south */
         a(worldObject, "maps", o);
     }

--- a/src/main/java/org/dynmap/hdmap/HDMap.java
+++ b/src/main/java/org/dynmap/hdmap/HDMap.java
@@ -144,6 +144,7 @@ public class HDMap extends MapType {
         s(o, "backgroundnight", c.getString("backgroundnight"));
         s(o, "bigmap", true);
         s(o, "mapzoomout", (world.getExtraZoomOutLevels()+mapzoomout));
+        s(o, "mapzoomin", c.getInteger("mapzoomin", 2));
         perspective.addClientConfiguration(o);
         shader.addClientConfiguration(o);
         lighting.addClientConfiguration(o);

--- a/src/main/java/org/dynmap/kzedmap/DefaultTileRenderer.java
+++ b/src/main/java/org/dynmap/kzedmap/DefaultTileRenderer.java
@@ -579,6 +579,7 @@ public class DefaultTileRenderer implements MapTileRenderer {
         s(o, "backgroundday", c.getString("backgroundday"));
         s(o, "backgroundnight", c.getString("backgroundnight"));
         s(o, "bigmap", map.isBigWorldMap(world));
+        s(o, "mapzoomin", c.getInteger("mapzoomin", 3));
         s(o, "compassview", "SE");   /* Always from southeast */
         a(worldObject, "maps", o);
     }

--- a/templates.txt
+++ b/templates.txt
@@ -40,6 +40,8 @@ templates:
   #      backgroundnight: "#000000"        
   #      # Background color for map (independent of night/day)
   #      background: "#000000"
+  #      # Adjust extra zoom in levels - default is 3
+  #      mapzoomin: 3
       - class: org.dynmap.kzedmap.KzedMap
         renderers:
           - class: org.dynmap.kzedmap.DefaultTileRenderer
@@ -64,6 +66,8 @@ templates:
   #          background: "#000000"
   #          # Sets the icon to 'images/block_custom.png'
   #          icon: custom
+  #          # Adjust extra zoom in levels - default is 3
+  #          mapzoomin: 3
   #          # Biome-based mapping
   #        - class: org.dynmap.kzedmap.DefaultTileRenderer
   #          name: biome
@@ -185,6 +189,8 @@ templates:
   #      backgroundnight: "#000000"        
   #      # Background color for map (independent of night/day)
   #      background: "#000000"
+        # Adjust extra zoom in levels - default is 2
+        mapzoomin: 2
       - class: org.dynmap.hdmap.HDMap
         name: surface
         title: "Surface"
@@ -206,6 +212,8 @@ templates:
   #      background: "#000000"
   #      # Sets the icon to 'images/block_custom.png'
   #      icon: custom
+        # Adjust extra zoom in levels - default is 2
+        mapzoomin: 2
   #      # Biome-based mapping
   #    - class: org.dynmap.hdmap.HDMap
   #      name: biome
@@ -215,6 +223,8 @@ templates:
   #      lighting: default
   #      # Biome-based shading : biome=biome type, temperature=biome-temperature, rainfall=biome-rainfall
   #      shader: biome
+  #      # Adjust extra zoom in levels - default is 2
+  #      mapzoomin: 2
       - class: org.dynmap.hdmap.HDMap
         name: cave
         title: "Cave"
@@ -222,6 +232,8 @@ templates:
         perspective: iso_SE_60_lowres
         shader: cave
         lighting: default
+        # Adjust extra zoom in levels - default is 2
+        mapzoomin: 2
          
   # Nether world template (HDMap)
   nether-HDMap:
@@ -244,6 +256,8 @@ templates:
         lighting: default
         # Map background color (day or night)
         background: "#300806"
+        # Adjust extra zoom in levels - default is 2
+        mapzoomin: 2
       - class: org.dynmap.hdmap.HDMap
         name: nether
         title: "Surface"
@@ -253,6 +267,8 @@ templates:
         lighting: default
         # Map background color (day or night)
         background: "#300806"
+        # Adjust extra zoom in levels - default is 2
+        mapzoomin: 2
   # Skylands world template (HDMap)
   skylands-HDMap:
     enabled: true
@@ -276,6 +292,8 @@ templates:
         backgroundday: "#153E7E"
         # Background color for map during the night
         backgroundnight: "#000000"        
+        # Adjust extra zoom in levels - default is 2
+        mapzoomin: 2
       - class: org.dynmap.hdmap.HDMap
         name: skylands
         title: "Surface"
@@ -287,4 +305,6 @@ templates:
         backgroundday: "#153E7E"
         # Background color for map during the night
         backgroundnight: "#000000"        
+        # Adjust extra zoom in levels - default is 2
+        mapzoomin: 2
             

--- a/web/js/flatmap.js
+++ b/web/js/flatmap.js
@@ -72,8 +72,9 @@ FlatMapType.prototype = $.extend(new DynMapType(), {
 	updateTileSize: function(zoom) {
         var size;
 		var extrazoom = this.dynmap.world.extrazoomout;
+		var mapzoomin = this.dynmap.world.mapzoomin;
 		this.projection.extrazoom = extrazoom;
-		this.maxZoom = 3 + extrazoom;
+		this.maxZoom = mapzoomin + extrazoom;
 		if (zoom <= extrazoom) {
         	size = 128;
     	}

--- a/web/js/hdmap.js
+++ b/web/js/hdmap.js
@@ -73,9 +73,10 @@ HDMapType.prototype = $.extend(new DynMapType(), {
 	updateTileSize: function(zoom) {
         var size;
 		var extrazoom = this.mapzoomout;
+		var mapzoomin = this.mapzoomin;
 		this.projection.extrazoom = extrazoom;
 		this.projection.worldtomap = this.worldtomap;
-		this.maxZoom = 2 + extrazoom;
+		this.maxZoom = mapzoomin + extrazoom;
 		if (zoom <= extrazoom) {
         	size = 128;
     	}

--- a/web/js/kzedmaps.js
+++ b/web/js/kzedmaps.js
@@ -115,8 +115,9 @@ KzedMapType.prototype = $.extend(new DynMapType(), {
 	updateTileSize: function(zoom) {
 		var size;
 		var extrazoom = this.dynmap.world.extrazoomout;
+		var mapzoomin = this.dynmap.world.mapzoomin;
 		this.projection.extrazoom = extrazoom;
-		this.maxZoom = 3 + extrazoom;
+		this.maxZoom = mapzoomin + extrazoom;
 		if (zoom <= extrazoom) {
 			size = 128;
 		} else {


### PR DESCRIPTION
Add mapzoomin attribute, to adjust zoom in levels beyond native tile resolution.  This is supported on all map types (KzedMap renderers, HDMaps, FlatMaps) and can be used to adjust (or disable) the zooming we allow on the web UI beyond the base tile resolution (that is, where the tiles start being stretched while being presented, which has issues on Chrome).  Default values match existing behavior - 3 extra levels for FlatMaps and KzedMaps, 2 extra levels for HDMaps.
