### PR TITLE
Add shader option to disable biome shading, disable biome shading on non-normal worlds

### DIFF
--- a/src/main/java/org/dynmap/DynmapPlugin.java
+++ b/src/main/java/org/dynmap/DynmapPlugin.java
@@ -133,7 +133,7 @@ public class DynmapPlugin extends JavaPlugin {
     }
     /* Table of default templates - all are resources in dynmap.jar unnder templates/, and go in templates directory when needed */
     private static final String[] stdtemplates = { "normal.txt", "nether.txt", "skylands.txt", "normal-lowres.txt", 
-        "nether-lowres.txt", "skylands-lowres.txt", "normal-hires.txt", "nether-hires.txt", "skyands-hires.txt"
+        "nether-lowres.txt", "skylands-lowres.txt", "normal-hires.txt", "nether-hires.txt", "skylands-hires.txt"
     };
     
     private static final String CUSTOM_PREFIX = "custom-";

--- a/src/main/java/org/dynmap/hdmap/TexturePack.java
+++ b/src/main/java/org/dynmap/hdmap/TexturePack.java
@@ -374,9 +374,15 @@ public class TexturePack {
             }
         }
         /* All the same - no biome lookup needed */
-        if(same)
+        if(same) {
             imgs[idx].argb = null;
-        li.trivial_color = clr;
+            li.trivial_color = clr;
+        }
+        else {  /* Else, calculate color average for lower left quadrant */
+            int[] clr_scale = new int[4];
+            scaleTerrainPNGSubImage(li.width, 2, li.argb, clr_scale);
+            li.trivial_color = clr_scale[2];
+        }
     }
     
     /* Patch image into texture table */
@@ -694,7 +700,7 @@ public class TexturePack {
     /**
      * Read color for given subblock coordinate, with given block id and data and face
      */
-    public void readColor(HDPerspectiveState ps, MapIterator mapiter, Color rslt, int blkid, int lastblocktype) {
+    public void readColor(HDPerspectiveState ps, MapIterator mapiter, Color rslt, int blkid, int lastblocktype, boolean biome_shaded) {
         int blkdata = ps.getBlockData();
         HDTextureMap map = HDTextureMap.getMap(blkid, blkdata);
         BlockStep laststep = ps.getLastBlockStep();
@@ -797,7 +803,7 @@ public class TexturePack {
             switch(textop) {
                 case COLORMOD_GRASSTONED:
                     li = imgs[IMG_GRASSCOLOR];
-                    if(li.argb == null) {
+                    if((li.argb == null) || (!biome_shaded)) {
                         rslt.blendColor(li.trivial_color);
                     }
                     else {
@@ -806,7 +812,7 @@ public class TexturePack {
                     break;
                 case COLORMOD_FOLIAGETONED:
                     li = imgs[IMG_FOLIAGECOLOR];
-                    if(li.argb == null) {
+                    if((li.argb == null) || (!biome_shaded)) {
                         rslt.blendColor(li.trivial_color);
                     }
                     else {

--- a/src/main/java/org/dynmap/utils/LegacyMapChunkCache.java
+++ b/src/main/java/org/dynmap/utils/LegacyMapChunkCache.java
@@ -541,4 +541,7 @@ public class LegacyMapChunkCache implements MapChunkCache {
             return false;
         return true;
     }
+    public World getWorld() {
+        return w;
+    }
 }

--- a/src/main/java/org/dynmap/utils/MapChunkCache.java
+++ b/src/main/java/org/dynmap/utils/MapChunkCache.java
@@ -96,4 +96,8 @@ public interface MapChunkCache {
      * Set autogenerate - must be done after at least one visible range has been set
      */
     public void setAutoGenerateVisbileRanges(DynmapWorld.AutoGenerateOption do_generate);
+    /**
+     * Get world
+     */
+    public World getWorld();
 }

--- a/src/main/java/org/dynmap/utils/NewMapChunkCache.java
+++ b/src/main/java/org/dynmap/utils/NewMapChunkCache.java
@@ -629,4 +629,9 @@ public class NewMapChunkCache implements MapChunkCache {
         this.blockdata = blockdata;
         return true;
     }
+    @Override
+    public World getWorld() {
+        return w;
+    }
+
 }

--- a/src/main/resources/shaders.txt
+++ b/src/main/resources/shaders.txt
@@ -43,3 +43,9 @@ shaders:
     name: stdtexture
     texturepack: standard
     
+  - class: org.dynmap.hdmap.TexturePackHDShader
+    name: stdtexture-nobiome
+    texturepack: standard
+    biomeshaded: false
+    
+    


### PR DESCRIPTION
Texture Pack shader now supports a 'biomeshaded' attribute (default true, false disables biome-based grass and foliage shading).  Also, non-normal worlds (skylands, nether) don't have valid raw biome data, so shading is disabled unconditionally when rendering those map types.
