### PR TITLE
Add escape sequence '&color;' support for webprefix/websuffix - avoid frequent editor code page problems

### DIFF
--- a/src/main/java/org/dynmap/Component.java
+++ b/src/main/java/org/dynmap/Component.java
@@ -10,4 +10,12 @@ public abstract class Component {
     
     public void dispose() {
     }
+    
+    /* Substitute proper values for escape sequences */
+    public static String unescapeString(String v) {
+        /* Replace color code &color; */
+        v = v.replaceAll("&color;", "\u00A7");
+        
+        return v;
+    }
 }

--- a/src/main/java/org/dynmap/SimpleWebChatComponent.java
+++ b/src/main/java/org/dynmap/SimpleWebChatComponent.java
@@ -19,7 +19,7 @@ public class SimpleWebChatComponent extends Component {
                 DynmapWebChatEvent evt = new DynmapWebChatEvent(t.source, t.name, t.message);
                 plugin.getServer().getPluginManager().callEvent(evt);
                 if(evt.isCancelled() == false)
-                    plugin.getServer().broadcastMessage(plugin.configuration.getString("webprefix", "\u00A72[WEB] ") + t.name + ": " + plugin.configuration.getString("websuffix", "\u00A7f") + t.message);
+                    plugin.getServer().broadcastMessage(unescapeString(plugin.configuration.getString("webprefix", "\u00A72[WEB] ")) + t.name + ": " + unescapeString(plugin.configuration.getString("websuffix", "\u00A7f")) + t.message);
             }
         });
         

--- a/src/main/java/org/dynmap/herochat/HeroWebChatComponent.java
+++ b/src/main/java/org/dynmap/herochat/HeroWebChatComponent.java
@@ -28,7 +28,7 @@ public class HeroWebChatComponent extends Component {
                 if(evt.isCancelled() == false) {
                     /* Let HeroChat take a look - only broadcast to players if it doesn't handle it */
                     if (!handler.sendWebMessageToHeroChat(t.name, t.message)) {
-                        plugin.getServer().broadcastMessage(plugin.configuration.getString("webprefix", "\u00A72[WEB] ") + t.name + ": " + plugin.configuration.getString("websuffix", "\u00A7f") + t.message);
+                        plugin.getServer().broadcastMessage(unescapeString(plugin.configuration.getString("webprefix", "\u00A72[WEB] ")) + t.name + ": " + unescapeString(plugin.configuration.getString("websuffix", "\u00A7f")) + t.message);
                     }
                 }
             }

--- a/src/main/resources/configuration.txt
+++ b/src/main/resources/configuration.txt
@@ -139,8 +139,9 @@ showplayerfacesinmenu: true
 joinmessage: "%playername% joined"
 quitmessage: "%playername% quit"
 spammessage: "You may only chat once every %interval% seconds."
-webprefix: "§2[WEB] "
-websuffix: "§f"
+# webprefix and websuffix support using '&color;' as escape code for color code
+webprefix: "&color;2[WEB] "
+websuffix: "&color;f"
 # Enable checking for banned IPs via banned-ips.txt (internal web server only)
 check-banned-ips: true
 
@@ -149,7 +150,7 @@ defaultworld: world
 
 # Set to true to enable verbose startup messages - can help with debugging map configuration problems
 # Set to false for a much quieter startup log
-verbose: true
+verbose: false
 
 # Enables debugging.
 #debuggers:


### PR DESCRIPTION
Existing settings still work, but new default in configuration.txt will not break when folks edit with non UTF-8 editors.
