### PR TITLE
Add max-sessions setting to configuration.txt - limits concurrent threads and sessions on internal web server

### DIFF
--- a/src/main/java/org/dynmap/DynmapPlugin.java
+++ b/src/main/java/org/dynmap/DynmapPlugin.java
@@ -275,11 +275,13 @@ public class DynmapPlugin extends JavaPlugin {
         int port = configuration.getInteger("webserver-port", 8123);
         boolean allow_symlinks = configuration.getBoolean("allow-symlinks", false);
         boolean checkbannedips = configuration.getBoolean("check-banned-ips", true);
+        int maxconnections = configuration.getInteger("max-sessions", 30);
+        if(maxconnections < 2) maxconnections = 2;
         if(allow_symlinks)
         	Log.verboseinfo("Web server is permitting symbolic links");
         else
         	Log.verboseinfo("Web server is not permitting symbolic links");        	
-        webServer = new HttpServer(bindAddress, port, checkbannedips);
+        webServer = new HttpServer(bindAddress, port, checkbannedips, maxconnections);
         webServer.handlers.put("/", new FilesystemHandler(getFile(configuration.getString("webpath", "web")), allow_symlinks));
         webServer.handlers.put("/tiles/", new FilesystemHandler(tilesDirectory, allow_symlinks));
         webServer.handlers.put("/up/configuration", new ClientConfigurationHandler(this));

--- a/src/main/resources/configuration.txt
+++ b/src/main/resources/configuration.txt
@@ -116,6 +116,9 @@ webserver-bindaddress: 0.0.0.0
 # The TCP-port the webserver will listen on.
 webserver-port: 8123
 
+# Maximum concurrent session on internal web server - limits resources used in Bukkit server
+max-sessions: 30
+
 # Disables Webserver portion of Dynmap (Advanced users only)
 disable-webserver: false
 


### PR DESCRIPTION
This is intended to prevent some relatively simple DOS type attacks, due to the internal web server's lack of a limit on spawning TCP sessions and threads to service them.  The max-sessions setting, which defaults to 30, limits the number of open TCP sessions for the web server.  Further, it limits the number of sessions that are long-lived keep-alive sessions to 1/2 the max-sessions limit.  Once the session limit is reached, additional connect attempts are ignored until at least one session closes - the limit on the number of keep-alive sessions allows the remaining 1/2 of the session pool to, worst case, round robin through the additional browsers attempting to connect to the server.  In the event of a DOS attack, the resource impacts to the Bukkit server should be bound by the limited session and pool population.
