### PR TITLE
Fix skylands premature-end-of-render issue

### DIFF
--- a/src/main/java/org/dynmap/MapManager.java
+++ b/src/main/java/org/dynmap/MapManager.java
@@ -310,7 +310,9 @@ public class MapManager {
                     tile.render(cache);
             }
             else {
-                if ((cache.isEmpty() == false) && tile.render(cache)) {
+            	/* Switch to not checking if rendered tile is blank - breaks us on skylands, where tiles can be nominally blank - just work off chunk cache empty */
+                if (cache.isEmpty() == false) {
+                	tile.render(cache);
                     found.remove(tile);
                     rendered.add(tile);
                     for (MapTile adjTile : map.getAdjecentTiles(tile)) {


### PR DESCRIPTION
For skylands, especially with high res render, we need to stop using the fact that a tile rendered as empty as a cue to clip the fullrender - we already clip when the chunk cache loaded for a tile has no chunks, which will work properly as the only test on all map types (including skylands, where chunks can exist that are, in fact, all air, but that doesn't imply the edge of the map).
