### PR TITLE
Clean up player icon transitions to/from visible map

### DIFF
--- a/web/js/custommarker.js
+++ b/web/js/custommarker.js
@@ -48,6 +48,8 @@ L.CustomMarker = L.Class.extend({
 		}
 		
 		map.off('viewreset', this._reset, this);
+		
+		map = null;
 	},
 	
 	getLatLng: function() {
@@ -60,6 +62,8 @@ L.CustomMarker = L.Class.extend({
 	},
 	
 	_reset: function() {
+		if(this._map == null)
+			return;
 		var pos = this._map.latLngToLayerPoint(this._latlng);
 		
 		if (this._element) {


### PR DESCRIPTION
Adding the markers to the maps unconditionally was causing issues with "flickering" on the initial map load (players that are not on the map showing their relative position on the world the ARE on, etc).  Changed the code to not add the layer for the marker when the player isn't on the world corresponding to the map, and to remove it when they move off the world represented by the map.
