### PR TITLE
Don't include face accessory overlay on faces for now - causes 'white face'

### DIFF
--- a/web/js/minecraft.js
+++ b/web/js/minecraft.js
@@ -8,12 +8,13 @@ var cloneCanvas = function(self) {
 };
 
 function blitImage(ctx, image, sx ,sy, sw, sh, dx, dy, dw, dh) {
-	var x; var y;
-	for (x=0;x<dw;x++) {
-		for (y=0;y<dh;y++) {
-			ctx.drawImage(image,Math.floor(sx+x*(sw/dw)),Math.floor(sy+y*(sw/dw)),1,1,dx+x,dy+y,1,1);
-		}
-	}	
+	ctx.drawImage(image, sx, sy, sw, sh, dx, dy, dw, dh);
+//	var x; var y;
+//	for (x=0;x<dw;x++) {
+//		for (y=0;y<dh;y++) {
+//			ctx.drawImage(image,Math.floor(sx+x*(sw/dw)),Math.floor(sy+y*(sw/dw)),1,1,dx+x,dy+y,1,1);
+//		}
+//	}	
 }
 
 function createMinecraftHead(player,completed,failed) {
@@ -24,7 +25,8 @@ function createMinecraftHead(player,completed,failed) {
 		headCanvas.height = 8;
 		var headContext = headCanvas.getContext('2d');
 		blitImage(headContext, skinImage,  8,8,8,8, 0,0,8,8);
-		blitImage(headContext, skinImage, 40,8,8,8, 0,0,8,8);
+		// Turn off accessory face overlay - causes white faces, and very few skins seem to have them anyway
+		//blitImage(headContext, skinImage, 40,8,8,8, 0,0,8,8);
 		completed(headCanvas);
 	};
 	skinImage.onerror = function() {


### PR DESCRIPTION
Also, seems like very few skins use it - and, clearly, since the skins work, we're missing some important detail on how the overlay process really works versus the in-game use of the ski.  I suspect we'll get fewer complaints about folks missing glasses or whatever than the daily complains on white faces.
