### PR TITLE
Fix map center consistency between map changes, add fromLatLngToLocation to Projection

### DIFF
--- a/web/js/dynmaputils.js
+++ b/web/js/dynmaputils.js
@@ -4,6 +4,9 @@ var DynmapProjection = L.Class.extend({
 	},
 	fromLocationToLatLng: function(location) {
 		throw "fromLocationToLatLng not implemented";
+	},
+	fromLatLngToLocation: function(location) {
+		return null;
 	}
 });
 

--- a/web/js/flatmap.js
+++ b/web/js/flatmap.js
@@ -4,7 +4,13 @@ var FlatProjection = DynmapProjection.extend({
 				-location.z / (1 << this.options.mapzoomout),
 				location.x / (1 << this.options.mapzoomout),
 				true);
+	},
+	fromLatLngToLocation: function(latlon, y) {
+		var z = -latlon.lat * (1 << this.options.mapzoomout);
+		var x = latlon.lng * (1 << this.options.mapzoomout);
+		return { x: x, y: y, z: z };
 	}
+	
 });
 
 var FlatMapType = DynmapTileLayer.extend({

--- a/web/js/hdmap.js
+++ b/web/js/hdmap.js
@@ -7,7 +7,16 @@ var HDProjection = DynmapProjection.extend({
 			  xx       / (1 << this.options.mapzoomout)
 			, (128-yy) / (1 << this.options.mapzoomout)
 			, true);
+	},
+	fromLatLngToLocation: function(latlon, y) {
+		var ptw = this.options.maptoworld;
+		var lat = latlon.lat * (1 << this.options.mapzoomout);
+		var lon = 128 - latlon.lng * (1 << this.options.mapzoomout);
+		var x = ptw[0]*lat + ptw[1]*lon + ptw[2]*y;
+		var z = ptw[6]*lat + ptw[7]*lon + ptw[8]*y;
+		return { x: x, y: y, z: z };
 	}
+	
 });
 
 var HDMapType = DynmapTileLayer.extend({

--- a/web/js/kzedmaps.js
+++ b/web/js/kzedmaps.js
@@ -10,7 +10,16 @@ var KzedProjection = DynmapProjection.extend({
 		var xx = (128 - px) / scale;
 		var yy = py / scale;
 		return new L.LatLng(xx, yy, true);
+	},
+	fromLatLngToLocation: function(latlon, y) {
+		var scale = 1 << this.options.mapzoomout;
+		var px = 128 - (latlon.lat * scale);
+		var py = latlon.lng * scale;
+		var x = (px + py + (y-127))/2;
+		var z = (px - x);
+		return { x: x, y: y, z: z };
 	}
+	
 });
 
 var KzedMapType = DynmapTileLayer.extend({

--- a/web/js/map.js
+++ b/web/js/map.js
@@ -323,6 +323,8 @@ DynMap.prototype = {
 			me.map.removeLayer(me.maptype);
 		}
 		
+		var prevmap = me.maptype;
+	
 		me.world = mapWorld;
 		me.maptype = map;
 
@@ -338,7 +340,13 @@ DynMap.prototype = {
 				centerPoint = me.getProjection().fromLocationToLatLng(centerLocation);
 			}
 			else {
-				centerPoint = me.map.getCenter();
+				var prevloc = null;
+				if(prevmap != null)
+					prevloc = prevmap.getProjection().fromLatLngToLocation(me.map.getCenter(), 64);
+				if(prevloc != null)
+					centerPoint = me.getProjection().fromLocationToLatLng(prevloc);
+				else
+					centerPoint = me.map.getCenter();
 			}
 			me.map.setView(centerPoint, prevzoom, true);
 		}


### PR DESCRIPTION
This addresses the issue of the map center jumping to different locations when switching between maps with non-identical projections.  As an artifact, the Projection class now has the previously requested "fromLatLngToLocation" method for producing a world location from a map coordinate (given a supplied assumed 'y' value - which we default to 64 for our use, since we need something and average ground level seems reasonable....).
