### PR TITLE
Handle leaf fade processing flag values in texture mapping

### DIFF
--- a/src/main/resources/texture.txt
+++ b/src/main/resources/texture.txt
@@ -48,13 +48,11 @@ block:id=17,data=1,allsides=116,top=21,bottom=21
 # Wood (birch)
 block:id=17,data=2,allsides=117,top=21,bottom=21
 # Leaves (std)
-block:id=18,data=0,allfaces=2052,transparency=TRANSPARENT
+block:id=18,data=0,data=4,data=8,allfaces=2052,transparency=TRANSPARENT
 # Leaves (spruce/pine)
-block:id=18,data=1,allfaces=2132,transparency=TRANSPARENT
+block:id=18,data=1,data=5,data=9,allfaces=2132,transparency=TRANSPARENT
 # Leaves (birch)
-block:id=18,data=2,allfaces=2052,transparency=TRANSPARENT
-# Leaves (skyland?)
-block:id=18,data=8,allfaces=2052,transparency=TRANSPARENT
+block:id=18,data=2,data=6,data=10,allfaces=2052,transparency=TRANSPARENT
 # Sponge
 block:id=19,allfaces=48
 # Glass


### PR DESCRIPTION
Leaf blocks can have the value 4 or 8 added to their basic block data - these appear to be associated with being marked for 'fade processing', and freshly created chunks can have them set: if the chunk doesn't stay loaded long, they are never cleared, and our textures.txt mapping doesn't account for them (so the leaves are invisible).  I've confirmed by scanning the data values on my map that this can happen on normal worlds, and that the range of values actually found correspond to this.  This texture.txt mapping update should handle all cases I've observed.
