### PR TITLE
Add support for selectively hiding portions of worlds (opposite of visibilitylimits)

### DIFF
--- a/src/main/java/org/dynmap/DynmapWorld.java
+++ b/src/main/java/org/dynmap/DynmapWorld.java
@@ -32,6 +32,7 @@ public class DynmapWorld {
     public ConfigurationNode configuration;
     public List<Location> seedloc;
     public List<MapChunkCache.VisibilityLimit> visibility_limits;
+    public List<MapChunkCache.VisibilityLimit> hidden_limits;
     public AutoGenerateOption do_autogenerate;
     public MapChunkCache.HiddenChunkStyle hiddenchunkstyle;
     public int servertime;

--- a/src/main/java/org/dynmap/MapManager.java
+++ b/src/main/java/org/dynmap/MapManager.java
@@ -550,6 +550,19 @@ public class MapManager {
                 dynmapWorld.seedloc.add(new Location(w, (lim.x0+lim.x1)/2, 64, (lim.z0+lim.z1)/2));
             }            
         }
+        /* Load hidden limits, if any are defined */
+        List<ConfigurationNode> hidelimits = worldConfiguration.getNodes("hiddenlimits");
+        if(hidelimits != null) {
+            dynmapWorld.hidden_limits = new ArrayList<MapChunkCache.VisibilityLimit>();
+            for(ConfigurationNode vis : hidelimits) {
+                MapChunkCache.VisibilityLimit lim = new MapChunkCache.VisibilityLimit();
+                lim.x0 = vis.getInteger("x0", 0);
+                lim.x1 = vis.getInteger("x1", 0);
+                lim.z0 = vis.getInteger("z0", 0);
+                lim.z1 = vis.getInteger("z1", 0);
+                dynmapWorld.hidden_limits.add(lim);
+            }            
+        }
         String autogen = worldConfiguration.getString("autogenerate-to-visibilitylimits", "none");
         if(autogen.equals("permanent")) {
             dynmapWorld.do_autogenerate = AutoGenerateOption.PERMANENT;
@@ -707,6 +720,13 @@ public class MapManager {
             c.setHiddenFillStyle(w.hiddenchunkstyle);
             c.setAutoGenerateVisbileRanges(w.do_autogenerate);
         }
+        if(w.hidden_limits != null) {
+            for(MapChunkCache.VisibilityLimit limit: w.hidden_limits) {
+                c.setHiddenRange(limit);
+            }
+            c.setHiddenFillStyle(w.hiddenchunkstyle);
+        }
+
         c.setChunks(w.world, chunks);
         if(c.setChunkDataTypes(blockdata, biome, highesty, rawbiome) == false)
             Log.severe("CraftBukkit build does not support biome APIs");

--- a/src/main/java/org/dynmap/utils/LegacyMapChunkCache.java
+++ b/src/main/java/org/dynmap/utils/LegacyMapChunkCache.java
@@ -524,6 +524,14 @@ public class LegacyMapChunkCache implements MapChunkCache {
         visible_limits.add(limit);
     }
     /**
+     * Add hidden area limit - can be called more than once 
+     * Needs to be set before chunks are loaded
+     * Coordinates are block coordinates
+     */
+    public void setHiddenRange(VisibilityLimit lim) {
+        Log.severe("LegacyMapChunkCache does not support hidden areas");
+    }
+    /**
      * Set autogenerate - must be done after at least one visible range has been set
      */
     public void setAutoGenerateVisbileRanges(DynmapWorld.AutoGenerateOption generateopt) {

--- a/src/main/java/org/dynmap/utils/MapChunkCache.java
+++ b/src/main/java/org/dynmap/utils/MapChunkCache.java
@@ -93,6 +93,12 @@ public interface MapChunkCache {
      */
     public void setVisibleRange(VisibilityLimit limit);
     /**
+     * Add hidden area limit - can be called more than once 
+     * Needs to be set before chunks are loaded
+     * Coordinates are block coordinates
+     */
+    public void setHiddenRange(VisibilityLimit limit);
+    /**
      * Set autogenerate - must be done after at least one visible range has been set
      */
     public void setAutoGenerateVisbileRanges(DynmapWorld.AutoGenerateOption do_generate);

--- a/src/main/java/org/dynmap/utils/NewMapChunkCache.java
+++ b/src/main/java/org/dynmap/utils/NewMapChunkCache.java
@@ -37,6 +37,7 @@ public class NewMapChunkCache implements MapChunkCache {
     private boolean biome, biomeraw, highesty, blockdata;
     private HiddenChunkStyle hidestyle = HiddenChunkStyle.FILL_AIR;
     private List<VisibilityLimit> visible_limits = null;
+    private List<VisibilityLimit> hidden_limits = null;
     private DynmapWorld.AutoGenerateOption generateopt;
     private boolean do_generate = false;
     private boolean do_save = false;
@@ -395,6 +396,14 @@ public class NewMapChunkCache implements MapChunkCache {
                     }
                 }
             }
+            if(vis && (hidden_limits != null)) {
+                for(VisibilityLimit limit : hidden_limits) {
+                    if((chunk.x >= limit.x0) && (chunk.x <= limit.x1) && (chunk.z >= limit.z0) && (chunk.z <= limit.z1)) {
+                        vis = false;
+                        break;
+                    }
+                }
+            }
             /* Check if cached chunk snapshot found */
             ChunkSnapshot ss = MapManager.mapman.sscache.getSnapshot(w.getName(), chunk.x, chunk.z, blockdata, biome, biomeraw, highesty); 
             if(ss != null) {
@@ -618,6 +627,29 @@ public class NewMapChunkCache implements MapChunkCache {
         if(visible_limits == null)
             visible_limits = new ArrayList<VisibilityLimit>();
         visible_limits.add(limit);
+    }
+    /**
+     * Add hidden area limit - can be called more than once 
+     * Needs to be set before chunks are loaded
+     * Coordinates are block coordinates
+     */
+    public void setHiddenRange(VisibilityLimit lim) {
+        VisibilityLimit limit = new VisibilityLimit();
+        if(lim.x0 > lim.x1) {
+            limit.x0 = (lim.x1 >> 4); limit.x1 = ((lim.x0+15) >> 4);
+        }
+        else {
+            limit.x0 = (lim.x0 >> 4); limit.x1 = ((lim.x1+15) >> 4);
+        }
+        if(lim.z0 > lim.z1) {
+            limit.z0 = (lim.z1 >> 4); limit.z1 = ((lim.z0+15) >> 4);
+        }
+        else {
+            limit.z0 = (lim.z0 >> 4); limit.z1 = ((lim.z1+15) >> 4);
+        }
+        if(hidden_limits == null)
+            hidden_limits = new ArrayList<VisibilityLimit>();
+        hidden_limits.add(limit);
     }
     @Override
     public boolean setChunkDataTypes(boolean blockdata, boolean biome, boolean highestblocky, boolean rawbiome) {

--- a/src/main/resources/worlds.txt
+++ b/src/main/resources/worlds.txt
@@ -35,6 +35,12 @@ worlds:
   #      z0: -1000
   #      x1: -1000
   #      z1: -500
+  #  # Use hiddenlimits to specifically hide portions of your world (the opposite of visibilitylimits)
+  #  hiddenlimits:
+  #    - x0: 100
+  #      z0: 0
+  #      x1: 200
+  #      z1: 0
   #  # Use hidestyle to control how hidden-but-existing chunks are to be rendered (air=empty air (same as ungenerated), stone=a flat stone plain, ocean=a flat ocean)
   #  hidestyle: stone
   #  # Use 'autogenerate-to-visibilitylimits: true' to choose to force the generation of ungenerated chunks while rendering maps on this world, for any chunks within the defined


### PR DESCRIPTION
Per request - option to specify rectangles that will not be rendered on a given world (for use with hiding projects that are not yet public, and the like).  Same format as visbilitylimits - just negative logic.
