### PR TITLE
Fix javadoc errors for building with Java SE 8

### DIFF
--- a/src/main/java/org/dynmap/bukkit/Metrics.java
+++ b/src/main/java/org/dynmap/bukkit/Metrics.java
@@ -56,9 +56,9 @@ import java.util.logging.Level;
  * <p> The metrics class obtains data about a plugin and submits statistics about it to the metrics backend. </p> <p>
  * Public methods provided by this class: </p>
  * <code>
- * Graph createGraph(String name); <br/>
- * void addCustomData(BukkitMetrics.Plotter plotter); <br/>
- * void start(); <br/>
+ * Graph createGraph(String name); <br>
+ * void addCustomData(BukkitMetrics.Plotter plotter); <br>
+ * void start(); <br>
  * </code>
  */
 public class Metrics {


### PR DESCRIPTION
More information about doclint (which is what checks syntax for javadoc comments) can be found here:
http://openjdk.java.net/jeps/172
