### PR TITLE
Changed default "skin-url" value

### DIFF
--- a/src/main/resources/configuration.txt
+++ b/src/main/resources/configuration.txt
@@ -274,7 +274,7 @@ custom-colors-support: true
 #refreshskins: false
 
 # Customize URL used for fetching player skins (%player% is macro for name)
-skin-url: "http://s3.amazonaws.com/MinecraftSkins/%player%.png"
+skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)
 #   default is 'newrose' (preserve pre-1.0 maps, rotate rose)


### PR DESCRIPTION
With the new skin system introduced in 1.7.10/1.8, Mojang now hosts skins under the minecraft.net domain instead of Amazon's. Since the Amazon link now only provides outdated skins, it would be better to use the new skins.minecraft.net URL as default.