### PR TITLE
Remove duplicate removeEntities - Fixes #1838

### DIFF
--- a/src/main/java/org/dynmap/bukkit/BukkitVersionHelper.java
+++ b/src/main/java/org/dynmap/bukkit/BukkitVersionHelper.java
@@ -88,10 +88,6 @@ public abstract class BukkitVersionHelper {
      * Test if normal chunk snapshot
      */
 //    public abstract boolean isCraftChunkSnapshot(ChunkSnapshot css);
-    /** 
-     * Remove entities from given chunk
-     */
-    public abstract void removeEntitiesFromChunk(Chunk c);
     /**
      * Get inhabited ticks count from chunk
      */

--- a/src/main/java/org/dynmap/bukkit/BukkitVersionHelperCB.java
+++ b/src/main/java/org/dynmap/bukkit/BukkitVersionHelperCB.java
@@ -89,7 +89,6 @@ public class BukkitVersionHelperCB extends BukkitVersionHelperGeneric {
         }
         /** n.m.s.Chunk */
         nmschunk = getNMSClass("net.minecraft.server.Chunk");
-        nmsc_removeentities = getMethod(nmschunk, new String[] { "removeEntities" }, nulltypes);
         nmsc_tileentities = getField(nmschunk, new String[] { "tileEntities" }, Map.class);
         nmsc_inhabitedticks = getFieldNoFail(nmschunk, new String[] { "s", "q", "u" }, long.class);
         if (nmsc_inhabitedticks == null) {
@@ -144,7 +143,6 @@ public class BukkitVersionHelperCB extends BukkitVersionHelperGeneric {
     }
     @Override
     public void unloadChunkNoSave(World w, Chunk c, int cx, int cz) {
-        this.removeEntitiesFromChunk(c);
         w.unloadChunk(cx, cz, false, false);
     }
     /**

--- a/src/main/java/org/dynmap/bukkit/BukkitVersionHelperGeneric.java
+++ b/src/main/java/org/dynmap/bukkit/BukkitVersionHelperGeneric.java
@@ -54,7 +54,6 @@ public abstract class BukkitVersionHelperGeneric extends BukkitVersionHelper {
     protected Method lhs_containskey;
     /** n.m.s.Chunk */
     protected Class<?> nmschunk;
-    protected Method nmsc_removeentities;
     protected Field nmsc_tileentities;
     protected Field nmsc_inhabitedticks;
     /** nbt classes */
@@ -322,13 +321,7 @@ public abstract class BukkitVersionHelperGeneric extends BukkitVersionHelper {
 //        }
 //        return false;
 //    }
-    /** Remove entities from given chunk */
-    public void removeEntitiesFromChunk(Chunk c) {
-        Object omsc = callMethod(c, cc_gethandle, nullargs, null);
-        if(omsc != null) {
-            callMethod(omsc, nmsc_removeentities, nullargs, null);
-        }
-    }
+
     /**
      * Get inhabited ticks count from chunk
      */

--- a/src/main/java/org/dynmap/bukkit/BukkitVersionHelperGlowstone.java
+++ b/src/main/java/org/dynmap/bukkit/BukkitVersionHelperGlowstone.java
@@ -92,12 +92,6 @@ public class BukkitVersionHelperGlowstone extends BukkitVersionHelper {
     }
 
     @Override
-    public void removeEntitiesFromChunk(Chunk c) {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
     public long getInhabitedTicks(Chunk c) {
         // TODO Auto-generated method stub
         return 0;


### PR DESCRIPTION
This is handled by unloadChunk and should not be running twice like it is.