### PR TITLE
Add support for LuckPerms offline permission checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,11 @@
 			<version>2.10.1</version>
 		</dependency>
 		<dependency>
+			<groupId>me.lucko.luckperms</groupId>
+			<artifactId>luckperms-api</artifactId>
+			<version>4.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.bstats</groupId>
 			<artifactId>bstats-bukkit</artifactId>
 			<version>1.1</version>

--- a/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
+++ b/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
@@ -78,6 +78,7 @@ import org.dynmap.MapManager;
 import org.dynmap.MapType;
 import org.dynmap.PlayerList;
 import org.dynmap.bukkit.permissions.BukkitPermissions;
+import org.dynmap.bukkit.permissions.LuckPermsPermissions;
 import org.dynmap.bukkit.permissions.NijikokunPermissions;
 import org.dynmap.bukkit.permissions.OpPermissions;
 import org.dynmap.bukkit.permissions.PEXPermissions;
@@ -800,6 +801,8 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
             permissions = NijikokunPermissions.create(getServer(), "dynmap");
         if (permissions == null)
             permissions = GroupManagerPermissions.create(getServer(), "dynmap");
+        if (permissions == null)
+            permissions = LuckPermsPermissions.create(getServer(), "dynmap");
         if (permissions == null)
             permissions = BukkitPermissions.create("dynmap", perdefs);
         if (permissions == null)

--- a/src/main/java/org/dynmap/bukkit/permissions/LuckPermsPermissions.java
+++ b/src/main/java/org/dynmap/bukkit/permissions/LuckPermsPermissions.java
@@ -1,0 +1,96 @@
+package org.dynmap.bukkit.permissions;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+
+import me.lucko.luckperms.api.LuckPermsApi;
+import me.lucko.luckperms.api.User;
+import me.lucko.luckperms.api.caching.PermissionData;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Server;
+import org.bukkit.command.CommandSender;
+import org.dynmap.Log;
+
+public class LuckPermsPermissions implements PermissionProvider {
+    String name;
+    LuckPermsApi luckPerms;
+
+    public static LuckPermsPermissions create(Server server, String name) {
+        if (!server.getPluginManager().isPluginEnabled("LuckPerms"))
+            return null;
+        LuckPermsApi luckPerms = server.getServicesManager().load(LuckPermsApi.class);
+        if(luckPerms == null)
+            return null;
+        Log.info("Using LuckPerms " + luckPerms.getPlatformInfo().getVersion() + " for access control");
+        return new LuckPermsPermissions(name, luckPerms);
+    }
+
+    public LuckPermsPermissions(String name, LuckPermsApi luckPerms) {
+        this.name = name;
+        this.luckPerms = luckPerms;
+    }
+
+    @Override
+    public boolean has(CommandSender sender, String permission) {
+        return sender.hasPermission(name + "." + permission);
+    }
+
+    @Override
+    public Set<String> hasOfflinePermissions(String player, Set<String> perms) {
+        Set<String> result = new HashSet<>();
+        PermissionData user = getUser(player);
+        if(user != null) {
+            for (String p : perms) {
+                if(user.getPermissionValue(name + "." + p).asBoolean())
+                    result.add(p);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean hasOfflinePermission(String player, String perm) {
+        PermissionData user = getUser(player);
+        if (user == null)
+            return false;
+        return user.getPermissionValue(name + "." + perm).asBoolean();
+    }
+
+    private PermissionData getUser(String username) {
+        OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(username);
+        UUID uuid;
+
+        if(offlinePlayer != null && offlinePlayer.getUniqueId() != null)
+            uuid = offlinePlayer.getUniqueId();
+        else
+            uuid = joinFuture(luckPerms.getStorage().getUUID(username));
+
+        if(uuid == null)
+            return null;
+
+        User user = luckPerms.getUser(uuid);
+        if(user == null) {
+            joinFuture(luckPerms.getStorage().loadUser(uuid));
+            user = luckPerms.getUser(uuid);
+        }
+
+        if(user == null)
+            return null;
+
+        return user.getCachedData().getPermissionData(luckPerms.getContextManager().getStaticContexts());
+    }
+
+    private static <T> T joinFuture(Future<T> future) {
+        try {
+            return future.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: org.dynmap.bukkit.DynmapPlugin
 version: "${project.version}-${BUILD_NUMBER}"
 authors: [mikeprimm]
 website: "http://www.minecraftforum.net/topic/1543523-dynmap-dynamic-web-based-maps-for-minecraft/"
-softdepend: [ Permissions, PermissionEx, bPermissions, PermissionsBukkit, GroupManager ]
+softdepend: [ Permissions, PermissionEx, bPermissions, PermissionsBukkit, GroupManager, LuckPerms ]
 commands:
   dynmap:
     description: Controls Dynmap.


### PR DESCRIPTION
As requested here:
https://www.spigotmc.org/threads/luckperms-an-advanced-permissions-plugin.174259/page-91#post-2843682

Fixes #2127 

---

I've tested the change, all seems to be working correctly. Offline permission check runs ok.

https://gist.github.com/anonymous/fe56b86040c52a1f8b852db73926d7cb

The `Storage` interface in the LP API returns Futures - they can cause lag if joined from the server thread, however my understanding is that the offline check methods are only called from the web server anyway - so shouldn't ever be an issue.

I've tried to copy the existing code style - might not be 100% though.