### PR TITLE
mavenLocal should always be first repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
 
 allprojects  {
   repositories {
-     mavenCentral()
      mavenLocal()
+     mavenCentral()
      maven { url "https://oss.sonatype.org/content/repositories/releases" }
      maven { url "http://repo.mikeprimm.com" }
      maven { url "http://repo.maven.apache.org/maven2" }


### PR DESCRIPTION
Using mavenCentral above mavenLocal means any library screenshots you may have installed locally are overridden. Having mavenLocal first ensures you trust the local cache above all else.