### PR TITLE
Added functionality for restarting the scheduled job that stores markers

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -140,7 +140,7 @@ public class DynmapCore implements DynmapCommonAPI {
     public boolean is_reload = false;
     public static boolean ignore_chunk_loads = false; /* Flag keep us from processing our own chunk loads */
 
-    public MarkerAPIImpl   markerapi;
+    private MarkerAPIImpl   markerapi;
     
     private File dataDirectory;
     private File tilesDirectory;
@@ -159,7 +159,9 @@ public class DynmapCore implements DynmapCommonAPI {
         server = null;
         markerapi = null;
     }
-    
+    public void restartMarkerSaveJob(){
+        this.markerapi.scheduleWriteJob();
+    }
     // Set plugin jar file
     public void setPluginJarFile(File f) {
         jarfile = f;

--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -140,7 +140,7 @@ public class DynmapCore implements DynmapCommonAPI {
     public boolean is_reload = false;
     public static boolean ignore_chunk_loads = false; /* Flag keep us from processing our own chunk loads */
 
-    private MarkerAPIImpl   markerapi;
+    public MarkerAPIImpl   markerapi;
     
     private File dataDirectory;
     private File tilesDirectory;

--- a/DynmapCore/src/main/java/org/dynmap/markers/impl/MarkerAPIImpl.java
+++ b/DynmapCore/src/main/java/org/dynmap/markers/impl/MarkerAPIImpl.java
@@ -407,7 +407,7 @@ public class MarkerAPIImpl implements MarkerAPI, Event.Listener<DynmapWorld> {
         return api;
     }
     
-    private void scheduleWriteJob() {
+    public void scheduleWriteJob() {
         core.getServer().scheduleServerTask(new DoFileWrites(), 20);
     }
     

--- a/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
@@ -790,6 +790,12 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
     
     @Override
     public void onEnable() {
+        if(core != null){
+            if(core.markerapi != null){
+                getLogger().info("Starting Scheduled Write Job (markerAPI).");
+                core.markerapi.scheduleWriteJob();
+            }
+        }
         if (helper == null) {
             Log.info("Dynmap is disabled (unsupported platform)");
             return;

--- a/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
@@ -791,9 +791,9 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
     @Override
     public void onEnable() {
         if(core != null){
-            if(core.markerapi != null){
+            if(core.getMarkerAPI() != null){
                 getLogger().info("Starting Scheduled Write Job (markerAPI).");
-                core.markerapi.scheduleWriteJob();
+                core.restartMarkerSaveJob();
             }
         }
         if (helper == null) {


### PR DESCRIPTION
This should fix problems with markers not being stored after a dynmap reload, as well as vanishing markers.
This only fixes the issue for the spigot version.