### PR TITLE
Fix for disappearing sign-markers on 1.14 (Issue #2533)

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/common/DynmapServerInterface.java
+++ b/DynmapCore/src/main/java/org/dynmap/common/DynmapServerInterface.java
@@ -178,6 +178,17 @@ public abstract class DynmapServerInterface {
      * @return block ID, or -1 if chunk at given coordinate isn't loaded
      */
     public abstract int getBlockIDAt(String wname, int x, int y, int z);
+	
+    /**
+     * Checks if a sign is at a given coordinate in a given world (if chunk is loaded)
+     * @param wname - world name
+     * @param x - X coordinate
+     * @param y - Y coordinate
+     * @param z - Z coordinate
+     * @return 1 if a sign is at the location, 0 if it's not, -1 if the chunk isn't loaded
+     */
+	public abstract int isSignAt(String wname, int x, int y, int z);
+	
     /**
      * Get current TPS for server (20.0 is nominal)
      * @return ticks per second

--- a/DynmapCore/src/main/java/org/dynmap/markers/impl/MarkerSignManager.java
+++ b/DynmapCore/src/main/java/org/dynmap/markers/impl/MarkerSignManager.java
@@ -20,9 +20,6 @@ public class MarkerSignManager {
     private static DynmapCore plugin = null;
     private static String defSignSet = null;
     
-    private static final int SIGNPOST_ID = 63;
-    private static final int WALLSIGN_ID = 68;
-        
     private static class SignRec {
         String wname;
         int x, y, z;
@@ -33,10 +30,12 @@ public class MarkerSignManager {
         @Override
         public void signChangeEvent(int blkid, String wname, int x, int y, int z, String[] lines, DynmapPlayer p) {
             if(mgr == null)
-                return;
+                return;			
+			
             if(!lines[0].equalsIgnoreCase("[dynmap]")) {  /* If not dynmap sign, quit */
                 return;
             }
+			
             /* If allowed to do marker signs */
             if((p == null) || ((plugin != null) && (plugin.checkPlayerPermission(p, "marker.sign")))) {
                 String id = getSignMarkerID(wname, x, y, z);  /* Get marker ID */
@@ -143,17 +142,15 @@ public class MarkerSignManager {
             for(Iterator<Entry<String, SignRec>> iter = sign_cache.entrySet().iterator(); iter.hasNext(); ) {
                 Entry<String, SignRec> ent = iter.next();
                 SignRec r = ent.getValue();
-                /* If deleted marker, remote */
+                /* If deleted marker, remove */
                 if(r.m.getMarkerSet() == null) {
                     iter.remove();
                 }
                 else {
-                    /* Get block ID */
-                    int blkid = plugin.getServer().getBlockIDAt(r.wname, r.x, r.y, r.z);
-                    if((blkid >= 0) && (blkid != WALLSIGN_ID) && (blkid != SIGNPOST_ID)) {
+                    if(plugin.getServer().isSignAt(r.wname, r.x, r.y, r.z) == 0) {						
                         r.m.deleteMarker();
                         iter.remove();
-                    }                    
+                    }
                 }
             }
             plugin.getServer().scheduleServerTask(sl, 60*20);

--- a/forge-1.10.2/src/main/java/org/dynmap/forge_1_10_2/DynmapPlugin.java
+++ b/forge-1.10.2/src/main/java/org/dynmap/forge_1_10_2/DynmapPlugin.java
@@ -145,6 +145,9 @@ public class DynmapPlugin
     private boolean isMCPC = false;
     private boolean useSaveFolder = true;
     private Field displayName = null; // MCPC+ display name
+	
+    private static final int SIGNPOST_ID = 63;
+    private static final int WALLSIGN_ID = 68;
 
     private static final String[] TRIGGER_DEFAULTS = { "blockupdate", "chunkpopulate", "chunkgenerate" };
 
@@ -509,6 +512,20 @@ public class DynmapPlugin
         	}
             return -1;
         }
+		
+		@Override
+		public int isSignAt(String wname, int x, int y, int z) {
+			int blkid = plugin.getServer().getBlockIDAt(r.wname, r.x, r.y, r.z);
+			
+			if (blkid == -1)
+				return -1;
+			
+            if((blkid == WALLSIGN_ID) || (blkid == SIGNPOST_ID)) {
+				return 1;
+            } else {
+            	return 0;
+            }
+		}
 
         @Override
         public void scheduleServerTask(Runnable run, long delay)

--- a/forge-1.11.2/src/main/java/org/dynmap/forge_1_11_2/DynmapPlugin.java
+++ b/forge-1.11.2/src/main/java/org/dynmap/forge_1_11_2/DynmapPlugin.java
@@ -146,6 +146,9 @@ public class DynmapPlugin
     private boolean useSaveFolder = true;
     private Field displayName = null; // MCPC+ display name
 
+    private static final int SIGNPOST_ID = 63;
+    private static final int WALLSIGN_ID = 68;
+
     private static final String[] TRIGGER_DEFAULTS = { "blockupdate", "chunkpopulate", "chunkgenerate" };
 
     private static final Pattern patternControlCode = Pattern.compile("(?i)\\u00A7[0-9A-FK-OR]");
@@ -517,6 +520,20 @@ public class DynmapPlugin
         	}
             return -1;
         }
+		
+		@Override
+		public int isSignAt(String wname, int x, int y, int z) {
+			int blkid = plugin.getServer().getBlockIDAt(r.wname, r.x, r.y, r.z);
+			
+			if (blkid == -1)
+				return -1;
+			
+            if((blkid == WALLSIGN_ID) || (blkid == SIGNPOST_ID)) {
+				return 1;
+            } else {
+            	return 0;
+            }
+		}
 
         @Override
         public void scheduleServerTask(Runnable run, long delay)

--- a/forge-1.12.2/src/main/java/org/dynmap/forge_1_12_2/DynmapPlugin.java
+++ b/forge-1.12.2/src/main/java/org/dynmap/forge_1_12_2/DynmapPlugin.java
@@ -145,6 +145,9 @@ public class DynmapPlugin
     private boolean isMCPC = false;
     private boolean useSaveFolder = true;
     private Field displayName = null; // MCPC+ display name
+	
+    private static final int SIGNPOST_ID = 63;
+    private static final int WALLSIGN_ID = 68;
 
     private static final String[] TRIGGER_DEFAULTS = { "blockupdate", "chunkpopulate", "chunkgenerate" };
 
@@ -522,6 +525,20 @@ public class DynmapPlugin
         	}
             return -1;
         }
+		
+		@Override
+		public int isSignAt(String wname, int x, int y, int z) {
+			int blkid = plugin.getServer().getBlockIDAt(r.wname, r.x, r.y, r.z);
+			
+			if (blkid == -1)
+				return -1;
+			
+            if((blkid == WALLSIGN_ID) || (blkid == SIGNPOST_ID)) {
+				return 1;
+            } else {
+            	return 0;
+            }
+		}
 
         @Override
         public void scheduleServerTask(Runnable run, long delay)

--- a/forge-1.13.2/src/main/java/org/dynmap/forge_1_13_2/DynmapPlugin.java
+++ b/forge-1.13.2/src/main/java/org/dynmap/forge_1_13_2/DynmapPlugin.java
@@ -156,6 +156,9 @@ public class DynmapPlugin
     private boolean isMCPC = false;
     private boolean useSaveFolder = true;
     private Field displayName = null; // MCPC+ display name
+	
+    private static final int SIGNPOST_ID = 63;
+    private static final int WALLSIGN_ID = 68;
 
     private static final String[] TRIGGER_DEFAULTS = { "blockupdate", "chunkpopulate", "chunkgenerate" };
 
@@ -513,6 +516,11 @@ public class DynmapPlugin
         public int getBlockIDAt(String wname, int x, int y, int z) {
             return -1;
         }
+		
+		@Override
+		public int isSignAt(String wname, int x, int y, int z) {
+			return -1;
+		}
 
         @Override
         public void scheduleServerTask(Runnable run, long delay)

--- a/forge-1.8.9/src/main/java/org/dynmap/forge_1_8_9/DynmapPlugin.java
+++ b/forge-1.8.9/src/main/java/org/dynmap/forge_1_8_9/DynmapPlugin.java
@@ -140,6 +140,9 @@ public class DynmapPlugin
     private boolean isMCPC = false;
     private boolean useSaveFolder = true;
     private Field displayName = null; // MCPC+ display name
+	
+    private static final int SIGNPOST_ID = 63;
+    private static final int WALLSIGN_ID = 68;
 
     private static final String[] TRIGGER_DEFAULTS = { "blockupdate", "chunkpopulate", "chunkgenerate" };
 
@@ -493,6 +496,20 @@ public class DynmapPlugin
         	}
             return -1;
         }
+		
+		@Override
+		public int isSignAt(String wname, int x, int y, int z) {
+			int blkid = plugin.getServer().getBlockIDAt(r.wname, r.x, r.y, r.z);
+			
+			if (blkid == -1)
+				return -1;
+			
+            if((blkid == WALLSIGN_ID) || (blkid == SIGNPOST_ID)) {
+				return 1;
+            } else {
+            	return 0;
+            }
+		}
 
         @Override
         public void scheduleServerTask(Runnable run, long delay)

--- a/forge-1.9.4/src/main/java/org/dynmap/forge_1_9_4/DynmapPlugin.java
+++ b/forge-1.9.4/src/main/java/org/dynmap/forge_1_9_4/DynmapPlugin.java
@@ -138,6 +138,9 @@ public class DynmapPlugin
     private boolean isMCPC = false;
     private boolean useSaveFolder = true;
     private Field displayName = null; // MCPC+ display name
+	
+    private static final int SIGNPOST_ID = 63;
+    private static final int WALLSIGN_ID = 68;
 
     private static final String[] TRIGGER_DEFAULTS = { "blockupdate", "chunkpopulate", "chunkgenerate" };
 
@@ -496,6 +499,20 @@ public class DynmapPlugin
         	}
             return -1;
         }
+		
+		@Override
+		public int isSignAt(String wname, int x, int y, int z) {
+			int blkid = plugin.getServer().getBlockIDAt(r.wname, r.x, r.y, r.z);
+			
+			if (blkid == -1)
+				return -1;
+			
+            if((blkid == WALLSIGN_ID) || (blkid == SIGNPOST_ID)) {
+				return 1;
+            } else {
+            	return 0;
+            }
+		}
 
         @Override
         public void scheduleServerTask(Runnable run, long delay)

--- a/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
@@ -28,6 +28,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
+import org.bukkit.block.Sign;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -212,6 +213,22 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
             }
             return -1;
         }
+		
+		@Override
+		public int isSignAt(String wname, int x, int y, int z) {
+			World w = getServer().getWorld(wname);
+            if((w != null) && w.isChunkLoaded(x >> 4, z >> 4)) {
+                Block b = w.getBlockAt(x, y, z);
+				BlockState s = b.getState();
+				
+				if (s instanceof Sign) {
+					return 1;
+				} else {
+					return 0;
+				}
+			}
+            return -1;
+		}
 
         @Override
         public void scheduleServerTask(Runnable run, long delay) {


### PR DESCRIPTION
I've tested this on Paper 1.14, and included (untested) forge code that mimics the old code. I've never messed with Forge so I didn't even manage to get it to build, some looking into that will be needed, as well as testing with CB 1.11 (although I think it should probably work).