### PR TITLE
Resume full renders (skip already rendered tiles)

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -1042,7 +1042,9 @@ public class DynmapCore implements DynmapCommonAPI {
         new CommandInfo("dynmap", "render", "Renders the tile at your location."),
         new CommandInfo("dynmap", "fullrender", "Render all maps for entire world from your location."),
         new CommandInfo("dynmap", "fullrender", "<world>", "Render all maps for world <world>."),
-        new CommandInfo("dynmap", "fullrender", "<world>:<map>", "Render map <map> of world'<world>."),
+        new CommandInfo("dynmap", "fullrender", "<world>:<map>", "Render map <map> of world <world>."),
+        new CommandInfo("dynmap", "fullrender", "resume <world>", "Resume render of all maps for world <world>. Skip already rendered tiles."),
+        new CommandInfo("dynmap", "fullrender", "resume <world>:<map>", "Resume render of map <map> of world <world>. Skip already rendered tiles."),
         new CommandInfo("dynmap", "radiusrender", "<radius>", "Render at least <radius> block radius from your location on all maps."),
         new CommandInfo("dynmap", "radiusrender", "<radius> <mapname>", "Render at least <radius> block radius from your location on map <mapname>."),
         new CommandInfo("dynmap", "radiusrender", "<world> <x> <z> <radius>", "Render at least <radius> block radius from location <x>,<z> on world <world>."),
@@ -1315,7 +1317,7 @@ public class DynmapCore implements DynmapCommonAPI {
                         loc = new DynmapLocation(w.getName(), x, 64, z);
                 }
                 if(loc != null)
-                    mapManager.renderFullWorld(loc, sender, mapname, true);
+                    mapManager.renderFullWorld(loc, sender, mapname, true, false);
             } else if (c.equals("hide")) {
                 if (args.length == 1) {
                     if(player != null && checkPlayerPermission(sender,"hide.self")) {
@@ -1343,7 +1345,12 @@ public class DynmapCore implements DynmapCommonAPI {
             } else if (c.equals("fullrender") && checkPlayerPermission(sender,"fullrender")) {
                 String map = null;
                 if (args.length > 1) {
+                    boolean resume = false;
                     for (int i = 1; i < args.length; i++) {
+                        if (args[i].equalsIgnoreCase("resume")) {
+                             resume = true;
+                             continue;
+                        }
                         int dot = args[i].indexOf(":");
                         DynmapWorld w;
                         String wname = args[i];
@@ -1358,7 +1365,7 @@ public class DynmapCore implements DynmapCommonAPI {
                                 loc = w.center;
                             else
                                 loc = w.getSpawnLocation();
-                            mapManager.renderFullWorld(loc,sender, map, false);
+                            mapManager.renderFullWorld(loc,sender, map, false, resume);
                         }
                         else
                             sender.sendMessage("World '" + wname + "' not defined/loaded");
@@ -1368,7 +1375,7 @@ public class DynmapCore implements DynmapCommonAPI {
                     if(args.length > 1)
                         map = args[1];
                     if(loc != null)
-                        mapManager.renderFullWorld(loc, sender, map, false);
+                        mapManager.renderFullWorld(loc, sender, map, false, false);
                 } else {
                     sender.sendMessage("World name is required");
                 }

--- a/DynmapCore/src/main/java/org/dynmap/storage/MapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/MapStorage.java
@@ -87,6 +87,15 @@ public abstract class MapStorage {
     public abstract void enumMapTiles(DynmapWorld world, MapType map, MapStorageTileEnumCB cb);
 
     /**
+     * Enumerate existing map tiles, matching given constraints, with zoom at 0
+     * @param world - specific world
+     * @param map - specific map (if non-null)
+     * @param cbBase - callback to receive matching tiles
+     * @param cbEnd - callback to receive end-of-search event
+     */
+    public abstract void enumMapBaseTiles(DynmapWorld world, MapType map, MapStorageBaseTileEnumCB cbBase, MapStorageTileSearchEndCB cbEnd);
+
+    /**
      * Purge existing map tiles, matching given constraints
      * @param world - specific world
      * @param map - specific map (if non-null)

--- a/DynmapCore/src/main/java/org/dynmap/storage/MapStorageBaseTileEnumCB.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/MapStorageBaseTileEnumCB.java
@@ -1,0 +1,12 @@
+package org.dynmap.storage;
+
+import org.dynmap.MapType.ImageEncoding;
+
+public interface MapStorageBaseTileEnumCB {
+    /**
+     * Callback for base (non-zoomed) tile enumeration calls
+     * @param tile - tile found
+     * @param enc - image encoding
+     */
+    public void tileFound(MapStorageTile tile, ImageEncoding enc);
+}

--- a/DynmapCore/src/main/java/org/dynmap/storage/MapStorageTileSearchEndCB.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/MapStorageTileSearchEndCB.java
@@ -1,0 +1,10 @@
+package org.dynmap.storage;
+
+import org.dynmap.MapType.ImageEncoding;
+
+public interface MapStorageTileSearchEndCB {
+    /**
+     * Callback for end of tile enumeration calls
+     */
+    public void searchEnded();
+}

--- a/DynmapCore/src/main/java/org/dynmap/storage/filetree/FileTreeMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/filetree/FileTreeMapStorage.java
@@ -22,6 +22,8 @@ import org.dynmap.debug.Debug;
 import org.dynmap.storage.MapStorage;
 import org.dynmap.storage.MapStorageTile;
 import org.dynmap.storage.MapStorageTileEnumCB;
+import org.dynmap.storage.MapStorageBaseTileEnumCB;
+import org.dynmap.storage.MapStorageTileSearchEndCB;
 import org.dynmap.utils.BufferInputStream;
 import org.dynmap.utils.BufferOutputStream;
 
@@ -295,9 +297,13 @@ public class FileTreeMapStorage extends MapStorage {
     }
 
 
-    private void processEnumMapTiles(DynmapWorld world, MapType map, File base, ImageVariant var, MapStorageTileEnumCB cb) {
+    private void processEnumMapTiles(DynmapWorld world, MapType map, File base, ImageVariant var, MapStorageTileEnumCB cb, MapStorageBaseTileEnumCB cbBase, MapStorageTileSearchEndCB cbEnd) {
         File bdir = new File(base, map.getPrefix() + var.variantSuffix);
-        if (bdir.isDirectory() == false) return;
+        if (bdir.isDirectory() == false) {
+            if(cbEnd != null)
+                cbEnd.searchEnded();
+            return;
+        }
 
         LinkedList<File> dirs = new LinkedList<File>(); // List to traverse
         dirs.add(bdir);   // Directory for map
@@ -343,13 +349,19 @@ public class FileTreeMapStorage extends MapStorage {
                             int y = Integer.parseInt(coord[1]);
                             // Invoke callback
                             MapStorageTile t = new StorageTile(world, map, x, y, zoom, var);
-                            cb.tileFound(t, fmt);
+                            if(cb != null)
+                                cb.tileFound(t, fmt);
+                            if(cbBase != null && t.zoom == 0)
+                                cbBase.tileFound(t, fmt);
                             t.cleanup();
                         } catch (NumberFormatException nfx) {
                         }
                     }
                 }
             }
+        }
+        if(cbEnd != null) {
+            cbEnd.searchEnded();
         }
     }
 
@@ -367,7 +379,26 @@ public class FileTreeMapStorage extends MapStorage {
         for (MapType mt : mtlist) {
             ImageVariant[] vars = mt.getVariants();
             for (ImageVariant var : vars) {
-                processEnumMapTiles(world, mt, base, var, cb);
+                processEnumMapTiles(world, mt, base, var, cb, null, null);
+            }
+        }
+    }
+
+    @Override
+    public void enumMapBaseTiles(DynmapWorld world, MapType map, MapStorageBaseTileEnumCB cbBase, MapStorageTileSearchEndCB cbEnd) {
+        File base = new File(baseTileDir, world.getName()); // Get base directory for world
+        List<MapType> mtlist;
+
+        if (map != null) {
+            mtlist = Collections.singletonList(map);
+        }
+        else {  // Else, add all directories under world directory (for maps)
+            mtlist = new ArrayList<MapType>(world.maps);
+        }
+        for (MapType mt : mtlist) {
+            ImageVariant[] vars = mt.getVariants();
+            for (ImageVariant var : vars) {
+                processEnumMapTiles(world, mt, base, var, null, cbBase, cbEnd);
             }
         }
     }

--- a/DynmapCore/src/main/java/org/dynmap/storage/mariadb/MariaDBMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/mariadb/MariaDBMapStorage.java
@@ -25,6 +25,8 @@ import org.dynmap.PlayerFaces.FaceType;
 import org.dynmap.storage.MapStorage;
 import org.dynmap.storage.MapStorageTile;
 import org.dynmap.storage.MapStorageTileEnumCB;
+import org.dynmap.storage.MapStorageBaseTileEnumCB;
+import org.dynmap.storage.MapStorageTileSearchEndCB;
 import org.dynmap.utils.BufferInputStream;
 import org.dynmap.utils.BufferOutputStream;
 
@@ -608,7 +610,7 @@ public class MariaDBMapStorage extends MapStorage {
 
     @Override
     public void enumMapTiles(DynmapWorld world, MapType map,
-            MapStorageTileEnumCB cb) {
+                             MapStorageTileEnumCB cb) {
         List<MapType> mtlist;
 
         if (map != null) {
@@ -620,15 +622,36 @@ public class MariaDBMapStorage extends MapStorage {
         for (MapType mt : mtlist) {
             ImageVariant[] vars = mt.getVariants();
             for (ImageVariant var : vars) {
-                processEnumMapTiles(world, mt, var, cb);
+                processEnumMapTiles(world, mt, var, cb, null, null);
             }
         }
     }
-    private void processEnumMapTiles(DynmapWorld world, MapType map, ImageVariant var, MapStorageTileEnumCB cb) {
+    @Override
+    public void enumMapBaseTiles(DynmapWorld world, MapType map, MapStorageBaseTileEnumCB cbBase, MapStorageTileSearchEndCB cbEnd) {
+        List<MapType> mtlist;
+
+        if (map != null) {
+            mtlist = Collections.singletonList(map);
+        }
+        else {  // Else, add all directories under world directory (for maps)
+            mtlist = new ArrayList<MapType>(world.maps);
+        }
+        for (MapType mt : mtlist) {
+            ImageVariant[] vars = mt.getVariants();
+            for (ImageVariant var : vars) {
+                processEnumMapTiles(world, mt, var, null, cbBase, cbEnd);
+            }
+        }
+    }
+    private void processEnumMapTiles(DynmapWorld world, MapType map, ImageVariant var, MapStorageTileEnumCB cb, MapStorageBaseTileEnumCB cbBase, MapStorageTileSearchEndCB cbEnd) {
         Connection c = null;
         boolean err = false;
         Integer mapkey = getMapKey(world, map, var);
-        if (mapkey == null) return;
+        if (mapkey == null) {
+            if(cbEnd != null)
+                cbEnd.searchEnded();
+            return;
+        }
         try {
             c = getConnection();
             // Query tiles for given mapkey
@@ -636,9 +659,15 @@ public class MariaDBMapStorage extends MapStorage {
             ResultSet rs = stmt.executeQuery("SELECT x,y,zoom,Format FROM " + tableTiles + " WHERE MapID=" + mapkey + ";");
             while (rs.next()) {
                 StorageTile st = new StorageTile(world, map, rs.getInt("x"), rs.getInt("y"), rs.getInt("zoom"), var);
-                cb.tileFound(st, MapType.ImageEncoding.fromOrd(rs.getInt("Format")));
+                final MapType.ImageEncoding encoding = MapType.ImageEncoding.fromOrd(rs.getInt("Format"));
+                if(cb != null)
+                    cb.tileFound(st, encoding);
+                if(cbBase != null && st.zoom == 0)
+                    cbBase.tileFound(st, encoding);
                 st.cleanup();
             }
+            if(cbEnd != null)
+                cbEnd.searchEnded();
             rs.close();
             stmt.close();
         } catch (SQLException x) {

--- a/DynmapCore/src/main/java/org/dynmap/storage/sqllte/SQLiteMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/sqllte/SQLiteMapStorage.java
@@ -23,6 +23,8 @@ import org.dynmap.PlayerFaces.FaceType;
 import org.dynmap.storage.MapStorage;
 import org.dynmap.storage.MapStorageTile;
 import org.dynmap.storage.MapStorageTileEnumCB;
+import org.dynmap.storage.MapStorageBaseTileEnumCB;
+import org.dynmap.storage.MapStorageTileSearchEndCB;
 import org.dynmap.utils.BufferInputStream;
 import org.dynmap.utils.BufferOutputStream;
 
@@ -541,7 +543,7 @@ public class SQLiteMapStorage extends MapStorage {
 
     @Override
     public void enumMapTiles(DynmapWorld world, MapType map,
-            MapStorageTileEnumCB cb) {
+                             MapStorageTileEnumCB cb) {
         List<MapType> mtlist;
 
         if (map != null) {
@@ -553,15 +555,38 @@ public class SQLiteMapStorage extends MapStorage {
         for (MapType mt : mtlist) {
             ImageVariant[] vars = mt.getVariants();
             for (ImageVariant var : vars) {
-                processEnumMapTiles(world, mt, var, cb);
+                processEnumMapTiles(world, mt, var, cb, null, null);
             }
         }
     }
-    private void processEnumMapTiles(DynmapWorld world, MapType map, ImageVariant var, MapStorageTileEnumCB cb) {
+
+    @Override
+    public void enumMapBaseTiles(DynmapWorld world, MapType map, MapStorageBaseTileEnumCB cbBase, MapStorageTileSearchEndCB cbEnd) {
+        List<MapType> mtlist;
+
+        if (map != null) {
+            mtlist = Collections.singletonList(map);
+        }
+        else {  // Else, add all directories under world directory (for maps)
+            mtlist = new ArrayList<MapType>(world.maps);
+        }
+        for (MapType mt : mtlist) {
+            ImageVariant[] vars = mt.getVariants();
+            for (ImageVariant var : vars) {
+                processEnumMapTiles(world, mt, var, null, cbBase, cbEnd);
+            }
+        }
+    }
+
+    private void processEnumMapTiles(DynmapWorld world, MapType map, ImageVariant var, MapStorageTileEnumCB cb, MapStorageBaseTileEnumCB cbBase, MapStorageTileSearchEndCB cbEnd) {
         Connection c = null;
         boolean err = false;
         Integer mapkey = getMapKey(world, map, var);
-        if (mapkey == null) return;
+        if (mapkey == null) {
+            if(cbEnd != null)
+                cbEnd.searchEnded();
+            return;
+        }
         try {
             c = getConnection();
             // Query tiles for given mapkey
@@ -570,9 +595,15 @@ public class SQLiteMapStorage extends MapStorage {
             ResultSet rs = doExecuteQuery(stmt, "SELECT x,y,zoom,Format FROM Tiles WHERE MapID=" + mapkey + ";");
             while (rs.next()) {
                 StorageTile st = new StorageTile(world, map, rs.getInt("x"), rs.getInt("y"), rs.getInt("zoom"), var);
-                cb.tileFound(st, MapType.ImageEncoding.fromOrd(rs.getInt("Format")));
+                final MapType.ImageEncoding encoding = MapType.ImageEncoding.fromOrd(rs.getInt("Format"));
+                if(cb != null)
+                    cb.tileFound(st, encoding);
+                if(cbBase != null && st.zoom == 0)
+                    cbBase.tileFound(st, encoding);
                 st.cleanup();
             }
+            if(cbEnd != null)
+                cbEnd.searchEnded();
             rs.close();
             stmt.close();
         } catch (SQLException x) {


### PR DESCRIPTION
Implemented functionality to resume full renders by typing "dynmap fullrender resume \<world\>" or "dynmap fullrender resume \<world\>:\<map\>". At the start of the render, existing map tiles are loaded from storage and their location info saved in a set. Before each tile is rendered, the set is checked if it contains the tile about to be rendered. If so, the tile is skipped. Information about skipped tiles is output in the periodic tile update message.