### PR TITLE
Fix typo for "LuckPerms" in plugin.yml softdepend

### DIFF
--- a/spigot/src/main/resources/plugin.yml
+++ b/spigot/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: org.dynmap.bukkit.DynmapPlugin
 version: "${version}-${buildnumber}"
 authors: [mikeprimm]
 website: "https://forums.dynmap.us"
-softdepend: [ Permissions, PermissionEx, bPermissions, PermissionsBukkit, GroupManager, LuckPerm ]
+softdepend: [ Permissions, PermissionEx, bPermissions, PermissionsBukkit, GroupManager, LuckPerms ]
 commands:
   dynmap:
     description: Controls Dynmap.


### PR DESCRIPTION
It's spelled "LuckPerms" like you can see [here](https://github.com/lucko/LuckPerms/blob/master/bukkit/src/main/resources/plugin.yml). The typo  was added in #2458.