### PR TITLE
Fix MariaDB Driver package name

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/storage/mariadb/MariaDBMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/mariadb/MariaDBMapStorage.java
@@ -289,7 +289,7 @@ public class MariaDBMapStorage extends MapStorage {
         connectionString = "jdbc:mariadb://" + hostname + ":" + port + "/" + database + "?allowReconnect=true";
         Log.info("Opening MariaDB database " + hostname + ":" + port + "/" + database + " as map store");
         try {
-            Class.forName("com.mariadb.jdbc.Driver");
+            Class.forName("org.mariadb.jdbc.Driver");
             // Initialize/update tables, if needed
             if(!initializeTables()) {
                 return false;


### PR DESCRIPTION
The package name for the MariaDB JDBC drivers available from https://mariadb.com/kb/en/library/mariadb-connector-j/ is `org.mariadb` not `com.mariadb`.

Fixes #2653