### PR TITLE
Fixed typo in config file comment

### DIFF
--- a/forge-1.10.2/src/main/resources/configuration.txt
+++ b/forge-1.10.2/src/main/resources/configuration.txt
@@ -140,7 +140,7 @@ components:
     messagettl: 5
     # Optional: set number of lines in scrollable message history: if set, messagettl is not used to age out messages
     #scrollback: 100
-    # Optiona; set maximum number of lines visible for chatbox
+    # Optional: set maximum number of lines visible for chatbox
     #visiblelines: 10
     # Optional: send push button
     sendbutton: false

--- a/forge-1.11.2/src/main/resources/configuration.txt
+++ b/forge-1.11.2/src/main/resources/configuration.txt
@@ -140,7 +140,7 @@ components:
     messagettl: 5
     # Optional: set number of lines in scrollable message history: if set, messagettl is not used to age out messages
     #scrollback: 100
-    # Optiona; set maximum number of lines visible for chatbox
+    # Optional: set maximum number of lines visible for chatbox
     #visiblelines: 10
     # Optional: send push button
     sendbutton: false

--- a/forge-1.12.2/src/main/resources/configuration.txt
+++ b/forge-1.12.2/src/main/resources/configuration.txt
@@ -140,7 +140,7 @@ components:
     messagettl: 5
     # Optional: set number of lines in scrollable message history: if set, messagettl is not used to age out messages
     #scrollback: 100
-    # Optiona; set maximum number of lines visible for chatbox
+    # Optional: set maximum number of lines visible for chatbox
     #visiblelines: 10
     # Optional: send push button
     sendbutton: false

--- a/forge-1.13.2/src/main/resources/configuration.txt
+++ b/forge-1.13.2/src/main/resources/configuration.txt
@@ -140,7 +140,7 @@ components:
     messagettl: 5
     # Optional: set number of lines in scrollable message history: if set, messagettl is not used to age out messages
     #scrollback: 100
-    # Optiona; set maximum number of lines visible for chatbox
+    # Optional: set maximum number of lines visible for chatbox
     #visiblelines: 10
     # Optional: send push button
     sendbutton: false

--- a/forge-1.8.9/src/main/resources/configuration.txt
+++ b/forge-1.8.9/src/main/resources/configuration.txt
@@ -140,7 +140,7 @@ components:
     messagettl: 5
     # Optional: set number of lines in scrollable message history: if set, messagettl is not used to age out messages
     #scrollback: 100
-    # Optiona; set maximum number of lines visible for chatbox
+    # Optional: set maximum number of lines visible for chatbox
     #visiblelines: 10
     # Optional: send push button
     sendbutton: false

--- a/forge-1.9.4/src/main/resources/configuration.txt
+++ b/forge-1.9.4/src/main/resources/configuration.txt
@@ -140,7 +140,7 @@ components:
     messagettl: 5
     # Optional: set number of lines in scrollable message history: if set, messagettl is not used to age out messages
     #scrollback: 100
-    # Optiona; set maximum number of lines visible for chatbox
+    # Optional: set maximum number of lines visible for chatbox
     #visiblelines: 10
     # Optional: send push button
     sendbutton: false

--- a/spigot/src/main/resources/configuration.txt
+++ b/spigot/src/main/resources/configuration.txt
@@ -141,7 +141,7 @@ components:
     messagettl: 5
     # Optional: set number of lines in scrollable message history: if set, messagettl is not used to age out messages
     #scrollback: 100
-    # Optiona; set maximum number of lines visible for chatbox
+    # Optional: set maximum number of lines visible for chatbox
     #visiblelines: 10
     # Optional: send push button
     sendbutton: false


### PR DESCRIPTION
I found a spelling error in my configuration file, and on further inspection discovered that the same typo was in fact recurring in several other places.

It is part of a comment serving as documentation, so impact is low, however clean language is always good to have.