### PR TITLE
Standalone: Load changes immediately after page load

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/js/map.js
+++ b/DynmapCore/src/main/resources/extracted/web/js/map.js
@@ -375,6 +375,7 @@ DynMap.prototype = {
 				componentstoload--;
 				if (componentstoload == 0) {
 					// Actually start updating once all components are loaded.
+					me.update();
 					setTimeout(function() { me.update(); }, me.options.updaterate);
 				}
 			});


### PR DESCRIPTION
This loads changes immediately after the page load without waiting for the updaterate.