### PR TITLE
Enable parallel Gradle builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx2G
+org.gradle.parallel=true


### PR DESCRIPTION
Tested with `gradle clean shadowJar`.

Enables parallel gradle builds so multiple Jars are shadowed at once.  This greatly reduces build time.

Without parallel builds:

```
time gradle clean shadowJar

real    0m37.091s
user    0m0.090s
sys     0m0.226s
```

With parallel builds:

```
time gradle clean shadowJar

real    0m18.434s
user    0m0.151s
sys     0m0.241s
```