### PR TITLE
Use Material instead of Block ID in SignChangeEvent and BlockEvent (Fixes #2699)

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -84,7 +84,7 @@ public class DynmapCore implements DynmapCommonAPI {
      */
     public static abstract class EnableCoreCallbacks {
         /**
-         * Called during enableCore to report that confniguration.txt is loaded
+         * Called during enableCore to report that configuration.txt is loaded
          */
         public abstract void configurationLoaded();
     }
@@ -2400,10 +2400,10 @@ public class DynmapCore implements DynmapCommonAPI {
     }
 
     @Override
-    public void processSignChange(int blkid, String world, int x, int y, int z,
+    public void processSignChange(String material, String world, int x, int y, int z,
             String[] lines, String playerid) {
         DynmapPlayer dp = server.getPlayer(playerid);
-        listenerManager.processSignChangeEvent(EventType.SIGN_CHANGE, blkid, world, x, y, z, lines, dp);
+        listenerManager.processSignChangeEvent(EventType.SIGN_CHANGE, material, world, x, y, z, lines, dp);
     }
     
     public MapStorage getDefaultMapStorage() {

--- a/DynmapCore/src/main/java/org/dynmap/common/DynmapListenerManager.java
+++ b/DynmapCore/src/main/java/org/dynmap/common/DynmapListenerManager.java
@@ -30,10 +30,10 @@ public class DynmapListenerManager {
         public void chatEvent(DynmapPlayer p, String msg);
     }
     public interface BlockEventListener extends EventListener {
-        public void blockEvent(int blkid, String w, int x, int y, int z);
+        public void blockEvent(String material, String w, int x, int y, int z);
     }
     public interface SignChangeEventListener extends EventListener {
-        public void signChangeEvent(int blkid, String w, int x, int y, int z, String[] lines, DynmapPlayer p);
+        public void signChangeEvent(String material, String w, int x, int y, int z, String[] lines, DynmapPlayer p);
     }
     public enum EventType {
         WORLD_LOAD,
@@ -105,7 +105,7 @@ public class DynmapListenerManager {
             }
         }
     }
-    public void processBlockEvent(EventType type, int blkid, String world, int x, int y, int z)
+    public void processBlockEvent(EventType type, String material, String world, int x, int y, int z)
     {
         ArrayList<EventListener> lst = listeners.get(type);
         if(lst == null) return;
@@ -114,14 +114,14 @@ public class DynmapListenerManager {
             EventListener el = lst.get(i);
             if(el instanceof BlockEventListener) {
                 try {
-                    ((BlockEventListener)el).blockEvent(blkid, world, x, y, z);
+                    ((BlockEventListener)el).blockEvent(material, world, x, y, z);
                 } catch (Throwable t) {
-                    Log.warning("processBlockEvent(" + type + "," + blkid + "," + world + "," + x + "," + y + "," + z + ") - exception", t);
+                    Log.warning("processBlockEvent(" + type + "," + material + "," + world + "," + x + "," + y + "," + z + ") - exception", t);
                 }
             }
         }
     }
-    public void processSignChangeEvent(EventType type, int blkid, String world, int x, int y, int z, String[] lines, DynmapPlayer p)
+    public void processSignChangeEvent(EventType type, String material, String world, int x, int y, int z, String[] lines, DynmapPlayer p)
     {
         ArrayList<EventListener> lst = listeners.get(type);
         if(lst == null) return;
@@ -130,9 +130,9 @@ public class DynmapListenerManager {
             EventListener el = lst.get(i);
             if(el instanceof SignChangeEventListener) {
                 try {
-                    ((SignChangeEventListener)el).signChangeEvent(blkid, world, x, y, z, lines, p);
+                    ((SignChangeEventListener)el).signChangeEvent(material, world, x, y, z, lines, p);
                 } catch (Throwable t) {
-                    Log.warning("processSignChangeEvent(" + type + "," + blkid + "," + world + "," + x + "," + y + "," + z + ") - exception", t);
+                    Log.warning("processSignChangeEvent(" + type + "," + material + "," + world + "," + x + "," + y + "," + z + ") - exception", t);
                 }
             }
         }

--- a/DynmapCore/src/main/java/org/dynmap/hdmap/TexturePack.java
+++ b/DynmapCore/src/main/java/org/dynmap/hdmap/TexturePack.java
@@ -2603,7 +2603,7 @@ public class TexturePack {
      * @param ps - perspective state
      * @param mapiter - map iterator
      * @param rslt - color result (returned with value)
-     * @param blkid - block ID
+     * @param blk - block state
      * @param lastblocktype - last block ID
      * @param ss - shader state
      */

--- a/DynmapCore/src/main/java/org/dynmap/markers/impl/MarkerSignManager.java
+++ b/DynmapCore/src/main/java/org/dynmap/markers/impl/MarkerSignManager.java
@@ -28,7 +28,7 @@ public class MarkerSignManager {
     
     private static class SignListener implements DynmapListenerManager.SignChangeEventListener, Runnable {
         @Override
-        public void signChangeEvent(int blkid, String wname, int x, int y, int z, String[] lines, DynmapPlayer p) {
+        public void signChangeEvent(String material, String wname, int x, int y, int z, String[] lines, DynmapPlayer p) {
             if(mgr == null)
                 return;			
 			

--- a/DynmapCoreAPI/src/main/java/org/dynmap/DynmapCommonAPI.java
+++ b/DynmapCoreAPI/src/main/java/org/dynmap/DynmapCommonAPI.java
@@ -135,7 +135,7 @@ public interface DynmapCommonAPI {
     public boolean testIfPlayerInfoProtected();
     /**
      * Process sign change
-     * @param blkid - block ID
+     * @param material - block's Material enum value as a string
      * @param world - world name
      * @param x - x coord
      * @param y - y coord
@@ -143,5 +143,5 @@ public interface DynmapCommonAPI {
      * @param lines - sign lines (input and output)
      * @param playerid - player ID
      */
-    public void processSignChange(int blkid, String world, int x, int y, int z, String[] lines, String playerid);
+    public void processSignChange(String material, String world, int x, int y, int z, String[] lines, String playerid);
 }

--- a/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
@@ -100,6 +100,7 @@ import org.dynmap.common.DynmapListenerManager.EventType;
 import org.dynmap.hdmap.HDMap;
 import org.dynmap.markers.MarkerAPI;
 import org.dynmap.modsupport.ModSupportImpl;
+import org.dynmap.renderer.DynmapBlockState;
 import org.dynmap.utils.MapChunkCache;
 import org.dynmap.utils.Polygon;
 import org.dynmap.utils.VisibilityLimit;
@@ -351,7 +352,7 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
                             Block b = evt.getBlock();
                             if(b == null) return;   /* Work around for stupid mods.... */
                             Location l = b.getLocation();
-                            core.listenerManager.processBlockEvent(EventType.BLOCK_BREAK, b.getType().getId(),
+                            core.listenerManager.processBlockEvent(EventType.BLOCK_BREAK, b.getType().name(),
                                 getWorld(l.getWorld()).getName(), l.getBlockX(), l.getBlockY(), l.getBlockZ());
                         }
                     }, DynmapPlugin.this);
@@ -366,7 +367,7 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
                             DynmapPlayer dp = null;
                             Player p = evt.getPlayer();
                             if(p != null) dp = new BukkitPlayer(p);
-                            core.listenerManager.processSignChangeEvent(EventType.SIGN_CHANGE, b.getType().getId(),
+                            core.listenerManager.processSignChangeEvent(EventType.SIGN_CHANGE, b.getType().name(),
                                 getWorld(l.getWorld()).getName(), l.getBlockX(), l.getBlockY(), l.getBlockZ(), lines, dp);
                         }
                     }, DynmapPlugin.this);
@@ -1631,9 +1632,9 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
         }));
     }
     @Override
-    public void processSignChange(int blkid, String world, int x, int y, int z,
+    public void processSignChange(String material, String world, int x, int y, int z,
             String[] lines, String playerid) {
-        core.processSignChange(blkid, world, x, y, z, lines, playerid);
+        core.processSignChange(material, world, x, y, z, lines, playerid);
     }
     
     Polygon getWorldBorder(World w) {


### PR DESCRIPTION
`getId` of `block.getType().getId()` was deprecated in 1.13 and lately causes crashes on newer materials that do not have block IDs. In many cases this included new signs, like dark oak and others. The result of this was the error: (See #2699)

```
[00:51:20] [Server thread/ERROR]: Could not pass event SignChangeEvent to dynmap v3.0-beta-8-244
java.lang.IllegalArgumentException: Cannot get ID of Modern Material
	at org.apache.commons.lang.Validate.isTrue(Validate.java:136) ~[patched_1.15.1.jar:git-Paper-23]
	at org.bukkit.Material.getId(Material.java:3333) ~[patched_1.15.1.jar:git-Paper-23]
	at org.dynmap.bukkit.DynmapPlugin$BukkitServer$5.onSignChange(DynmapPlugin.java:369) ~[?:?]
	at com.destroystokyo.paper.event.executor.MethodHandleEventExecutor.execute(MethodHandleEventExecutor.java:37) ~[patched_1.15.1.jar:git-Paper-23]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[patched_1.15.1.jar:git-Paper-23]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[patched_1.15.1.jar:git-Paper-23]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:545) ~[patched_1.15.1.jar:git-Paper-23]
	at net.minecraft.server.v1_15_R1.PlayerConnection.a(PlayerConnection.java:2581) ~[patched_1.15.1.jar:git-Paper-23]
	at net.minecraft.server.v1_15_R1.PacketPlayInUpdateSign.a(SourceFile:44) ~[patched_1.15.1.jar:git-Paper-23]
	at net.minecraft.server.v1_15_R1.PacketPlayInUpdateSign.a(SourceFile:10) ~[patched_1.15.1.jar:git-Paper-23]
	at net.minecraft.server.v1_15_R1.PlayerConnectionUtils.lambda$ensureMainThread$0(PlayerConnectionUtils.java:23) ~[patched_1.15.1.jar:git-Paper-23]
	at net.minecraft.server.v1_15_R1.TickTask.run(SourceFile:18) ~[patched_1.15.1.jar:git-Paper-23]
	at net.minecraft.server.v1_15_R1.IAsyncTaskHandler.executeTask(IAsyncTaskHandler.java:136) ~[patched_1.15.1.jar:git-Paper-23]
	at net.minecraft.server.v1_15_R1.IAsyncTaskHandlerReentrant.executeTask(SourceFile:23) ~[patched_1.15.1.jar:git-Paper-23]
	at net.minecraft.server.v1_15_R1.IAsyncTaskHandler.executeNext(IAsyncTaskHandler.java:109) ~[patched_1.15.1.jar:git-Paper-23]
	at net.minecraft.server.v1_15_R1.MinecraftServer.aZ(MinecraftServer.java:1037) ~[patched_1.15.1.jar:git-Paper-23]
	at net.minecraft.server.v1_15_R1.MinecraftServer.executeNext(MinecraftServer.java:1030) ~[patched_1.15.1.jar:git-Paper-23]
	at net.minecraft.server.v1_15_R1.IAsyncTaskHandler.executeAll(IAsyncTaskHandler.java:95) ~[patched_1.15.1.jar:git-Paper-23]
	at net.minecraft.server.v1_15_R1.MinecraftServer.a(MinecraftServer.java:1166) ~[patched_1.15.1.jar:git-Paper-23]
	at net.minecraft.server.v1_15_R1.MinecraftServer.run(MinecraftServer.java:933) ~[patched_1.15.1.jar:git-Paper-23]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_232]
```

I resolved this on my server by changing `int blkid` throughout the API to `String material`, since Materials are now the "source of truth" rather than block IDs.

I realize that other plugins may depend on these API changes, but assuming they are using `blkid` currently, then their plugin is already broken and I believe that leaves them with no choice but to update anyway.

Curious to hear your thoughts.