### PR TITLE
Add Vault compatibility and fix PEX v2 usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,9 @@ plugins {
 allprojects  {
   repositories {
      mavenLocal()
-     mavenCentral()
      maven { url "https://oss.sonatype.org/content/repositories/releases" }
      maven { url "http://repo.mikeprimm.com" }
-     maven { url "http://repo.maven.apache.org/maven2" }
+     maven { url "https://repo.maven.apache.org/maven2" }
      maven { url "https://hub.spigotmc.org/nexus/content/repositories/snapshots/" }
      maven { url "https://repo.codemc.org/repository/maven-public/" }
   }

--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -1,11 +1,18 @@
 
 description = 'dynmap'
 
+repositories {
+    maven {
+        url 'https://jitpack.io'
+    }
+}
+
 dependencies {
   compile group: 'org.bukkit', name: 'bukkit', version:'1.7.10-R0.1-SNAPSHOT'
     compile 'com.nijikokun.bukkit:Permissions:3.1.6'
     compile 'me.lucko.luckperms:luckperms-api:4.3'
     compile 'net.luckperms:api:5.0'
+    compile('com.github.MilkBowl:VaultAPI:1.7') { transitive = false }
     compile project(":dynmap-api")
     compile project(path: ":DynmapCore", configuration: "shadow")
     compile group: 'ru.tehkode', name: 'PermissionsEx', version:'1.19.1'

--- a/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
@@ -89,6 +89,7 @@ import org.dynmap.bukkit.permissions.PEXPermissions;
 import org.dynmap.bukkit.permissions.PermBukkitPermissions;
 import org.dynmap.bukkit.permissions.GroupManagerPermissions;
 import org.dynmap.bukkit.permissions.PermissionProvider;
+import org.dynmap.bukkit.permissions.VaultPermissions;
 import org.dynmap.bukkit.permissions.bPermPermissions;
 import org.dynmap.bukkit.permissions.LuckPermsPermissions;
 import org.dynmap.bukkit.permissions.LuckPerms5Permissions;
@@ -854,6 +855,7 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
             perdefs.put(p.getName(), p.getDefault() == PermissionDefault.TRUE);
         }
         
+
         permissions = PEXPermissions.create(getServer(), "dynmap");
         if (permissions == null)
             permissions = bPermPermissions.create(getServer(), "dynmap", perdefs);
@@ -867,6 +869,8 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
             permissions = LuckPermsPermissions.create(getServer(), "dynmap");
         if (permissions == null)
             permissions = LuckPerms5Permissions.create(getServer(), "dynmap");
+        if (permissions == null)
+            permissions = VaultPermissions.create(this, "dynmap");
         if (permissions == null)
             permissions = BukkitPermissions.create("dynmap", perdefs);
         if (permissions == null)

--- a/spigot/src/main/java/org/dynmap/bukkit/permissions/PEXPermissions.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/permissions/PEXPermissions.java
@@ -21,9 +21,17 @@ public class PEXPermissions implements PermissionProvider {
         Plugin permissionsPlugin = server.getPluginManager().getPlugin("PermissionsEx");
         if (permissionsPlugin == null)
             return null;
+
+        try {
+            Class.forName("ru.tehkode.permissions.bukkit.PermissionsEx");
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+
         server.getPluginManager().enablePlugin(permissionsPlugin);
         if(permissionsPlugin.isEnabled() == false)
             return null;
+
         //Broken in new dev builds, apparently
         //if(PermissionsEx.isAvailable() == false)
         //    return null;

--- a/spigot/src/main/java/org/dynmap/bukkit/permissions/VaultPermissions.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/permissions/VaultPermissions.java
@@ -1,0 +1,90 @@
+package org.dynmap.bukkit.permissions;
+
+import net.milkbowl.vault.permission.Permission;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.server.ServiceRegisterEvent;
+import org.bukkit.plugin.RegisteredServiceProvider;
+import org.dynmap.Log;
+import org.dynmap.bukkit.DynmapPlugin;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class VaultPermissions implements PermissionProvider, Listener {
+    private RegisteredServiceProvider<Permission> permissionProvider;
+    private final String prefix;
+
+    public static VaultPermissions create(DynmapPlugin plugin, String name) {
+        try {
+            Class.forName("net.milkbowl.vault.permission.Permission");
+        } catch (ClassNotFoundException cnfx) {
+            return null;
+        }
+
+        RegisteredServiceProvider<Permission> provider = plugin.getServer().getServicesManager().getRegistration(Permission.class);
+        if (provider == null || provider.getProvider() == null)
+            return null;
+
+        Log.info("Using Vault provider " + provider.getProvider().getName() + " for access control");
+        VaultPermissions ret = new VaultPermissions(name, provider);
+        plugin.getServer().getPluginManager().registerEvents(ret, plugin);
+        return ret;
+    }
+
+    private VaultPermissions(String prefix, RegisteredServiceProvider<Permission> initialProvider) {
+        this.prefix = prefix;
+        this.permissionProvider = initialProvider;
+    }
+
+    /**
+     * Update the used permission provider if a new one becomes available
+     *
+     * @param event The event with new service registration details
+     */
+    @SuppressWarnings("unchecked")
+    @EventHandler
+    public void onServiceRegister(ServiceRegisterEvent event) {
+        if (event.getProvider().getService().equals(Permission.class)) {
+            RegisteredServiceProvider<Permission> newProvider = (RegisteredServiceProvider<Permission>) event.getProvider().getProvider();
+            if (newProvider != this.permissionProvider && newProvider.getPriority().compareTo(this.permissionProvider.getPriority()) >= 0) {
+                this.permissionProvider = newProvider;
+                Log.info("Using Vault provider " + this.permissionProvider.getProvider().getName() + " for access control");
+            }
+        }
+    }
+
+    @Override
+    public boolean has(CommandSender sender, String permission) {
+        return permissionProvider.getProvider().has(sender, processPermission(permission));
+    }
+
+    @Override
+    public Set<String> hasOfflinePermissions(String playerName, Set<String> perms) {
+        final Permission vault = this.permissionProvider.getProvider();
+        OfflinePlayer player = Bukkit.getOfflinePlayer(playerName);
+
+        Set<String> hasperms = new HashSet<>();
+
+        for (String perm : perms) {
+            if (vault.playerHas(null, player, processPermission(perm))) {
+                hasperms.add(perm);
+            }
+        }
+
+        return hasperms;
+    }
+
+    @Override
+    public boolean hasOfflinePermission(String playerName, String perm) {
+        OfflinePlayer player = Bukkit.getOfflinePlayer(playerName);
+        return permissionProvider.getProvider().playerHas(null, player, processPermission(perm));
+    }
+
+    private String processPermission(String perm) {
+        return prefix + "." + perm;
+    }
+}

--- a/spigot/src/main/resources/plugin.yml
+++ b/spigot/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: org.dynmap.bukkit.DynmapPlugin
 version: "${version}-${buildnumber}"
 authors: [mikeprimm]
 website: "https://forums.dynmap.us"
-softdepend: [ Permissions, PermissionEx, bPermissions, PermissionsBukkit, GroupManager, LuckPerms ]
+softdepend: [ Permissions, PermissionEx, bPermissions, PermissionsBukkit, GroupManager, LuckPerms, Vault ]
 commands:
   dynmap:
     description: Controls Dynmap.


### PR DESCRIPTION
This would resolve #2730 without having to depend on PEX's internal API by:

a) Making sure that Dynmap's PEX v1 permission resolver only tries to register itself when PEX 1 is running on the server
b) Adding a Vault resolver to support PEX 2, as well as any other permissions plugin that may be created

I've also tossed in a change to how maven central is referenced, since that no longer supports plain http access -- that was mostly just needed so I could make dynmap build.