### PR TITLE
Adding standalone files for postgres

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/storage/postgresql/PostgreSQLMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/postgresql/PostgreSQLMapStorage.java
@@ -456,7 +456,7 @@ public class PostgreSQLMapStorage extends MapStorage {
                 doUpdate(c, "CREATE TABLE " + tableFaces + " (PlayerName VARCHAR(64) NOT NULL, TypeID INT NOT NULL, Image BYTEA, PRIMARY KEY(PlayerName, TypeID))");
                 doUpdate(c, "CREATE TABLE " + tableMarkerIcons + " (IconName VARCHAR(128) PRIMARY KEY NOT NULL, Image BYTEA)");
                 doUpdate(c, "CREATE TABLE " + tableMarkerFiles + " (FileName VARCHAR(128) PRIMARY KEY NOT NULL, Content BYTEA)");
-                doUpdate(c, "CREATE TABLE " + tableStandaloneFiles + " (FileName VARCHAR(128) NOT NULL, ServerID BIGINT NOT NULL DEFAULT 0, Content TEXT, PRIMARY KEY (FileName, ServerID))");
+                doUpdate(c, "CREATE TABLE " + tableStandaloneFiles + " (FileName VARCHAR(128) NOT NULL, ServerID BIGINT NOT NULL DEFAULT 0, Content BYTEA, PRIMARY KEY (FileName, ServerID))");
                 doUpdate(c, "CREATE TABLE " + tableSchemaVersion + " (level INT PRIMARY KEY NOT NULL)");
                 doUpdate(c, "INSERT INTO " + tableSchemaVersion + " (level) VALUES (3)");
             } catch (SQLException x) {
@@ -488,7 +488,7 @@ public class PostgreSQLMapStorage extends MapStorage {
                 c = getConnection();
                 doUpdate(c, "DELETE FROM " + tableStandaloneFiles + ";");
                 doUpdate(c, "ALTER TABLE " + tableStandaloneFiles + " DROP COLUMN Content;");
-                doUpdate(c, "ALTER TABLE " + tableStandaloneFiles + " ADD COLUMN Content TEXT;");
+                doUpdate(c, "ALTER TABLE " + tableStandaloneFiles + " ADD COLUMN Content BYTEA;");
                 doUpdate(c, "UPDATE " + tableSchemaVersion + " SET level=3 WHERE level = 2;");
             } catch (SQLException x) {
                 Log.severe("Error creating tables - " + x.getMessage());

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_access.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_access.php
@@ -1,0 +1,9 @@
+<?php
+require_once('PostgreSQL_funcs.php');
+
+if ($loginenabled) {
+    $rslt = getStandaloneFile('dynmap_access.php');
+	var_dump($rslt);
+	eval($rslt);
+}
+?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_configuration.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_configuration.php
@@ -1,0 +1,78 @@
+<?php
+ob_start();
+require_once('PostgreSQL_funcs.php');
+include('PostgreSQL_config.php');
+include('PostgreSQL_access.php');
+ob_end_clean();
+
+session_start();
+
+if(isset($_SESSION['userid'])) {
+  $userid = $_SESSION['userid'];
+}
+else {
+  $userid = '-guest-';
+}
+
+$loggedin = false;
+if(strcmp($userid, '-guest-')) {
+  $loggedin = true;
+}
+
+$content = getStandaloneFile('dynmap_config.json');
+
+header('Content-type: application/json; charset=utf-8');
+
+$json = json_decode($content);
+
+if (!$loginenabled) {
+	echo $content;
+}
+else if($json->loginrequired && !$loggedin) {
+    echo "{ \"error\": \"login-required\" }";
+}
+else {
+	$uid = '[' . strtolower($userid) . ']';
+	$json->loggedin = $loggedin;
+	$wcnt = count($json->worlds);
+	$newworlds = array();
+	for($i = 0; $i < $wcnt; $i++) {
+		$w = $json->worlds[$i];
+		if($w->protected) {
+		    $ss = stristr($worldaccess[$w->name], $uid);
+			if($ss !== false) {
+				$newworlds[] = $w;
+			}
+			else {
+				$w = null;
+			}
+		}
+		else {
+			$newworlds[] = $w;
+		}
+		if($w != null) {
+			$mcnt = count($w->maps);
+			$newmaps = array();
+			for($j = 0; $j < $mcnt; $j++) {
+				$m = $w->maps[$j];
+				if($m->protected) {
+				    $ss = stristr($mapaccess[$w->name . '.' . $m->prefix], $uid);
+					if($ss !== false) {
+						$newmaps[] = $m;
+					}
+				}
+				else {
+					$newmaps[] = $m;
+				}
+			}
+			$w->maps = $newmaps;		
+		}
+	}
+	$json->worlds = $newworlds;
+	
+	echo json_encode($json);
+}
+cleanupDb();
+ 
+?>
+

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_funcs.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_funcs.php
@@ -1,0 +1,116 @@
+<?php
+
+function cleanupDb() {
+   if (isset($db)) {
+      $db->close();
+      $db = NULL;
+   }
+}
+
+function abortDb($errormsg) {
+   header('HTTP/1.0 500 Error');
+   echo "<h1>500 Error</h1>";
+   echo $errormsg;
+   cleanupDb();
+   exit;
+}
+
+function initDbIfNeeded() {
+   global $db, $dbhost, $dbuserid, $dbpassword, $dbname, $dbport;
+   
+   $pos = strpos($dbname, '?');
+
+   if ($pos) {
+      $dbname = substr($dbname, 0, $pos);
+   }
+   
+   if (!$db) {
+      $db = new PDO("pgsql:host=$dbhost;port=$dbport;dbname=$dbname", $dbuserid , $dbpassword, array(PDO::ATTR_PERSISTENT => true));
+      $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+      if (!$db) {
+         abortDb("Error opening database");
+	  }
+   }
+}
+
+
+function getStandaloneFileByServerId($fname, $sid) {
+   global $db, $dbprefix;
+   
+   initDbIfNeeded();
+   $stmt = $db->prepare('SELECT Content from ' . $dbprefix . 'StandaloneFiles WHERE FileName=:fname AND ServerID=:sid');
+   $stmt->bindParam(':fname', $fname, PDO::PARAM_STR);
+   $stmt->bindParam(':sid', $sid, PDO::PARAM_INT);
+   $res = $stmt->execute();
+   $content = $stmt->fetch(PDO::FETCH_BOTH);
+   if ($res && $content) {
+        $rslt = stream_get_contents($content[0]); //stupid streams...
+   }
+   else {
+        $rslt = NULL;
+   }
+   $stmt->closeCursor();
+   return $rslt;
+}
+
+function getStandaloneFile($fname) {
+   global $serverid;
+   
+   if (!isset($serverid)) {
+      $serverid = 0;
+      if(isset($_REQUEST['serverid'])) {
+         $serverid = $_REQUEST['serverid'];
+      }
+   }
+   return getStandaloneFileByServerId($fname, $serverid);
+}
+
+function updateStandaloneFileByServerId($fname, $sid, $content) {
+   global $db, $dbprefix;
+   
+   initDbIfNeeded();
+   $stmt = $db->prepare('UPDATE ' . $dbprefix . 'StandaloneFiles SET Content=? WHERE FileName=? AND ServerID=?');
+   $stmt->bind_param('ssi', $content, $fname, $sid);
+   $res = $stmt->execute();
+   $stmt->close();
+   if (!$res) {
+      $res = insertStandaloneFileByServerId($fname, $sid, $content);
+   }
+   return $res;
+}
+
+function updateStandaloneFile($fname, $content) {
+   global $serverid;
+   
+   if (!isset($serverid)) {
+      $serverid = 0;
+      if(isset($_REQUEST['serverid'])) {
+         $serverid = $_REQUEST['serverid'];
+      }
+   }
+   return updateStandaloneFileByServerId($fname, $serverid, $content);
+}
+
+function insertStandaloneFileByServerId($fname, $sid, $content) {
+   global $db, $dbprefix;
+   
+   initDbIfNeeded();
+   $stmt = $db->prepare('INSERT INTO ' . $dbprefix . 'StandaloneFiles (Content,FileName,ServerID) VALUES (?,?,?);');
+   $res = $stmt->execute(array($content, $fname, $sid));
+   $stmt->close();
+   return $res;
+}
+
+function insertStandaloneFile($fname, $content) {
+   global $serverid;
+   
+   if (!isset($serverid)) {
+      $serverid = 0;
+      if(isset($_REQUEST['serverid'])) {
+         $serverid = $_REQUEST['serverid'];
+      }
+   }
+   return insertStandaloneFileByServerId($fname, $serverid, $content);
+}
+
+?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_getlogin.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_getlogin.php
@@ -1,0 +1,8 @@
+<?php
+require_once('PostgreSQL_funcs.php');
+
+if ($loginenabled) {
+    $rslt = getStandaloneFile("dynmap_login.php");
+	eval($rslt);
+}
+?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_login.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_login.php
@@ -1,0 +1,75 @@
+<?php
+ob_start();
+require_once('PostgreSQL_funcs.php');
+include('PostgreSQL_config.php');
+include('PostgreSQL_getlogin.php');
+ob_end_clean();
+
+session_start();
+
+if(isset($_POST['j_username'])) {
+  $userid = $_POST['j_username'];
+}
+else {
+  $userid = '-guest-';
+}
+$good = false;
+
+if(strcmp($userid, '-guest-')) {
+  if(isset($_POST['j_password'])) {
+    $password = $_POST['j_password'];
+  }
+  else {
+    $password = '';
+  }
+  $ctx = hash_init('sha256');
+  hash_update($ctx, $pwdsalt);
+  hash_update($ctx, $password);
+  $hash = hash_final($ctx);
+  $useridlc = strtolower($userid);
+  if (strcasecmp($hash, $pwdhash[$useridlc]) == 0) {
+     $_SESSION['userid'] = $userid;
+     $good = true; 
+  }
+  else {
+     $_SESSION['userid'] = '-guest-';
+  }
+}
+else {
+  $_SESSION['userid'] = '-guest-';
+  $good = true;
+}
+$content = getStandaloneFile('dynmap_reg.php');
+
+/* Prune pending registrations, if needed */
+$lines = explode('\n', $content);
+$newlines[] = array();
+if(!empty($lines)) {
+	$cnt = count($lines) - 1;
+	$changed = false;
+	for($i=1; $i < $cnt; $i++) {
+		list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
+		if($uid == $useridlc) continue;
+		if(array_key_exists($uid, $pendingreg)) {
+			$newlines[] = $uid . '=' . $pc . '=' . $hsh;
+		}
+		else {
+			$changed = true;
+		}
+	}
+	if($changed) {
+        updateStandaloneFile('dynmap_reg.php', implode("\n", $newlines));
+	}
+}
+
+if($good) {
+   echo "{ \"result\": \"success\" }"; 
+}
+else {
+   echo "{ \"result\": \"loginfailed\" }"; 
+}
+
+cleanupDb();
+ 
+?>
+

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_markers.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_markers.php
@@ -1,0 +1,110 @@
+<?php
+ob_start();
+require_once('PostgreSQL_funcs.php');
+include('PostgreSQL_config.php');
+include('PostgreSQL_access.php');
+ob_end_clean();
+
+session_start();
+
+if(isset($_SESSION['userid'])) {
+  $userid = $_SESSION['userid'];
+}
+else {
+  $userid = '-guest-';
+}
+
+$loggedin = false;
+if(strcmp($userid, '-guest-')) {
+  $loggedin = true;
+}
+
+$path = $_REQUEST['marker'];
+if ((!isset($path)) || strstr($path, "..")) {
+    header('HTTP/1.0 500 Error');
+    echo "<h1>500 Error</h1>";
+    echo "Bad marker: " . $path;
+    exit();
+}
+
+$parts = explode("/", $path);
+
+if(($parts[0] != "faces") && ($parts[0] != "_markers_")) {
+    header('HTTP/1.0 500 Error');
+    echo "<h1>500 Error</h1>";
+    echo "Bad marker: " . $path;
+    exit();
+}
+
+initDbIfNeeded();
+
+if ($parts[0] == "faces") {
+	if (count($parts) != 3) {
+	    header('HTTP/1.0 500 Error');
+    	echo "<h1>500 Error</h1>";
+    	echo "Bad face: " . $path;
+    	cleanupDb();
+    	exit();
+	}
+	$ft = 0;
+	if ($parts[1] == "8x8") {
+		$ft = 0;
+	}
+	else if ($parts[1] == '16x16') {
+	    $ft = 1;
+   	}
+   	else if ($parts[1] == '32x32') {
+   	    $ft = 2;
+	}
+	else if ($parts[1] == 'body') {
+		$ft = 3;
+	}
+	$pn = explode(".", $parts[2]);
+	$stmt = $db->prepare('SELECT Image from ' . $dbprefix . 'Faces WHERE PlayerName=? AND TypeID=?');
+	$res = $stmt->execute(array($pn[0], $ft));
+	$timage = $stmt->fetch();
+	if ($res && $timage) {
+          header('Content-Type: image/png');
+	  echo stream_get_contents($timage[0]);
+	}
+	else {
+		header('Location: ../images/blank.png');
+	}
+}
+else { // _markers_
+	$in = explode(".", $parts[1]);
+	$name = implode(".", array_slice($in, 0, count($in) - 1));
+	$ext = $in[count($in) - 1];
+	if (($ext == "json") && (strpos($name, "marker_") == 0)) {
+		$world = substr($name, 7);
+		$stmt = $db->prepare('SELECT Content from ' . $dbprefix . 'MarkerFiles WHERE FileName=?');
+		$res = $stmt->execute(array($world));
+		$timage = $stmt->fetch();
+  		header('Content-Type: application/json');
+		if ($res && $timage) {
+			echo stream_get_contents($timage[0]); //PDO returns arrays, even for single colums, and bytea is returned as stream.
+		}
+		else {
+			echo "{ }";
+		}
+	}
+	else {
+		$stmt = $db->prepare('SELECT Image from ' . $dbprefix . 'MarkerIcons WHERE IconName=?');
+		$res = $stmt->execute(array($name));
+        $timage = $stmt->fetch();
+		if ($res && $timage) {
+      		header('Content-Type: image/png');
+			echo stream_get_contents($timage[0]);
+		}
+		else {
+			header('Location: ../images/blank.png');
+		}
+	}
+}
+
+$stmt->closeCursor();
+
+cleanupDb();
+
+exit;
+?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_sendmessage.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_sendmessage.php
@@ -1,0 +1,75 @@
+<?php
+ob_start();
+require_once('PostgreSQL_funcs.php');
+include('PostgreSQL_config.php');
+ob_end_clean();
+
+session_start();
+
+$content = getStandaloneFile('dynmap_config.json');
+if (isset($content)) {
+   $config = json_decode($content, true);
+   $msginterval = $config['webchat-interval'];
+}
+else {
+   $msginterval = 2000;
+}
+
+if(isset($_SESSION['lastchat']))
+    $lastchat = $_SESSION['lastchat'];
+else
+    $lastchat = 0;
+
+if($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat < time())
+{
+	$micro = microtime(true);
+	$timestamp = round($micro*1000.0);
+	
+	$data = json_decode(trim(file_get_contents('php://input')));
+	$data->timestamp = $timestamp;
+	$data->ip = $_SERVER['REMOTE_ADDR'];
+	if(isset($_SESSION['userid'])) {
+		$uid = $_SESSION['userid'];
+		if(strcmp($uid, '-guest-')) {
+		   $data->userid = $uid;
+		}
+	}
+	if(isset($_SERVER['HTTP_X_FORWARDED_FOR']))
+		$data->ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+	$content = getStandaloneFile('dynmap_webchat.json');
+	$gotold = false;
+	if (isset($content)) {
+		$old_messages = json_decode($content, true);
+		$gotold = true;
+	}
+	
+	if(!empty($old_messages))
+	{
+		foreach($old_messages as $message)
+		{
+			if(($timestamp - $config['updaterate'] - 10000) < $message['timestamp'])
+				$new_messages[] = $message;
+		}
+	}
+	$new_messages[] = $data;
+
+	if ($gotold) {
+	    updateStandaloneFile('dynmap_webchat.json', json_encode($new_messages));
+	}
+	else {
+	    insertStandaloneFile('dynmap_webchat.json', json_encode($new_messages));
+	}
+	
+	$_SESSION['lastchat'] = time()+$msginterval;
+	echo "{ \"error\" : \"none\" }";
+}
+elseif($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat > time())
+{
+	header('HTTP/1.1 403 Forbidden');
+}
+else {
+	echo "{ \"error\" : \"none\" }";
+}
+cleanupDb();
+
+?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_tiles.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_tiles.php
@@ -1,0 +1,114 @@
+<?php
+ob_start();
+require_once('PostgreSQL_funcs.php');
+include('PostgreSQL_config.php');
+include('PostgreSQL_access.php');
+ob_end_clean();
+
+session_start();
+
+if(isset($_SESSION['userid'])) {
+  $userid = $_SESSION['userid'];
+}
+else {
+  $userid = '-guest-';
+}
+
+$loggedin = false;
+if(strcmp($userid, '-guest-')) {
+  $loggedin = true;
+}
+
+$path = $_REQUEST['tile'];
+if ((!isset($path)) || strstr($path, "..")) {
+    header('HTTP/1.0 500 Error');
+    echo "<h1>500 Error</h1>";
+    echo "Bad tile: " . $path;
+    exit();
+}
+
+$parts = explode("/", $path);
+
+if (count($parts) != 4) {
+   header('Location: ../images/blank.png');
+   cleanupDb();
+   exit;
+}
+ 
+$uid = '[' . strtolower($userid) . ']';
+
+$world = $parts[0];
+
+if(isset($worldaccess[$world])) {
+    $ss = stristr($worldaccess[$world], $uid);
+	if($ss === false) {
+           header('Location: ../images/blank.png');
+           cleanupDb();
+           exit;
+	}
+}
+$variant='STANDARD';
+
+  $prefix = $parts[1];
+  $plen = strlen($prefix);
+  if(($plen > 4) && (substr($prefix, $plen - 4) === "_day")) {
+	$prefix = substr($prefix, 0, $plen - 4);
+        $variant = 'DAY';
+  }
+  $mapid = $world . "." . $prefix;
+  if(isset($mapaccess[$mapid])) {
+    $ss = stristr($mapaccess[$mapid], $uid);
+	if($ss === false) {
+           header('Location: ../images/blank.png');
+           cleanupDb();
+           exit;
+	}
+  }
+
+$fparts = explode("_", $parts[3]);
+if (count($fparts) == 3) { // zoom_x_y
+   $zoom = strlen($fparts[0]);
+   $x = intval($fparts[1]);
+   $y = intval($fparts[2]);
+}
+else if (count($fparts) == 2) { // x_y
+   $zoom = 0;
+   $x = intval($fparts[0]);
+   $y = intval($fparts[1]);
+}
+else {
+   header('Location: ../images/blank.png');
+   cleanupDb();
+   exit;
+}
+initDbIfNeeded();
+
+$stmt = $db->prepare('SELECT t.Image,t.Format,t.HashCode,t.LastUpdate FROM ' . $dbprefix . 'Maps m JOIN ' . $dbprefix . 'Tiles t ON m.ID=t.MapID WHERE m.WorldID=? AND m.MapID=? AND m.Variant=? AND t.x=? AND t.y=? and t.zoom=?');
+$stmt->bindParam(1,$world, PDO::PARAM_STR);
+$stmt->bindParam(2,$prefix, PDO::PARAM_STR);
+$stmt->bindParam(3,$variant, PDO::PARAM_STR);
+$stmt->bindParam(4,$x, PDO::PARAM_INT);
+$stmt->bindParam(5,$y, PDO::PARAM_INT);
+$stmt->bindParam(6,$zoom, PDO::PARAM_INT);
+$res = $stmt->execute();
+list($timage, $format, $thash, $tlast) = $stmt->fetch();
+if ($res && $timage) {
+   if ($format == 0) {
+      header('Content-Type: image/png');
+   }
+   else {
+      header('Content-Type: image/jpeg');
+   }
+   header('ETag: \'' . $thash . '\'');
+   header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $tlast/1000) . ' GMT'); 
+   echo stream_get_contents($timage);
+}
+else {
+   header('Location: ../images/blank.png');
+}
+
+$stmt->closeCursor();
+cleanupDb();
+
+exit;
+?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_update.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_update.php
@@ -1,0 +1,107 @@
+<?php
+ob_start();
+require_once('PostgreSQL_funcs.php');
+include('PostgreSQL_config.php');
+include('PostgreSQL_access.php');
+ob_end_clean();
+
+$world = $_REQUEST['world'];
+
+session_start();
+
+if(isset($_SESSION['userid'])) {
+  $userid = $_SESSION['userid'];
+}
+else {
+  $userid = '-guest-';
+}
+
+$loggedin = false;
+if(strcmp($userid, '-guest-')) {
+  $loggedin = true;
+}
+
+header('Content-type: application/json; charset=utf-8');
+
+if(strpos($world, '/') || strpos($world, '\\') || empty($world)) {
+    echo "{ \"error\": \"invalid-world\" }";
+    return;
+}
+
+if ($loginenabled)
+	$fname = 'updates_' . $world . '.php';
+else
+	$fname = 'updates_' . $world . '.json';
+
+$useridlc = strtolower($userid);
+$uid = '[' . $useridlc . ']';
+
+if(isset($worldaccess[$world])) {
+    $ss = stristr($worldaccess[$world], $uid);
+	if($ss === false) {
+	    echo "{ \"error\": \"access-denied\" }";
+		return;
+	}
+}
+
+$serverid = 0;
+if(isset($_REQUEST['serverid'])) {
+  $serverid = $_REQUEST['serverid'];
+}
+
+$content = getStandaloneFile('dynmap_' . $world . '.json');
+if (!isset($content)) {
+    header('HTTP/1.0 503 Database Unavailable');
+    echo "<h1>503 Database Unavailable</h1>";
+    echo 'Error reading database - ' . $fname . ' #' . $serverid;
+    cleanupDb();
+    exit;
+}
+
+
+if (!$loginenabled) {
+	echo $content;
+}
+else if(isset($json->loginrequired) && $json->loginrequired && !$loggedin) {
+    echo "{ \"error\": \"login-required\" }";
+}
+else {
+	$json = json_decode($content);
+	$json->loggedin = $loggedin;
+	if (isset($json->protected) && $json->protected) {
+	    $ss = stristr($seeallmarkers, $uid);
+		if($ss === false) {
+			if(isset($playervisible[$useridlc])) {
+				$plist = $playervisible[$useridlc];
+				$pcnt = count($json->players);
+				for($i = 0; $i < $pcnt; $i++) {
+					$p = $json->players[$i];
+					if(!stristr($plist, '[' . $p->account . ']')) { 
+						$p->world = "-some-other-bogus-world-";
+						$p->x = 0.0;
+						$p->y = 64.0;
+						$p->z = 0.0;
+					}
+				}
+			}
+			else {
+				$pcnt = count($json->players);
+				for($i = 0; $i < $pcnt; $i++) {
+					$p = $json->players[$i];
+					if(strcasecmp($userid, $p->account) != 0) {
+						$p->world = "-some-other-bogus-world-";
+						$p->x = 0.0;
+						$p->y = 64.0;
+						$p->z = 0.0;
+					}
+				}
+			}
+		}
+	}
+	echo json_encode($json);
+}
+cleanupDb();
+
+ 
+?>
+

--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ The following target platforms are supported:
 - Forge v1.10.2 - via Dynmap-<version>-forge-1.10.2.jar mod
 - Forge v1.11.2 - via Dynmap-<version>-forge-1.11.2.jar mod
 - Forge v1.12.2 - via Dynmap-<version>-forge-1.12.2.jar mod
+
+# Data Storage
+Dynmap supports the following storage backends:
+- Flat files: The default for a new installation
+- SQLite
+- MySQL
+- PostgreSQL: EXPERIMENTAL


### PR DESCRIPTION
Added `PostgreSQL_` standalone drivers.
Also updated the README to indicate that there are multiple ways to store tile data, and that postgres support is currently experimental (bugs and performance, as well as broken features)
these are EXPERIMENTAL, but tile access, markers, and players all work.

Known issues:
Chat broken (does jetty support websockets? PHP doesn't like them very much, so we'd need a standalone relay for that, maybe an advanced config for large servers.)
Likely parameter sanitization issues (prepared statements mitigate 99.9% of this though)

Untested:
login (side note: should probably use a DB table for users; using an `eval()`ed PHP file in a database is probably not the best for performance...)

bugs fixed: missed a `TEXT` in the standalone files table; internal doesn't use this, so I didn't notice it until now.

EDIT: the force-push was fixing commit attribution; forgot to do the `git config --global` dance...