### PR TITLE
Fix unintended redirection to welcome file

### DIFF
--- a/DynmapCore/build.gradle
+++ b/DynmapCore/build.gradle
@@ -3,8 +3,8 @@ description = "DynmapCore"
 dependencies {
     compile project(path: ':DynmapCoreAPI', configuration: 'shadow')
     compile 'javax.servlet:javax.servlet-api:3.1'
-    compile 'org.eclipse.jetty:jetty-server:9.4.24.v20191120'
-    compile 'org.eclipse.jetty:jetty-servlet:9.4.24.v20191120'
+    compile 'org.eclipse.jetty:jetty-server:9.4.26.v20200117'
+    compile 'org.eclipse.jetty:jetty-servlet:9.4.26.v20200117'
     compile 'com.googlecode.json-simple:json-simple:1.1.1'
     compile 'org.yaml:snakeyaml:1.23'
     compile 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20180219.1'

--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -49,10 +49,7 @@ import org.dynmap.markers.MarkerAPI;
 import org.dynmap.markers.impl.MarkerAPIImpl;
 import org.dynmap.modsupport.ModSupportImpl;
 import org.dynmap.renderer.DynmapBlockState;
-import org.dynmap.servlet.FileResourceHandler;
-import org.dynmap.servlet.JettyNullLogger;
-import org.dynmap.servlet.LoginServlet;
-import org.dynmap.servlet.MapStorageResourceHandler;
+import org.dynmap.servlet.*;
 import org.dynmap.storage.MapStorage;
 import org.dynmap.storage.filetree.FileTreeMapStorage;
 import org.dynmap.storage.mysql.MySQLMapStorage;
@@ -843,12 +840,15 @@ public class DynmapCore implements DynmapCommonAPI {
         filters.add(new CustomHeaderFilter(configuration.getNode("http-response-headers")));
 
         FilterHandler fh = new FilterHandler(router, filters);
+        ContextHandler contextHandler = new ContextHandler();
+        contextHandler.setContextPath("/");
+        contextHandler.setHandler(fh);
         HandlerList hlist = new HandlerList();
-        hlist.setHandlers(new org.eclipse.jetty.server.Handler[] { new SessionHandler(), fh });
+        hlist.setHandlers(new org.eclipse.jetty.server.Handler[] { new SessionHandler(), contextHandler });
         webServer.setHandler(hlist);
         
-        addServlet("/up/configuration", new org.dynmap.servlet.ClientConfigurationServlet(this));
-        addServlet("/standalone/config.js", new org.dynmap.servlet.ConfigJSServlet(this));
+        addServlet("/up/configuration", new ClientConfigurationServlet(this));
+        addServlet("/standalone/config.js", new ConfigJSServlet(this));
         if(authmgr != null) {
             LoginServlet login = new LoginServlet(this);
             addServlet("/up/login", login);


### PR DESCRIPTION
This pull request fixes #2765 which caused by #2748. 
(It'll update Jetty to the latest version which released in this year.)
Eclipse Jetty changed the internal behavior of welcome file. I thought it can be fixed with `setRedirectWelcome(false)`, however, it wasn't working correctly.
`setRedirectWelcome` requires context to not be null. So this pull request wraps `FilterHandler` with `ContextHandler`.
I believe this won't break anything, however, it still may break something that I unexpected.
(Tested with Spigot 1.12.2)