### PR TITLE
fix vertical centering of markers

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/css/dynmap_style.css
+++ b/DynmapCore/src/main/resources/extracted/web/css/dynmap_style.css
@@ -887,22 +887,19 @@
 }
 
 .dynmap .mapMarker .markerIcon16x16 {
-	margin-top: -8px;
-	margin-left: -8px;
+	transform: translate(-50%, -50%);
 	width: 16px;
 	height: 16px;
 }
 
 .dynmap .mapMarker .markerIcon8x8 {
-	margin-top: -4px;
-	margin-left: -4px;
+	transform: translate(-50%, -50%);
 	width: 8px;
 	height: 8px;
 }
 
 .dynmap .mapMarker .markerIcon32x32 {
-	margin-top: -16px;
-	margin-left: -16px;
+	transform: translate(-50%, -50%);
 	width: 32px;
 	height: 32px;
 }


### PR DESCRIPTION
I've noticed that all my markers weren't vertically centered properly.
the `margin-top: -8px;` in `.dynmap .mapMarker .markerIcon16x16` wasn't actually working correctly, it was getting limited by something else beyond -3px. Changing this to `transform: translate(-50%, -50%);` fixed the issue for me.