### PR TITLE
Add `worldborderlabel` configuration.txt setting

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/MarkersComponent.java
+++ b/DynmapCore/src/main/java/org/dynmap/MarkersComponent.java
@@ -25,6 +25,7 @@ public class MarkersComponent extends ClientComponent {
     private MarkerSignManager signmgr;
     private MarkerIcon spawnicon;
     private String spawnlbl;
+    private String worldborderlbl;
     private MarkerSet offlineset;
     private MarkerIcon offlineicon;
     private MarkerSet spawnbedset;
@@ -56,6 +57,9 @@ public class MarkersComponent extends ClientComponent {
             if(spawnicon == null) {
                 spawnicon = api.getMarkerIcon(MarkerIcon.WORLD);
             }
+        }
+        if (showBorder) {
+            worldborderlbl = configuration.getString("worldborderlabel", "Border");
         }
         if (showSpawn || showBorder) {
             /* Add listener for world loads */
@@ -280,7 +284,7 @@ public class MarkersComponent extends ClientComponent {
                     }
                 }
                 if (am == null) {
-                    am = ms.createAreaMarker(borderid, "Border", false, w.getName(), x, z, false);
+                    am = ms.createAreaMarker(borderid, worldborderlbl, false, w.getName(), x, z, false);
                 }
                 else {
                     am.setCornerLocations(x, z);

--- a/forge-1.10.2/src/main/resources/configuration.txt
+++ b/forge-1.10.2/src/main/resources/configuration.txt
@@ -127,6 +127,7 @@ components:
     spawnbedformat: "%name%'s bed"
     # (optional) Show world border (vanilla 1.8+)
     showworldborder: true
+    worldborderlabel: "Border"
     
   - class: org.dynmap.ClientComponent
     type: chat

--- a/forge-1.11.2/src/main/resources/configuration.txt
+++ b/forge-1.11.2/src/main/resources/configuration.txt
@@ -127,6 +127,7 @@ components:
     spawnbedformat: "%name%'s bed"
     # (optional) Show world border (vanilla 1.8+)
     showworldborder: true
+    worldborderlabel: "Border"
     
   - class: org.dynmap.ClientComponent
     type: chat

--- a/forge-1.12.2/src/main/resources/configuration.txt
+++ b/forge-1.12.2/src/main/resources/configuration.txt
@@ -127,6 +127,7 @@ components:
     spawnbedformat: "%name%'s bed"
     # (optional) Show world border (vanilla 1.8+)
     showworldborder: true
+    worldborderlabel: "Border"
     
   - class: org.dynmap.ClientComponent
     type: chat

--- a/forge-1.13.2/src/main/resources/configuration.txt
+++ b/forge-1.13.2/src/main/resources/configuration.txt
@@ -127,6 +127,7 @@ components:
     spawnbedformat: "%name%'s bed"
     # (optional) Show world border (vanilla 1.8+)
     showworldborder: true
+    worldborderlabel: "Border"
     
   - class: org.dynmap.ClientComponent
     type: chat

--- a/forge-1.8.9/src/main/resources/configuration.txt
+++ b/forge-1.8.9/src/main/resources/configuration.txt
@@ -127,6 +127,7 @@ components:
     spawnbedformat: "%name%'s bed"
     # (optional) Show world border (vanilla 1.8+)
     showworldborder: true
+    worldborderlabel: "Border"
     
   - class: org.dynmap.ClientComponent
     type: chat

--- a/forge-1.9.4/src/main/resources/configuration.txt
+++ b/forge-1.9.4/src/main/resources/configuration.txt
@@ -127,6 +127,7 @@ components:
     spawnbedformat: "%name%'s bed"
     # (optional) Show world border (vanilla 1.8+)
     showworldborder: true
+    worldborderlabel: "Border"
     
   - class: org.dynmap.ClientComponent
     type: chat

--- a/spigot/src/main/resources/configuration.txt
+++ b/spigot/src/main/resources/configuration.txt
@@ -128,6 +128,7 @@ components:
     spawnbedformat: "%name%'s bed"
     # (optional) show world border (vanilla 1.8+)
     showworldborder: true
+    worldborderlabel: "Border"
     
   - class: org.dynmap.ClientComponent
     type: chat


### PR DESCRIPTION
Hi there! This is just a quick patch to add a `worldborderlabel` setting. Tested with Paper 1.15.2 #155, and seems to work just fine.

I didn't see any contribution guidelines/testing procedures, please let me know if I've missed those, or if there are any changes you'd like to this.

<img width="190" alt="Screen Shot 2020-04-02 at 10 08 00 PM" src="https://user-images.githubusercontent.com/117288/78326139-6e6ffd80-752e-11ea-9475-3621ae3383e6.png">
