### PR TITLE
WIP Allow using %uuid% in skin-url

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/PlayerFaces.java
+++ b/DynmapCore/src/main/java/org/dynmap/PlayerFaces.java
@@ -108,6 +108,7 @@ public class PlayerFaces {
     private class LoadPlayerImages implements Runnable {
         public final String playername;
         public final String playerskinurl;
+        public final String playeruuid;
         public LoadPlayerImages(String playername, String playerskinurl, UUID playeruuid) {
             this.playername = playername;
             this.playerskinurl = playerskinurl;

--- a/DynmapCore/src/main/java/org/dynmap/PlayerFaces.java
+++ b/DynmapCore/src/main/java/org/dynmap/PlayerFaces.java
@@ -111,6 +111,7 @@ public class PlayerFaces {
         public LoadPlayerImages(String playername, String playerskinurl, UUID playeruuid) {
             this.playername = playername;
             this.playerskinurl = playerskinurl;
+            this.playeruuid = playeruuid;
         }
         public void run() {
             boolean has_8x8 = storage.hasPlayerFaceImage(playername, FaceType.FACE_8X8);
@@ -125,7 +126,7 @@ public class PlayerFaces {
                 if(fetchskins && (refreshskins || missing_any)) {
                 	URL url = null;
                 	if (skinurl.equals("") == false) {
-                		url = new URL(skinurl.replace("%player%", URLEncoder.encode(playername, "UTF-8")));
+                		url = new URL(skinurl.replace("%player%", URLEncoder.encode(playername, "UTF-8").replace("%UUID%", playeruuid)));
                 	}
                 	else if (playerskinurl != null) {
                 		url = new URL(playerskinurl);

--- a/DynmapCore/src/main/java/org/dynmap/PlayerFaces.java
+++ b/DynmapCore/src/main/java/org/dynmap/PlayerFaces.java
@@ -127,7 +127,7 @@ public class PlayerFaces {
                 if(fetchskins && (refreshskins || missing_any)) {
                 	URL url = null;
                 	if (skinurl.equals("") == false) {
-                		url = new URL(skinurl.replace("%player%", URLEncoder.encode(playername, "UTF-8").replace("%UUID%", playeruuid)));
+                		url = new URL(skinurl.replace("%player%", URLEncoder.encode(playername, "UTF-8").replace("%uuid%", playeruuid)));
                 	}
                 	else if (playerskinurl != null) {
                 		url = new URL(playerskinurl);


### PR DESCRIPTION
This simple change allows you to use %uuid% inside skin-url allowing us to lookup skins on newer versions of minecraft (assuming you have an api setup for it).