### PR TITLE
[Fabric] Make it so dynmap commands can be proxied via `/execute` without failing to parse.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,11 @@
 /bin
 /dist
 /manifest.mf
+/run
 
 # Mac filesystem dust
 /.DS_Store
 /dependency-reduced-pom.xml
 
+*.log
 /.gradle

--- a/fabric-1.16.1/src/main/java/org/dynmap/fabric_1_16_1/command/DynmapCommandExecutor.java
+++ b/fabric-1.16.1/src/main/java/org/dynmap/fabric_1_16_1/command/DynmapCommandExecutor.java
@@ -45,7 +45,13 @@ public class DynmapCommandExecutor implements Command<ServerCommandSource> {
 
     @Override
     public int run(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        String[] args = context.getInput().split("\\s+");
+        // Commands in brigadier may be proxied in Minecraft via a syntax like `/execute ... ... run dmap [args]`
+        // Dynmap will fail to parse this properly, so we find the starting position of the actual command being parsed after any forks or redirects.
+        // The start position of the range specifies where the actual command dynmap has registered starts
+        int start = context.getRange().getStart();
+        String dynmapInput = context.getInput().substring(start);
+
+        String[] args = dynmapInput.split("\\s+");
         plugin.handleCommand(context.getSource(), cmd, Arrays.copyOfRange(args, 1, args.length));
         return 1;
     }

--- a/fabric-1.16.2/src/main/java/org/dynmap/fabric_1_16_2/command/DynmapCommandExecutor.java
+++ b/fabric-1.16.2/src/main/java/org/dynmap/fabric_1_16_2/command/DynmapCommandExecutor.java
@@ -45,7 +45,13 @@ public class DynmapCommandExecutor implements Command<ServerCommandSource> {
 
     @Override
     public int run(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        String[] args = context.getInput().split("\\s+");
+        // Commands in brigadier may be proxied in Minecraft via a syntax like `/execute ... ... run dmap [args]`
+        // Dynmap will fail to parse this properly, so we find the starting position of the actual command being parsed after any forks or redirects.
+        // The start position of the range specifies where the actual command dynmap has registered starts
+        int start = context.getRange().getStart();
+        String dynmapInput = context.getInput().substring(start);
+
+        String[] args = dynmapInput.split("\\s+");
         plugin.handleCommand(context.getSource(), cmd, Arrays.copyOfRange(args, 1, args.length));
         return 1;
     }


### PR DESCRIPTION
Also adds some gitignore entries for stuff generated by fabric at runtime.