### PR TITLE
Fix comma on some locales when formatting float and double values

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/web/Json.java
+++ b/DynmapCore/src/main/java/org/dynmap/web/Json.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class Json {
@@ -69,7 +70,7 @@ public class Json {
         } else if (o instanceof Integer || o instanceof Long) {
             s.append(o.toString());
         } else if (o instanceof Float || o instanceof Double) {
-            s.append(String.format("%.2f",((Number)o).doubleValue()));
+            s.append(String.format(Locale.US, "%.2f",((Number)o).doubleValue()));
         } else if (o instanceof Map<?, ?>) {
             Map<?, ?> m = (Map<?, ?>) o;
             s.append("{");


### PR DESCRIPTION
`String.format()` respects the current locale.

![2020-09-22_16-45-02](https://user-images.githubusercontent.com/1076914/93890755-574ae500-fcf3-11ea-9e87-b29a43e35b15.png)


I tested it on my server, the problems with markers are gone.
