### PR TITLE
Improving map icon logics and correcting Surface mapname in templates.

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/js/map.js
+++ b/DynmapCore/src/main/resources/extracted/web/js/map.js
@@ -280,18 +280,19 @@ DynMap.prototype = {
 
 				var worldName = wname;
 				var mapName = mapindex;
-				if (worldName.endsWith('_nether') || (worldName == 'DIM-1')) {
-				   worldName = 'nether';
-				   mapName = (mapindex == 'nether') ? 'surface' : 'flat';
+				//Standart minecraft world names
+				if(worldName.startsWith('world_')) {
+					worldName = wname.substring(6);
 				}
-				else if (worldName.endsWith('the_end') || (worldName == 'DIM1')) {
-				   worldName = 'the_end';
-				   mapName = (mapindex == 'the_end') ? 'surface' : 'flat';
+				//Nether in CurseForge and other custom maps
+				else if(worldName.endsWith('nether') || (worldName == 'DIM-1')) {
+					worldName == 'nether';
 				}
-				else {
-				    worldName = 'world';
-				    mapName = [ 'surface', 'flat', 'biome', 'cave' ].includes(mapindex) ? mapindex : 'flat';
+				//The end in CurseForge and other custom maps
+				else if(worldName.endsWith('the_end') || (worldName == 'DIM1')) {
+					worldName = 'the_end';
 				}
+
 				map.element = $('<li/>')
 					.addClass('map item')
 					.append($('<a/>')

--- a/DynmapCore/src/main/resources/templates/nether-hi_boost_vhi.txt
+++ b/DynmapCore/src/main/resources/templates/nether-hi_boost_vhi.txt
@@ -24,7 +24,7 @@ templates:
         background: "#300806"
         mapzoomin: 4
       - class: org.dynmap.hdmap.HDMap
-        name: nether
+        name: surface
         title: "Surface"
         prefix: nt
         perspective: iso_SE_30_hires

--- a/DynmapCore/src/main/resources/templates/nether-hi_boost_xhi.txt
+++ b/DynmapCore/src/main/resources/templates/nether-hi_boost_xhi.txt
@@ -24,7 +24,7 @@ templates:
         background: "#300806"
         mapzoomin: 5
       - class: org.dynmap.hdmap.HDMap
-        name: nether
+        name: surface
         title: "Surface"
         prefix: nt
         perspective: iso_SE_30_hires

--- a/DynmapCore/src/main/resources/templates/nether-hires.txt
+++ b/DynmapCore/src/main/resources/templates/nether-hires.txt
@@ -27,7 +27,7 @@ templates:
         background: "#300806"
         mapzoomin: 1
       - class: org.dynmap.hdmap.HDMap
-        name: nether
+        name: surface
         title: "Surface"
         prefix: nt
         perspective: iso_SE_30_hires

--- a/DynmapCore/src/main/resources/templates/nether-low_boost_hi.txt
+++ b/DynmapCore/src/main/resources/templates/nether-low_boost_hi.txt
@@ -25,7 +25,7 @@ templates:
         # Adjust extra zoom in levels - default is 2
         mapzoomin: 4
       - class: org.dynmap.hdmap.HDMap
-        name: nether
+        name: surface
         title: "Surface"
         prefix: nt
         perspective: iso_SE_30_lowres

--- a/DynmapCore/src/main/resources/templates/nether-lowres.txt
+++ b/DynmapCore/src/main/resources/templates/nether-lowres.txt
@@ -28,7 +28,7 @@ templates:
         # Adjust extra zoom in levels - default is 2
         mapzoomin: 2
       - class: org.dynmap.hdmap.HDMap
-        name: nether
+        name: surface
         title: "Surface"
         prefix: nt
         perspective: iso_SE_60_lowres

--- a/DynmapCore/src/main/resources/templates/nether-vlowres.txt
+++ b/DynmapCore/src/main/resources/templates/nether-vlowres.txt
@@ -28,7 +28,7 @@ templates:
         # Adjust extra zoom in levels - default is 2
         mapzoomin: 2
       - class: org.dynmap.hdmap.HDMap
-        name: nether
+        name: surface
         title: "Surface"
         prefix: nt
         perspective: iso_SE_60_vlowres

--- a/DynmapCore/src/main/resources/templates/nether.txt
+++ b/DynmapCore/src/main/resources/templates/nether.txt
@@ -27,7 +27,7 @@ templates:
         # Adjust extra zoom in levels - default is 2
         mapzoomin: 2
       - class: org.dynmap.hdmap.HDMap
-        name: nether
+        name: surface
         title: "Surface"
         prefix: nt
         perspective: iso_SE_60_vlowres

--- a/DynmapCore/src/main/resources/templates/the_end-hi_boost_vhi.txt
+++ b/DynmapCore/src/main/resources/templates/the_end-hi_boost_vhi.txt
@@ -22,7 +22,7 @@ templates:
         lighting: brightnight
         mapzoomin: 4
       - class: org.dynmap.hdmap.HDMap
-        name: the_end
+        name: surface
         title: "Surface"
         prefix: st
         perspective: iso_SE_30_hires

--- a/DynmapCore/src/main/resources/templates/the_end-hi_boost_xhi.txt
+++ b/DynmapCore/src/main/resources/templates/the_end-hi_boost_xhi.txt
@@ -22,7 +22,7 @@ templates:
         lighting: brightnight
         mapzoomin: 5
       - class: org.dynmap.hdmap.HDMap
-        name: the_end
+        name: surface
         title: "Surface"
         prefix: st
         perspective: iso_SE_30_hires

--- a/DynmapCore/src/main/resources/templates/the_end-hires.txt
+++ b/DynmapCore/src/main/resources/templates/the_end-hires.txt
@@ -25,7 +25,7 @@ templates:
         lighting: brightnight
         mapzoomin: 1
       - class: org.dynmap.hdmap.HDMap
-        name: the_end
+        name: surface
         title: "Surface"
         prefix: st
         perspective: iso_SE_30_hires

--- a/DynmapCore/src/main/resources/templates/the_end-low_boost_hi.txt
+++ b/DynmapCore/src/main/resources/templates/the_end-low_boost_hi.txt
@@ -23,7 +23,7 @@ templates:
         # Adjust extra zoom in levels - default is 2
         mapzoomin: 4
       - class: org.dynmap.hdmap.HDMap
-        name: the_end
+        name: surface
         title: "Surface"
         prefix: st
         perspective: iso_SE_30_lowres

--- a/DynmapCore/src/main/resources/templates/the_end-lowres.txt
+++ b/DynmapCore/src/main/resources/templates/the_end-lowres.txt
@@ -26,7 +26,7 @@ templates:
         # Adjust extra zoom in levels - default is 2
         mapzoomin: 2
       - class: org.dynmap.hdmap.HDMap
-        name: the_end
+        name: surface
         title: "Surface"
         prefix: st
         perspective: iso_SE_60_lowres

--- a/DynmapCore/src/main/resources/templates/the_end-vlowres.txt
+++ b/DynmapCore/src/main/resources/templates/the_end-vlowres.txt
@@ -26,7 +26,7 @@ templates:
         # Adjust extra zoom in levels - default is 2
         mapzoomin: 2
       - class: org.dynmap.hdmap.HDMap
-        name: the_end
+        name: surface
         title: "Surface"
         prefix: st
         perspective: iso_SE_60_vlowres

--- a/DynmapCore/src/main/resources/templates/the_end.txt
+++ b/DynmapCore/src/main/resources/templates/the_end.txt
@@ -25,7 +25,7 @@ templates:
         # Adjust extra zoom in levels - default is 2
         mapzoomin: 2
       - class: org.dynmap.hdmap.HDMap
-        name: the_end
+        name: surface
         title: "Surface"
         prefix: st
         perspective: iso_SE_60_vlowres


### PR DESCRIPTION
Alot more versatile for custom maps and icons.

This logic will always refer to the naming in worlds.txt or default world naming, when using the option "deftemplatesuffix" in Configuration.txt

The icon for "world_nether:flat" will be block_nether_flat.png

Then lets say you have a custom map rendering to only show the top of the nether and you named the rendering "top" in the worlds.txt under the map nether. Then the icon will be block_nether_top.png