### PR TITLE
Null check for path environment variable.

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -438,7 +438,12 @@ public class DynmapCore implements DynmapCommonAPI {
     }
 
     private String findExecutableOnPath(String fname) {
-		for (String dirname : System.getenv("PATH").split(File.pathSeparator)) {
+        String path = System.getenv("PATH");
+        // Fast-fail if path is null.
+        if (path == null)
+            return null;
+
+		for (String dirname : path.split(File.pathSeparator)) {
 			File file = new File(dirname, fname);
 			if (file.isFile() && file.canExecute()) {
 				return file.getAbsolutePath();


### PR DESCRIPTION
Some systems do not set a path environment variable for whatever reason and thus `System.getenv("PATH")` returns a null value for the string. 

Closes #3170