### PR TITLE
Fix fullrender deleting the files in the new format instead of the old

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/storage/filetree/FileTreeMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/filetree/FileTreeMapStorage.java
@@ -73,15 +73,17 @@ public class FileTreeMapStorage extends MapStorage {
             }
             return ff;
         }
-        private File getTileFileAltFormat() {
+        private List<File> getTileFilesAltFormats() {
             ImageEncoding fmt = map.getImageFormat().getEncoding();
-            if (fmt == ImageEncoding.PNG) {
-                fmt = ImageEncoding.JPG;
+
+            List<File> files = new ArrayList<File>();
+            for (ImageEncoding ie: ImageEncoding.values()) {
+                if (ie != fmt) {
+                    files.add(getTileFile(ie));
+                }
             }
-            else {
-                fmt = ImageEncoding.PNG;
-            }
-            return getTileFile(fmt);
+
+            return files;
         }
         @Override
         public boolean exists() {
@@ -136,11 +138,13 @@ public class FileTreeMapStorage extends MapStorage {
         @Override
         public boolean write(long hash, BufferOutputStream encImage) {
             File ff = getTileFile(map.getImageFormat().getEncoding());
-            File ffalt = getTileFileAltFormat();
+            List<File> ffalt = getTileFilesAltFormats();
             File ffpar = ff.getParentFile();
-            // Always clean up old alternate file, if it exsits
-            if (ffalt.exists()) {
-                ffalt.delete();
+            // Always clean up old alternate files, if they exist
+            for (File file: ffalt) {
+                if (file.exists()) {
+                    file.delete();
+                }
             }
             if (encImage == null) { // Delete?
                 ff.delete();


### PR DESCRIPTION
WebP support was recently added, but only PNG and JPG were hardcoded in FileTreeMapStorage. This caused an issue with running fullrender after changing the image format in the config file, which tried to delete the outdated files using the *current* image format.
This removes the hardcoded values and replaces them with code that uses all the ImageEncoding enum values except the one matching the current format.

Fixes #3195.

There's still a remaining issue with the zoom tiles not getting regenerated after an image format change, but I don't want to dig into that tonight.