### PR TITLE
Add warning for ClientUpdateComponent misconfiguration, related to disable-webserver

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/ComponentManager.java
+++ b/DynmapCore/src/main/java/org/dynmap/ComponentManager.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 
 public class ComponentManager {
     public Set<Component> components = new HashSet<Component>();
@@ -38,10 +39,14 @@ public class ComponentManager {
         components.clear();
     }
     
-    public Iterable<Component> getComponents(Class<Component> c) {
+    public Iterable<Component> getComponents(Class<? extends Component> c) {
         List<Component> list = componentLookup.get(c.toString());
         if (list == null)
             return new ArrayList<Component>();
         return list;
+    }
+
+    public Boolean isLoaded(Class<? extends Component> c){
+        return StreamSupport.stream(getComponents(c).spliterator(), false).count() > 0;
     }
 }

--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -159,6 +159,9 @@ public class DynmapCore implements DynmapCommonAPI {
     
     private String[] deftriggers = { };
 
+    private Boolean webserverCompConfigWarn = false;
+    private final String CompConfigWiki = "https://github.com/webbukkit/dynmap/wiki/Component-Configuration";
+
     /* Constructor for core */
     public DynmapCore() {
     }
@@ -610,6 +613,27 @@ public class DynmapCore implements DynmapCommonAPI {
 
         if (!configuration.getBoolean("disable-webserver", false)) {
             startWebserver();
+            if(!componentManager.isLoaded(InternalClientUpdateComponent.class)) {
+                Log.warning("Using internal server, but " + InternalClientUpdateComponent.class.toString() + " is DISABLED!");
+                webserverCompConfigWarn = true;
+            }
+            if(componentManager.isLoaded(JsonFileClientUpdateComponent.class)) {
+                Log.warning("Using internal server, but " + JsonFileClientUpdateComponent.class.toString() + " is ENABLED!");
+            }
+        }
+        else {
+            if(componentManager.isLoaded(InternalClientUpdateComponent.class)) {
+                Log.warning("Using external server, but " + InternalClientUpdateComponent.class.toString() + " is ENABLED!");
+            }
+            if(!componentManager.isLoaded(JsonFileClientUpdateComponent.class)) {
+                Log.warning("Using external server, but " + JsonFileClientUpdateComponent.class.toString() + " is DISABLED!");
+                webserverCompConfigWarn = true;
+            }
+        }
+        if(webserverCompConfigWarn){
+            Log.warning("If the website is missing files or not loading/updating, this might be why.");
+            Log.warning("For more info, read this: " + CompConfigWiki);
+            webserverCompConfigWarn = false;
         }
         
         /* Add login/logoff listeners */


### PR DESCRIPTION
Quality of life change, adds a warning if the user changed the setting of disable-webserver, without making the appropriate changes to org.dynmap.JsonFileClientUpdateComponent & org.dynmap.InternalClientUpdateComponent. Would make for less confusion if someone didn't read the wiki (includes a link).