### PR TITLE
Allow for URI-unsafe player names

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/js/minecraft.js
+++ b/DynmapCore/src/main/resources/extracted/web/js/minecraft.js
@@ -8,9 +8,9 @@ function createMinecraftHead(player,size,completed,failed) {
 	};
 	var faceimg;
 	if(size == 'body')
-		faceimg = 'faces/body/' + player + '.png';
+		faceimg = 'faces/body/' + encodeURIComponent(player) + '.png';
 	else
-		faceimg = 'faces/' + size + 'x' + size + '/' + player + '.png';
+		faceimg = 'faces/' + size + 'x' + size + '/' + encodeURIComponent(player) + '.png';
 	
 	faceImage.src = concatURL(dynmap.options.url.markers, faceimg);
 }


### PR DESCRIPTION
Some plugins allow for a player name prefix. If this contains a username-unsafe character like %, it can break player face rendering on the map.