### PR TITLE
Fixed not replacing {timestamp} placeholder in configuration request

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/js/map.js
+++ b/DynmapCore/src/main/resources/extracted/web/js/map.js
@@ -25,7 +25,7 @@ function DynMap(options) {
 	if(me.checkForSavedURL())
 		return;
 	me.options = options;
-	$.getJSON(me.options.url.configuration, function(configuration) {
+	$.getJSON(me.formatUrl("configuration", { timestamp: me.lasttimestamp }), function(configuration) {
 		if(configuration.error == 'login-required') {
 			me.saveURL();
 			window.location = 'login.html';
@@ -47,7 +47,7 @@ DynMap.prototype = {
 	registeredTiles: [],
 	players: {},
 	
-	lasttimestamp: new Date().getUTCMilliseconds(), /* Pseudorandom - prevent cached '?0' */
+	lasttimestamp: new Date().getTime(), /* Pseudorandom - prevent cached '?0' */
 	reqid: 0,
     servertime: 0,
     serverday: false,


### PR DESCRIPTION
From time to time, I have an issue with dynmap stucking in a reload loop (looks similar to the reload loop issue in #3128).

I just figured out why that happens: The `{timestamp}` placeholder in the configuration request (i.e. `dynmap_config.json?_={timestamp}`) is not replaced. Therefore, the browser caches the JSON containing the confighash. The JSON requests done for the world every 2 seconds also contain a confighash which is then compared to the hash in the initially loaded configuration. In case the configuration changes, the config hash in the world JSON response changes and the site is reloaded, but the configuration JSON is still the old one due to browser caching.