### PR TITLE
Update SkinsRestorer hook to v14 API

### DIFF
--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compile 'me.lucko.luckperms:luckperms-api:4.3'
     compile 'net.luckperms:api:5.0'
     compile('com.github.MilkBowl:VaultAPI:1.7') { transitive = false }
-    compileOnly 'com:skinsrestorer:13.7.5-20191221.213031-7@jar'
+    compileOnly 'net.skinsrestorer:skinsrestorer:14.0.0-SNAPSHOT@jar'
     compile project(":dynmap-api")
     compile project(path: ":DynmapCore", configuration: "shadow")
     compile group: 'ru.tehkode', name: 'PermissionsEx', version: '1.19.1'

--- a/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
@@ -105,7 +105,7 @@ import org.dynmap.renderer.DynmapBlockState;
 import org.dynmap.utils.MapChunkCache;
 import org.dynmap.utils.Polygon;
 import org.dynmap.utils.VisibilityLimit;
-import skinsrestorer.bukkit.SkinsRestorer;
+import net.skinsrestorer.bukkit.SkinsRestorer;
 
 public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
     private DynmapCore core;
@@ -140,7 +140,7 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
     private BukkitWorld last_bworld;
     
     private BukkitVersionHelper helper;
-    
+
     private final BukkitWorld getWorldByName(String name) {
         if((last_world != null) && (last_world.getName().equals(name))) {
             return last_bworld;
@@ -911,13 +911,18 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
         SkinsRestorerSkinUrlProvider skinUrlProvider = null;
 
         if (core.configuration.getBoolean("skinsrestorer-integration", false)) {
-            SkinsRestorer skinsRestorer = (SkinsRestorer) getServer().getPluginManager().getPlugin("SkinsRestorer");
+            try {
+                SkinsRestorer skinsRestorer = (SkinsRestorer) getServer().getPluginManager().getPlugin("SkinsRestorer");
 
-            if (skinsRestorer == null) {
-                Log.warning("SkinsRestorer integration can't be enabled because SkinsRestorer not installed");
-            } else {
-                skinUrlProvider = new SkinsRestorerSkinUrlProvider(skinsRestorer);
-                Log.info("SkinsRestorer integration enabled");
+                if (skinsRestorer == null) {
+                    Log.warning("SkinsRestorer integration can't be enabled because SkinsRestorer not installed");
+                } else {
+                    skinUrlProvider = new SkinsRestorerSkinUrlProvider(skinsRestorer);
+                    Log.info("SkinsRestorer API v14 integration enabled");
+                }
+            }catch(NoClassDefFoundError e) {
+                Log.warning("You are using unsupported version of SkinsRestorer. Use v14 or newer.");
+                Log.warning("Disabled SkinsRestorer integration for this session");
             }
         }
 

--- a/spigot/src/main/java/org/dynmap/bukkit/SkinsRestorerSkinUrlProvider.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/SkinsRestorerSkinUrlProvider.java
@@ -4,9 +4,9 @@ import org.dynmap.SkinUrlProvider;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.json.simple.JSONObject;
-import skinsrestorer.bukkit.SkinsRestorer;
-import skinsrestorer.bukkit.SkinsRestorerBukkitAPI;
-import skinsrestorer.shared.utils.ReflectionUtil;
+import net.skinsrestorer.api.SkinsRestorerAPI;
+import net.skinsrestorer.bukkit.SkinsRestorer;
+import net.skinsrestorer.shared.utils.ReflectionUtil;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -15,7 +15,7 @@ import java.util.Base64;
 
 public class SkinsRestorerSkinUrlProvider implements SkinUrlProvider {
     private JSONParser mJsonParser;
-    private SkinsRestorerBukkitAPI mSkinsRestorerApi;
+    private SkinsRestorerAPI mSkinsRestorerApi;
 
     SkinsRestorerSkinUrlProvider(SkinsRestorer skinsRestorer) {
         mJsonParser = new JSONParser();


### PR DESCRIPTION
#3304 
SkinsRestorer has aggressive auto-updater so I don't include any backwards compatibility in this PR, as it would blow the size of code. There is a check for old version, if it passes, the SkinsRestorer integration doesn't get enabled
Build of Spigot branch with no errors
tested on Java 15 and Paper-519 for MC 1.16.5 with both SkinsRestorer v14 and v13.8.9, with no errors

SkinsRestorer is backwards compatible all the way to 1.8 and developers say this compatibility will be included in v14.
Yes, I update dependency and I somehow edit your code to add compatibility with another plugin, but as this support is already included in your code, but will get outdated very soon, I hope it's ok.
Any user with new SkinsRestorer v14 and dynmap v3.1-b7 with enabled skinsrestorer-integration will crash dynmap. This fixes it.