### PR TITLE
Resize stateByID by 10% instead of a single element at a time

### DIFF
--- a/forge-1.16.5/src/main/java/org/dynmap/forge_1_16_5/DynmapPlugin.java
+++ b/forge-1.16.5/src/main/java/org/dynmap/forge_1_16_5/DynmapPlugin.java
@@ -239,7 +239,8 @@ public class DynmapPlugin
 			int idx = bsids.getId(bs);
     		if (idx >= stateByID.length) {
     			int plen = stateByID.length;
-    			stateByID = Arrays.copyOf(stateByID, idx+1);
+    			stateByID = Arrays.copyOf(stateByID, idx*11/10); // grow array by 10%
+			Log.debug("Resized stateByID from " + plen + " to " + stateByID.length);
     			Arrays.fill(stateByID, plen, stateByID.length, DynmapBlockState.AIR);
     		}
             Block b = bs.getBlock();


### PR DESCRIPTION
For a complex modpack, this reduces startup time by more than 99%, because Arrays.copyOf() is invoked only dozens of times instead of hundreds of thousands of times. Fixes #3284 and #3296, and possibly others.

Only patched forge 1.16.5 because that's all I'm running at the moment (and I'd prefer to not submit untested code), but I expect the same fix can be applied to many/most/all of the other versions.

Thanks!