### PR TITLE
Add option to disable HTML Sanitizer

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -122,6 +122,7 @@ public class DynmapCore implements DynmapCommonAPI {
     private boolean transparentLeaves = true;
     private List<String> sortPermissionNodes;
     private int perTickLimit = 50;   // 50 ms
+    private boolean sanitizeHtml = true;
     private boolean dumpMissing = false;
     private static boolean migrate_chunks = false;
     public boolean isInternalWebServerDisabled = false;
@@ -534,6 +535,8 @@ public class DynmapCore implements DynmapCommonAPI {
         updateplayerlimit = configuration.getInteger("updateplayerlimit", 0);
         /* Load sort permission nodes */
         sortPermissionNodes = configuration.getStrings("player-sort-permission-nodes", null);
+        /* Whether to sanitize html labels and descriptions */
+        sanitizeHtml = configuration.getBoolean("sanitize-html", true);
         
         perTickLimit = configuration.getInteger("per-tick-time-limit", 50);
         if (perTickLimit < 5) perTickLimit = 5;
@@ -2534,6 +2537,7 @@ public class DynmapCore implements DynmapCommonAPI {
     public int getMaxTickUseMS() {
         return perTickLimit;
     }
+    public boolean shouldSanitizeHtml() { return sanitizeHtml; }
     public boolean dumpMissingBlocks() {
         return dumpMissing;
     }

--- a/DynmapCore/src/main/java/org/dynmap/markers/impl/MarkerAPIImpl.java
+++ b/DynmapCore/src/main/java/org/dynmap/markers/impl/MarkerAPIImpl.java
@@ -3090,10 +3090,10 @@ public class MarkerAPIImpl implements MarkerAPI, Event.Listener<DynmapWorld> {
                     mi = MarkerAPIImpl.getMarkerIconImpl(MarkerIcon.DEFAULT);
                 mdata.put("icon", mi.getMarkerIconID());
                 mdata.put("dim", mi.getMarkerIconSize().getSize());
-                mdata.put("label", Client.sanitizeHTML(m.getLabel()));
+                mdata.put("label", core.shouldSanitizeHtml() ? Client.sanitizeHTML(m.getLabel()) : m.getLabel());
                 mdata.put("markup", m.isLabelMarkup());
                 if(m.getDescription() != null)
-                    mdata.put("desc", Client.sanitizeHTML(m.getDescription()));
+                    mdata.put("desc", core.shouldSanitizeHtml() ? Client.sanitizeHTML(m.getDescription()) : m.getDescription());
                 if (m.getMinZoom() >= 0) {
                     mdata.put("minzoom", m.getMinZoom());
                 }
@@ -3126,10 +3126,10 @@ public class MarkerAPIImpl implements MarkerAPI, Event.Listener<DynmapWorld> {
                 mdata.put("opacity", m.getLineOpacity());
                 mdata.put("fillopacity", m.getFillOpacity());
                 mdata.put("weight", m.getLineWeight());
-                mdata.put("label", Client.sanitizeHTML(m.getLabel()));
+                mdata.put("label", core.shouldSanitizeHtml() ? Client.sanitizeHTML(m.getLabel()) : m.getLabel());
                 mdata.put("markup", m.isLabelMarkup());
                 if(m.getDescription() != null)
-                    mdata.put("desc", Client.sanitizeHTML(m.getDescription()));
+                    mdata.put("desc", core.shouldSanitizeHtml() ? Client.sanitizeHTML(m.getDescription()) : m.getDescription());
                 if (m.getMinZoom() >= 0) {
                     mdata.put("minzoom", m.getMinZoom());
                 }
@@ -3161,10 +3161,10 @@ public class MarkerAPIImpl implements MarkerAPI, Event.Listener<DynmapWorld> {
                 mdata.put("color", String.format("#%06X", m.getLineColor()));
                 mdata.put("opacity", m.getLineOpacity());
                 mdata.put("weight", m.getLineWeight());
-                mdata.put("label", Client.sanitizeHTML(m.getLabel()));
+                mdata.put("label", core.shouldSanitizeHtml() ? Client.sanitizeHTML(m.getLabel()) : m.getLabel());
                 mdata.put("markup", m.isLabelMarkup());
                 if(m.getDescription() != null)
-                    mdata.put("desc", Client.sanitizeHTML(m.getDescription()));
+                    mdata.put("desc", core.shouldSanitizeHtml() ? Client.sanitizeHTML(m.getDescription()) : m.getDescription());
                 if (m.getMinZoom() >= 0) {
                     mdata.put("minzoom", m.getMinZoom());
                 }
@@ -3191,10 +3191,10 @@ public class MarkerAPIImpl implements MarkerAPI, Event.Listener<DynmapWorld> {
                 mdata.put("opacity", m.getLineOpacity());
                 mdata.put("fillopacity", m.getFillOpacity());
                 mdata.put("weight", m.getLineWeight());
-                mdata.put("label", Client.sanitizeHTML(m.getLabel()));
+                mdata.put("label", core.shouldSanitizeHtml() ? Client.sanitizeHTML(m.getLabel()) : m.getLabel());
                 mdata.put("markup", m.isLabelMarkup());
                 if(m.getDescription() != null)
-                    mdata.put("desc", Client.sanitizeHTML(m.getDescription()));
+                    mdata.put("desc", core.shouldSanitizeHtml() ? Client.sanitizeHTML(m.getDescription()) : m.getDescription());
                 if (m.getMinZoom() >= 0) {
                     mdata.put("minzoom", m.getMinZoom());
                 }

--- a/forge-1.11.2/src/main/resources/configuration.txt
+++ b/forge-1.11.2/src/main/resources/configuration.txt
@@ -465,3 +465,6 @@ verbose: false
 #  - class: org.dynmap.debug.LogDebugger
 # Debug: dump blocks missing render data
 dump-missing-blocks: false
+
+# Disable sanitizing the html code of labels and descriptions of markers. Default is true
+sanitize-html: true

--- a/forge-1.12.2/src/main/resources/configuration.txt
+++ b/forge-1.12.2/src/main/resources/configuration.txt
@@ -465,3 +465,6 @@ verbose: false
 #  - class: org.dynmap.debug.LogDebugger
 # Debug: dump blocks missing render data
 dump-missing-blocks: false
+
+# Disable sanitizing the html code of labels and descriptions of markers. Default is true
+sanitize-html: true

--- a/spigot/src/main/resources/configuration.txt
+++ b/spigot/src/main/resources/configuration.txt
@@ -131,7 +131,7 @@ components:
     # (optional) show world border (vanilla 1.8+)
     showworldborder: true
     worldborderlabel: "Border"
-    
+
   - class: org.dynmap.ClientComponent
     type: chat
     allowurlname: false
@@ -179,7 +179,7 @@ components:
     hidey: false
     show-mcr: false
     show-chunk: false
-    
+
   # Note: more than one logo component can be defined
   #- class: org.dynmap.ClientComponent
   #  type: logo
@@ -499,3 +499,6 @@ dump-missing-blocks: false
 # your worlds before running with this setting enabled (set to true)
 #
 #migrate-chunks: true
+
+# Disable sanitizing the html code of labels and descriptions of markers. Default is true
+#sanitize-html: true


### PR DESCRIPTION
I added the option to disable the HTML Sanitizer as I have some issues with changing html snippets via the api.
The default behavior is unchanged as the default value is set to "true".

Maybe this should include a check whether the label is markup or not.

It should close https://github.com/webbukkit/dynmap/issues/2288
