### PR TITLE
Prevent updating map while invisible

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/js/map.js
+++ b/DynmapCore/src/main/resources/extracted/web/js/map.js
@@ -636,6 +636,11 @@ DynMap.prototype = {
 	update: function() {
 		var me = this;
 
+		if (document.visibilityState === "hidden") {
+		    setTimeout(function() { me.update(); }, me.options.updaterate);
+			return;
+		}
+
 		$(me).trigger('worldupdating');
 		$.getJSON(me.formatUrl('update', { world: me.world.name, timestamp: me.lasttimestamp, reqid: me.reqid }), function(update) {
 				me.reqid++; // Bump request ID always


### PR DESCRIPTION
Currently, dynmap requests data from the server every second (or whatever is configured) even if the map is not visible (i.e. because the browser tab is not active, the browser is minimized or the device screen is turned off).

I've implemented a check using the [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) in the update method to prevent updating the map while it is not visible.