### PR TITLE
Fix SkinsRestorer API integration

### DIFF
--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compile 'me.lucko.luckperms:luckperms-api:4.3'
     compile 'net.luckperms:api:5.0'
     compile('com.github.MilkBowl:VaultAPI:1.7') { transitive = false }
-    compileOnly 'net.skinsrestorer:skinsrestorer:14.0.0-SNAPSHOT@jar'
+    compileOnly 'net.skinsrestorer:skinsrestorer:14.1.0-SNAPSHOT@jar'
     compile project(":dynmap-api")
     compile project(path: ":DynmapCore", configuration: "shadow")
     compile group: 'ru.tehkode', name: 'PermissionsEx', version: '1.19.1'

--- a/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
@@ -917,10 +917,10 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
                 if (skinsRestorer == null) {
                     Log.warning("SkinsRestorer integration can't be enabled because SkinsRestorer not installed");
                 } else {
-                    skinUrlProvider = new SkinsRestorerSkinUrlProvider(skinsRestorer);
+                    skinUrlProvider = new SkinsRestorerSkinUrlProvider();
                     Log.info("SkinsRestorer API v14 integration enabled");
                 }
-            }catch(NoClassDefFoundError e) {
+            } catch(NoClassDefFoundError e) {
                 Log.warning("You are using unsupported version of SkinsRestorer. Use v14 or newer.");
                 Log.warning("Disabled SkinsRestorer integration for this session");
             }

--- a/spigot/src/main/java/org/dynmap/bukkit/SkinsRestorerSkinUrlProvider.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/SkinsRestorerSkinUrlProvider.java
@@ -17,9 +17,9 @@ public class SkinsRestorerSkinUrlProvider implements SkinUrlProvider {
     private JSONParser mJsonParser;
     private SkinsRestorerAPI mSkinsRestorerApi;
 
-    SkinsRestorerSkinUrlProvider(SkinsRestorer skinsRestorer) {
+    SkinsRestorerSkinUrlProvider() {
         mJsonParser = new JSONParser();
-        mSkinsRestorerApi = skinsRestorer.getSkinsRestorerBukkitAPI();
+        mSkinsRestorerApi = SkinsRestorerAPI.getApi();
     }
 
     @Override


### PR DESCRIPTION
Fixes #3394

The dynmap plugin fetches the `SkinsRestorerAPI` instance using an unsupported method that has been removed in SkinsRestorer v14.1.0. This PR changes that to use the method suggested by the SkinsRestorer devs. It also updates the SR dependency to the latest version See the linked issue for more details.

I've tested this change with SR v14.0.2 and SR v14.1.0 and it works as expected with both versions of SkinsRestorer.

Also SR v14.1.0 will need to be supported at some point because it's the only release of SR that supports MC v1.17.