### PR TITLE
Fix issue with getting the type id of a block

### DIFF
--- a/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
@@ -183,12 +183,17 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
             } catch (NoSuchMethodError e) {
                 // We failed once, no need to retry
                 tryNativeId.set(false);
+            } catch (java.lang.IllegalArgumentException e) {
+                // Ignore this entirely, as modern materials throw
+                // java.lang.IllegalArgumentException: Cannot get ID of Modern Material
             }
         }
 
         // We're living in a world where numerical IDs have been phased out completely.
-        // Let's return *some* number, because we need one
-        return material.ordinal();
+        // Let's return *some* number, because we need one.
+        // Also in that case we are adding a constant to ensure we're not conflicting with the
+        // actual IDs
+        return material.ordinal() + (1 << 20);
     }
     private static final int getBlockIdFromBlock(Block block) {
         return getBlockIdFromMaterial(block.getType());


### PR DESCRIPTION
This is a fix for #3418. The idea is to handle the case of when the the numeric IDs have been removed completely.

Includes some performance optimizations. Also handles the case of new materials not even having an ID.

This is really just a dirty solution.  
Ideally `DynmapServerInterface#getBlockIDAt` gets removed and all comparisons on the Spigot side get done with the Material enum. Removing this method completely should be fine, as it only seems to be used by Forge 1.11 and 1.12 when checking if something is a sign.  
Should that bigger change get approved by the project leads, feel free to reject this change in favor of that removal.

Change has been tested on 1.16.5 and 1.17.1