### PR TITLE
Parse Essentials RGB Hexcode nickname colors

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/Client.java
+++ b/DynmapCore/src/main/java/org/dynmap/Client.java
@@ -226,6 +226,26 @@ public class Client {
                         break;
                     }
                 }
+                else if (c == 'x') { // Essentials nickname hexcode format
+                    if (i + 12 <= cnt){ // Check if string is at least long enough to be valid hexcode
+                        if (s.charAt(i+1) == s.charAt(i+3) &&
+                            s.charAt(i+1) == s.charAt(i+5) &&
+                            s.charAt(i+1) == s.charAt(i+7) &&
+                            s.charAt(i+1) == s.charAt(i+9) &&
+                            s.charAt(i+1) == s.charAt(i+11) && // Check if there are enough § in a row
+                            s.charAt(i+1) == '\u00A7'){ 
+                                StringBuilder hex = new StringBuilder().append(s.charAt(i+2))
+                                                                        .append(s.charAt(i+4))
+                                                                        .append(s.charAt(i+6))
+                                                                        .append(s.charAt(i+8))
+                                                                        .append(s.charAt(i+10))
+                                                                        .append(s.charAt(i+12)); // Build hexcode string
+                                sb.append("<span style=\'color:#" + hex + "\'>"); // Substitute with hexcode
+                            i = i + 12; //move past hex codes
+                        }
+                    }
+                    break;
+                }
             }
             else if (c == '&') {    // Essentials color code?
                 i++;    // Move past it


### PR DESCRIPTION
Essentials nicknames using RGB hex values end up in the format `§x§R§R§G§G§B§B`. For example, a hex color code of #1A2B3C will be formatted as `§x§1§A§2§B§3§C`.
This PR checks for the §x and then builds the hexcode from the next 6 values behind § to properly display the nickname