### PR TITLE
chore: run formatter tools against PHP code

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/gettiles.php
+++ b/DynmapCore/src/main/resources/extracted/web/gettiles.php
@@ -1,21 +1,22 @@
 <?php
-define ('TILESPATH', 'tiles/');
+
+define('TILESPATH', 'tiles/');
 
 $path = $_SERVER['PATH_INFO'];
 
 $fname = TILESPATH . $path;
 
 if (!file_exists($fname)) {
-  $fname = "images/blank.png";
+    $fname = "images/blank.png";
 }
 $fp = fopen($fname, 'rb');
-if (strstr($path, ".png"))
-  header("Content-Type: image/png");
-else
-  header("Content-Type: image/jpeg");
+if (strstr($path, ".png")) {
+    header("Content-Type: image/png");
+} else {
+    header("Content-Type: image/jpeg");
+}
 
 header("Content-Length: " . filesize($fname));
 
 fpassthru($fp);
 exit;
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_access.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_access.php
@@ -1,8 +1,8 @@
 <?php
-require_once('MySQL_funcs.php');
+
+require_once 'MySQL_funcs.php';
 
 if ($loginenabled) {
     $rslt = getStandaloneFile('dynmap_access.php');
-	eval($rslt);
+    eval($rslt);
 }
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_configuration.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_configuration.php
@@ -1,22 +1,22 @@
 <?php
+
 ob_start();
-require_once('MySQL_funcs.php');
-include('MySQL_config.php');
-include('MySQL_access.php');
+require_once 'MySQL_funcs.php';
+require 'MySQL_config.php';
+require 'MySQL_access.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 $content = getStandaloneFile('dynmap_config.json');
@@ -26,53 +26,45 @@ header('Content-type: application/json; charset=utf-8');
 $json = json_decode($content);
 
 if (!$loginenabled) {
-	echo $content;
-}
-else if($json->loginrequired && !$loggedin) {
+    echo $content;
+} elseif ($json->loginrequired && !$loggedin) {
     echo "{ \"error\": \"login-required\" }";
-}
-else {
-	$uid = '[' . strtolower($userid) . ']';
-	$json->loggedin = $loggedin;
-	$wcnt = count($json->worlds);
-	$newworlds = array();
-	for($i = 0; $i < $wcnt; $i++) {
-		$w = $json->worlds[$i];
-		if($w->protected) {
-		    $ss = stristr($worldaccess[$w->name], $uid);
-			if($ss !== false) {
-				$newworlds[] = $w;
-			}
-			else {
-				$w = null;
-			}
-		}
-		else {
-			$newworlds[] = $w;
-		}
-		if($w != null) {
-			$mcnt = count($w->maps);
-			$newmaps = array();
-			for($j = 0; $j < $mcnt; $j++) {
-				$m = $w->maps[$j];
-				if($m->protected) {
-				    $ss = stristr($mapaccess[$w->name . '.' . $m->prefix], $uid);
-					if($ss !== false) {
-						$newmaps[] = $m;
-					}
-				}
-				else {
-					$newmaps[] = $m;
-				}
-			}
-			$w->maps = $newmaps;		
-		}
-	}
-	$json->worlds = $newworlds;
-	
-	echo json_encode($json);
+} else {
+    $uid = '[' . strtolower($userid) . ']';
+    $json->loggedin = $loggedin;
+    $wcnt = count($json->worlds);
+    $newworlds = array();
+    for ($i = 0; $i < $wcnt; $i++) {
+        $w = $json->worlds[$i];
+        if ($w->protected) {
+            $ss = stristr($worldaccess[$w->name], $uid);
+            if ($ss !== false) {
+                $newworlds[] = $w;
+            } else {
+                $w = null;
+            }
+        } else {
+            $newworlds[] = $w;
+        }
+        if ($w != null) {
+            $mcnt = count($w->maps);
+            $newmaps = array();
+            for ($j = 0; $j < $mcnt; $j++) {
+                $m = $w->maps[$j];
+                if ($m->protected) {
+                    $ss = stristr($mapaccess[$w->name . '.' . $m->prefix], $uid);
+                    if ($ss !== false) {
+                        $newmaps[] = $m;
+                    }
+                } else {
+                    $newmaps[] = $m;
+                }
+            }
+            $w->maps = $newmaps;
+        }
+    }
+    $json->worlds = $newworlds;
+
+    echo json_encode($json);
 }
 cleanupDb();
- 
-?>
-

--- a/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_funcs.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_funcs.php
@@ -1,115 +1,121 @@
 <?php
 
-function cleanupDb() {
-   if (isset($db)) {
-      $db->close();
-      $db = NULL;
-   }
+function cleanupDb()
+{
+    if (isset($db)) {
+        $db->close();
+        $db = null;
+    }
 }
 
-function abortDb($errormsg) {
-   header('HTTP/1.0 500 Error');
-   echo "<h1>500 Error</h1>";
-   echo $errormsg;
-   cleanupDb();
-   exit;
+function abortDb($errormsg)
+{
+    header('HTTP/1.0 500 Error');
+    echo "<h1>500 Error</h1>";
+    echo $errormsg;
+    cleanupDb();
+    exit;
 }
 
-function initDbIfNeeded() {
-   global $db, $dbhost, $dbuserid, $dbpassword, $dbname, $dbport;
-   
-   $pos = strpos($dbname, '?');
+function initDbIfNeeded()
+{
+    global $db, $dbhost, $dbuserid, $dbpassword, $dbname, $dbport;
 
-   if ($pos) {
-      $dbname = substr($dbname, 0, $pos);
-   }
-   
-   if (!$db) {
-      $db = mysqli_connect('p:' . $dbhost, $dbuserid, $dbpassword, $dbname, $dbport);
-      if (mysqli_connect_errno()) {
-         abortDb("Error opening database");
-	  }
-   }
+    $pos = strpos($dbname, '?');
+
+    if ($pos) {
+        $dbname = substr($dbname, 0, $pos);
+    }
+
+    if (!$db) {
+        $db = mysqli_connect('p:' . $dbhost, $dbuserid, $dbpassword, $dbname, $dbport);
+        if (mysqli_connect_errno()) {
+            abortDb("Error opening database");
+        }
+    }
 }
 
-function getStandaloneFileByServerId($fname, $sid) {
-   global $db, $dbprefix;
-   
-   initDbIfNeeded();
-   $stmt = $db->prepare('SELECT Content from ' . $dbprefix . 'StandaloneFiles WHERE FileName=? AND ServerID=?');
-   $stmt->bind_param('si', $fname, $sid);
-   $res = $stmt->execute();
-   $stmt->store_result();
-   $stmt->bind_result($content);
-   if ($stmt->fetch()) {
+function getStandaloneFileByServerId($fname, $sid)
+{
+    global $db, $dbprefix;
+
+    initDbIfNeeded();
+    $stmt = $db->prepare('SELECT Content from ' . $dbprefix . 'StandaloneFiles WHERE FileName=? AND ServerID=?');
+    $stmt->bind_param('si', $fname, $sid);
+    $res = $stmt->execute();
+    $stmt->store_result();
+    $stmt->bind_result($content);
+    if ($stmt->fetch()) {
         $rslt = $content;
-   }
-   else {
-        $rslt = NULL;
-   }
-   $stmt->close();	
-   return $rslt;
+    } else {
+        $rslt = null;
+    }
+    $stmt->close();
+    return $rslt;
 }
 
-function getStandaloneFile($fname) {
-   global $serverid;
-   
-   if (!isset($serverid)) {
-      $serverid = 0;
-      if(isset($_REQUEST['serverid'])) {
-         $serverid = $_REQUEST['serverid'];
-      }
-   }
-   return getStandaloneFileByServerId($fname, $serverid);
+function getStandaloneFile($fname)
+{
+    global $serverid;
+
+    if (!isset($serverid)) {
+        $serverid = 0;
+        if (isset($_REQUEST['serverid'])) {
+            $serverid = $_REQUEST['serverid'];
+        }
+    }
+    return getStandaloneFileByServerId($fname, $serverid);
 }
 
-function updateStandaloneFileByServerId($fname, $sid, $content) {
-   global $db, $dbprefix;
-   
-   initDbIfNeeded();
-   $stmt = $db->prepare('UPDATE ' . $dbprefix . 'StandaloneFiles SET Content=? WHERE FileName=? AND ServerID=?');
-   $stmt->bind_param('ssi', $content, $fname, $sid);
-   $res = $stmt->execute();
-   $stmt->close();
-   if (!$res) {
-      $res = insertStandaloneFileByServerId($fname, $sid, $content);
-   }
-   return $res;
+function updateStandaloneFileByServerId($fname, $sid, $content)
+{
+    global $db, $dbprefix;
+
+    initDbIfNeeded();
+    $stmt = $db->prepare('UPDATE ' . $dbprefix . 'StandaloneFiles SET Content=? WHERE FileName=? AND ServerID=?');
+    $stmt->bind_param('ssi', $content, $fname, $sid);
+    $res = $stmt->execute();
+    $stmt->close();
+    if (!$res) {
+        $res = insertStandaloneFileByServerId($fname, $sid, $content);
+    }
+    return $res;
 }
 
-function updateStandaloneFile($fname, $content) {
-   global $serverid;
-   
-   if (!isset($serverid)) {
-      $serverid = 0;
-      if(isset($_REQUEST['serverid'])) {
-         $serverid = $_REQUEST['serverid'];
-      }
-   }
-   return updateStandaloneFileByServerId($fname, $serverid, $content);
+function updateStandaloneFile($fname, $content)
+{
+    global $serverid;
+
+    if (!isset($serverid)) {
+        $serverid = 0;
+        if (isset($_REQUEST['serverid'])) {
+            $serverid = $_REQUEST['serverid'];
+        }
+    }
+    return updateStandaloneFileByServerId($fname, $serverid, $content);
 }
 
-function insertStandaloneFileByServerId($fname, $sid, $content) {
-   global $db, $dbprefix;
-   
-   initDbIfNeeded();
-   $stmt = $db->prepare('INSERT INTO ' . $dbprefix . 'StandaloneFiles (Content,FileName,ServerID) VALUES (?,?,?);');
-   $stmt->bind_param('ssi', $content, $fname, $sid);
-   $res = $stmt->execute();
-   $stmt->close();
-   return $res;
+function insertStandaloneFileByServerId($fname, $sid, $content)
+{
+    global $db, $dbprefix;
+
+    initDbIfNeeded();
+    $stmt = $db->prepare('INSERT INTO ' . $dbprefix . 'StandaloneFiles (Content,FileName,ServerID) VALUES (?,?,?);');
+    $stmt->bind_param('ssi', $content, $fname, $sid);
+    $res = $stmt->execute();
+    $stmt->close();
+    return $res;
 }
 
-function insertStandaloneFile($fname, $content) {
-   global $serverid;
-   
-   if (!isset($serverid)) {
-      $serverid = 0;
-      if(isset($_REQUEST['serverid'])) {
-         $serverid = $_REQUEST['serverid'];
-      }
-   }
-   return insertStandaloneFileByServerId($fname, $serverid, $content);
-}
+function insertStandaloneFile($fname, $content)
+{
+    global $serverid;
 
-?>
+    if (!isset($serverid)) {
+        $serverid = 0;
+        if (isset($_REQUEST['serverid'])) {
+            $serverid = $_REQUEST['serverid'];
+        }
+    }
+    return insertStandaloneFileByServerId($fname, $serverid, $content);
+}

--- a/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_getlogin.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_getlogin.php
@@ -1,8 +1,8 @@
 <?php
-require_once('MySQL_funcs.php');
+
+require_once 'MySQL_funcs.php';
 
 if ($loginenabled) {
     $rslt = getStandaloneFile("dynmap_login.php");
-	eval($rslt);
+    eval($rslt);
 }
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_login.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_login.php
@@ -1,75 +1,69 @@
 <?php
+
 ob_start();
-require_once('MySQL_funcs.php');
-include('MySQL_config.php');
-include('MySQL_getlogin.php');
+require_once 'MySQL_funcs.php';
+require 'MySQL_config.php';
+require 'MySQL_getlogin.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_POST['j_username'])) {
-  $userid = $_POST['j_username'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_POST['j_username'])) {
+    $userid = $_POST['j_username'];
+} else {
+    $userid = '-guest-';
 }
 $good = false;
 
-if(strcmp($userid, '-guest-')) {
-  if(isset($_POST['j_password'])) {
-    $password = $_POST['j_password'];
-  }
-  else {
-    $password = '';
-  }
-  $ctx = hash_init('sha256');
-  hash_update($ctx, $pwdsalt);
-  hash_update($ctx, $password);
-  $hash = hash_final($ctx);
-  $useridlc = strtolower($userid);
-  if (strcasecmp($hash, $pwdhash[$useridlc]) == 0) {
-     $_SESSION['userid'] = $userid;
-     $good = true; 
-  }
-  else {
-     $_SESSION['userid'] = '-guest-';
-  }
-}
-else {
-  $_SESSION['userid'] = '-guest-';
-  $good = true;
+if (strcmp($userid, '-guest-')) {
+    if (isset($_POST['j_password'])) {
+        $password = $_POST['j_password'];
+    } else {
+        $password = '';
+    }
+    $ctx = hash_init('sha256');
+    hash_update($ctx, $pwdsalt);
+    hash_update($ctx, $password);
+    $hash = hash_final($ctx);
+    $useridlc = strtolower($userid);
+    if (strcasecmp($hash, $pwdhash[$useridlc]) == 0) {
+        $_SESSION['userid'] = $userid;
+        $good = true;
+    } else {
+        $_SESSION['userid'] = '-guest-';
+    }
+} else {
+    $_SESSION['userid'] = '-guest-';
+    $good = true;
 }
 $content = getStandaloneFile('dynmap_reg.php');
 
 /* Prune pending registrations, if needed */
 $lines = explode('\n', $content);
 $newlines[] = array();
-if(!empty($lines)) {
-	$cnt = count($lines) - 1;
-	$changed = false;
-	for($i=1; $i < $cnt; $i++) {
-		list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
-		if($uid == $useridlc) continue;
-		if(array_key_exists($uid, $pendingreg)) {
-			$newlines[] = $uid . '=' . $pc . '=' . $hsh;
-		}
-		else {
-			$changed = true;
-		}
-	}
-	if($changed) {
+if (!empty($lines)) {
+    $cnt = count($lines) - 1;
+    $changed = false;
+    for ($i = 1; $i < $cnt; $i++) {
+        list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
+        if ($uid == $useridlc) {
+            continue;
+        }
+        if (array_key_exists($uid, $pendingreg)) {
+            $newlines[] = $uid . '=' . $pc . '=' . $hsh;
+        } else {
+            $changed = true;
+        }
+    }
+    if ($changed) {
         updateStandaloneFile('dynmap_reg.php', implode("\n", $newlines));
-	}
+    }
 }
 
-if($good) {
-   echo "{ \"result\": \"success\" }"; 
-}
-else {
-   echo "{ \"result\": \"loginfailed\" }"; 
+if ($good) {
+    echo "{ \"result\": \"success\" }";
+} else {
+    echo "{ \"result\": \"loginfailed\" }";
 }
 
 cleanupDb();
- 
-?>
-

--- a/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_markers.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_markers.php
@@ -1,22 +1,22 @@
 <?php
+
 ob_start();
-require_once('MySQL_funcs.php');
-include('MySQL_config.php');
-include('MySQL_access.php');
+require_once 'MySQL_funcs.php';
+require 'MySQL_config.php';
+require 'MySQL_access.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 $path = $_REQUEST['marker'];
@@ -29,7 +29,7 @@ if ((!isset($path)) || strstr($path, "..")) {
 
 $parts = explode("/", $path);
 
-if(($parts[0] != "faces") && ($parts[0] != "_markers_")) {
+if (($parts[0] != "faces") && ($parts[0] != "_markers_")) {
     header('HTTP/1.0 500 Error');
     echo "<h1>500 Error</h1>";
     echo "Bad marker: " . $path;
@@ -39,70 +39,62 @@ if(($parts[0] != "faces") && ($parts[0] != "_markers_")) {
 initDbIfNeeded();
 
 if ($parts[0] == "faces") {
-	if (count($parts) != 3) {
-	    header('HTTP/1.0 500 Error');
-    	echo "<h1>500 Error</h1>";
-    	echo "Bad face: " . $path;
-    	cleanupDb();
-    	exit();
-	}
-	$ft = 0;
-	if ($parts[1] == "8x8") {
-		$ft = 0;
-	}
-	else if ($parts[1] == '16x16') {
-	    $ft = 1;
-   	}
-   	else if ($parts[1] == '32x32') {
-   	    $ft = 2;
-	}
-	else if ($parts[1] == 'body') {
-		$ft = 3;
-	}
-	$pn = explode(".", $parts[2]);
-	$stmt = $db->prepare('SELECT Image from ' . $dbprefix . 'Faces WHERE PlayerName=? AND TypeID=?');
-	$stmt->bind_param('si', $pn[0], $ft);
-	$res = $stmt->execute();
-	$stmt->bind_result($timage);
-	if ($stmt->fetch()) {
-      header('Content-Type: image/png');
-	  echo $timage;
-	}
-	else {
-		header('Location: ../images/blank.png');
-	}
-}
-else { // _markers_
-	$in = explode(".", $parts[1]);
-	$name = implode(".", array_slice($in, 0, count($in) - 1));
-	$ext = $in[count($in) - 1];
-	if (($ext == "json") && (strpos($name, "marker_") == 0)) {
-		$world = substr($name, 7);
-		$stmt = $db->prepare('SELECT Content from ' . $dbprefix . 'MarkerFiles WHERE FileName=?');
-		$stmt->bind_param('s', $world);
-		$res = $stmt->execute();
-		$stmt->bind_result($timage);
-  		header('Content-Type: application/json');
-		if ($stmt->fetch()) {
-			echo $timage;
-		}
-		else {
-			echo "{ }";
-		}
-	}
-	else {
-		$stmt = $db->prepare('SELECT Image from ' . $dbprefix . 'MarkerIcons WHERE IconName=?');
-		$stmt->bind_param('s', $name);
-		$res = $stmt->execute();
-		$stmt->bind_result($timage);
-		if ($stmt->fetch()) {
-      		header('Content-Type: image/png');
-			echo $timage;
-		}
-		else {
-			header('Location: ../images/blank.png');
-		}
-	}
+    if (count($parts) != 3) {
+        header('HTTP/1.0 500 Error');
+        echo "<h1>500 Error</h1>";
+        echo "Bad face: " . $path;
+        cleanupDb();
+        exit();
+    }
+    $ft = 0;
+    if ($parts[1] == "8x8") {
+        $ft = 0;
+    } elseif ($parts[1] == '16x16') {
+        $ft = 1;
+    } elseif ($parts[1] == '32x32') {
+        $ft = 2;
+    } elseif ($parts[1] == 'body') {
+        $ft = 3;
+    }
+    $pn = explode(".", $parts[2]);
+    $stmt = $db->prepare('SELECT Image from ' . $dbprefix . 'Faces WHERE PlayerName=? AND TypeID=?');
+    $stmt->bind_param('si', $pn[0], $ft);
+    $res = $stmt->execute();
+    $stmt->bind_result($timage);
+    if ($stmt->fetch()) {
+        header('Content-Type: image/png');
+        echo $timage;
+    } else {
+        header('Location: ../images/blank.png');
+    }
+} else { // _markers_
+    $in = explode(".", $parts[1]);
+    $name = implode(".", array_slice($in, 0, count($in) - 1));
+    $ext = $in[count($in) - 1];
+    if (($ext == "json") && (strpos($name, "marker_") == 0)) {
+        $world = substr($name, 7);
+        $stmt = $db->prepare('SELECT Content from ' . $dbprefix . 'MarkerFiles WHERE FileName=?');
+        $stmt->bind_param('s', $world);
+        $res = $stmt->execute();
+        $stmt->bind_result($timage);
+        header('Content-Type: application/json');
+        if ($stmt->fetch()) {
+            echo $timage;
+        } else {
+            echo "{ }";
+        }
+    } else {
+        $stmt = $db->prepare('SELECT Image from ' . $dbprefix . 'MarkerIcons WHERE IconName=?');
+        $stmt->bind_param('s', $name);
+        $res = $stmt->execute();
+        $stmt->bind_result($timage);
+        if ($stmt->fetch()) {
+            header('Content-Type: image/png');
+            echo $timage;
+        } else {
+            header('Location: ../images/blank.png');
+        }
+    }
 }
 
 $stmt->close();
@@ -110,4 +102,3 @@ $stmt->close();
 cleanupDb();
 
 exit;
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_register.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_register.php
@@ -1,40 +1,37 @@
 <?php
+
 ob_start();
-require_once('MySQL_funcs.php');
-include('MySQL_config.php');
-require('MySQL_getlogin.php');
+require_once 'MySQL_funcs.php';
+require 'MySQL_config.php';
+require 'MySQL_getlogin.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_POST['j_password'])) {
-  $password = $_POST['j_password'];
+if (isset($_POST['j_password'])) {
+    $password = $_POST['j_password'];
+} else {
+    $password = '';
 }
-else {
-  $password = '';
+if (isset($_POST['j_verify_password'])) {
+    $verify = $_POST['j_verify_password'];
+} else {
+    $verify = '';
 }
-if(isset($_POST['j_verify_password'])) {
-  $verify = $_POST['j_verify_password'];
-}
-else {
-  $verify = '';
-}
-if(strcmp($password, $verify)) {
-  echo "{ \"result\": \"verifyfailed\" }"; 
-  return;
+if (strcmp($password, $verify)) {
+    echo "{ \"result\": \"verifyfailed\" }";
+    return;
 }
 
-if(isset($_POST['j_username'])) {
-  $userid = $_POST['j_username'];
+if (isset($_POST['j_username'])) {
+    $userid = $_POST['j_username'];
+} else {
+    $userid = '-guest-';
 }
-else {
-  $userid = '-guest-';
-}
-if(isset($_POST['j_passcode'])) {
-  $passcode = $_POST['j_passcode'];
-}
-else {
-  $passcode = '';
+if (isset($_POST['j_passcode'])) {
+    $passcode = $_POST['j_passcode'];
+} else {
+    $passcode = '';
 }
 $good = false;
 
@@ -44,51 +41,48 @@ $_SESSION['userid'] = '-guest-';
 
 $good = false;
 
-if(strcmp($useridlc, '-guest-')) {
-  if(isset($pendingreg[$useridlc])) {
-     if(!strcmp($passcode, $pendingreg[$useridlc])) {
-        $ctx = hash_init('sha256');
-        hash_update($ctx, $pwdsalt);
-        hash_update($ctx, $password);
-        $hash = hash_final($ctx);
-        $_SESSION['userid'] = $userid;
-        $good = true;
-		$newlines[] = array();
-		$content = getStandaloneFile('dynmap_reg.php');
-		if (isset($content)) {
-		    $lines = explode('\n', $content);
-		    $isnew = false;
-		}
-		else {
-		    $lines = array();
-		    $isnew = true;
-		}
-		if(!empty($lines)) {
-			$cnt = count($lines) - 1;
-			for($i=1; $i < $cnt; $i++) {
-				list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
-				if($uid == $useridlc) continue;
-				if(array_key_exists($uid, $pendingreg)) {
-					$newlines[] = $uid . '=' . $pc . '=' . $hsh;
-				}
-			}
-		}
-		$newlines[] = $useridlc . '=' . $passcode . '=' . $hash;
-		if ($isnew) {
-			insertStandaloneFile('dynmap_reg.php', implode("\n", $newlines));
-		}
-		else {		
-			updateStandaloneFile('dynmap_reg.php', implode("\n", $newlines));
-		}
-     }
-  }
+if (strcmp($useridlc, '-guest-')) {
+    if (isset($pendingreg[$useridlc])) {
+        if (!strcmp($passcode, $pendingreg[$useridlc])) {
+            $ctx = hash_init('sha256');
+            hash_update($ctx, $pwdsalt);
+            hash_update($ctx, $password);
+            $hash = hash_final($ctx);
+            $_SESSION['userid'] = $userid;
+            $good = true;
+            $newlines[] = array();
+            $content = getStandaloneFile('dynmap_reg.php');
+            if (isset($content)) {
+                $lines = explode('\n', $content);
+                $isnew = false;
+            } else {
+                $lines = array();
+                $isnew = true;
+            }
+            if (!empty($lines)) {
+                $cnt = count($lines) - 1;
+                for ($i = 1; $i < $cnt; $i++) {
+                    list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
+                    if ($uid == $useridlc) {
+                        continue;
+                    }
+                    if (array_key_exists($uid, $pendingreg)) {
+                        $newlines[] = $uid . '=' . $pc . '=' . $hsh;
+                    }
+                }
+            }
+            $newlines[] = $useridlc . '=' . $passcode . '=' . $hash;
+            if ($isnew) {
+                insertStandaloneFile('dynmap_reg.php', implode("\n", $newlines));
+            } else {
+                updateStandaloneFile('dynmap_reg.php', implode("\n", $newlines));
+            }
+        }
+    }
 }
-if($good) {
-   echo "{ \"result\": \"success\" }"; 
-}
-else {
-   echo "{ \"result\": \"registerfailed\" }"; 
+if ($good) {
+    echo "{ \"result\": \"success\" }";
+} else {
+    echo "{ \"result\": \"registerfailed\" }";
 }
 cleanupDb();
-   
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_sendmessage.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_sendmessage.php
@@ -1,75 +1,69 @@
 <?php
+
 ob_start();
-require_once('MySQL_funcs.php');
-include('MySQL_config.php');
+require_once 'MySQL_funcs.php';
+require 'MySQL_config.php';
 ob_end_clean();
 
 session_start();
 
 $content = getStandaloneFile('dynmap_config.json');
 if (isset($content)) {
-   $config = json_decode($content, true);
-   $msginterval = $config['webchat-interval'];
-}
-else {
-   $msginterval = 2000;
+    $config = json_decode($content, true);
+    $msginterval = $config['webchat-interval'];
+} else {
+    $msginterval = 2000;
 }
 
-if(isset($_SESSION['lastchat']))
+if (isset($_SESSION['lastchat'])) {
     $lastchat = $_SESSION['lastchat'];
-else
+} else {
     $lastchat = 0;
-
-if($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat < time())
-{
-	$micro = microtime(true);
-	$timestamp = round($micro*1000.0);
-	
-	$data = json_decode(trim(file_get_contents('php://input')));
-	$data->timestamp = $timestamp;
-	$data->ip = $_SERVER['REMOTE_ADDR'];
-	if(isset($_SESSION['userid'])) {
-		$uid = $_SESSION['userid'];
-		if(strcmp($uid, '-guest-')) {
-		   $data->userid = $uid;
-		}
-	}
-	if(isset($_SERVER['HTTP_X_FORWARDED_FOR']))
-		$data->ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
-	$content = getStandaloneFile('dynmap_webchat.json');
-	$gotold = false;
-	if (isset($content)) {
-		$old_messages = json_decode($content, true);
-		$gotold = true;
-	}
-	
-	if(!empty($old_messages))
-	{
-		foreach($old_messages as $message)
-		{
-			if(($timestamp - $config['updaterate'] - 10000) < $message['timestamp'])
-				$new_messages[] = $message;
-		}
-	}
-	$new_messages[] = $data;
-
-	if ($gotold) {
-	    updateStandaloneFile('dynmap_webchat.json', json_encode($new_messages));
-	}
-	else {
-	    insertStandaloneFile('dynmap_webchat.json', json_encode($new_messages));
-	}
-	
-	$_SESSION['lastchat'] = time()+$msginterval;
-	echo "{ \"error\" : \"none\" }";
 }
-elseif($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat > time())
-{
-	header('HTTP/1.1 403 Forbidden');
-}
-else {
-	echo "{ \"error\" : \"none\" }";
+
+if ($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat < time()) {
+    $micro = microtime(true);
+    $timestamp = round($micro * 1000.0);
+
+    $data = json_decode(trim(file_get_contents('php://input')));
+    $data->timestamp = $timestamp;
+    $data->ip = $_SERVER['REMOTE_ADDR'];
+    if (isset($_SESSION['userid'])) {
+        $uid = $_SESSION['userid'];
+        if (strcmp($uid, '-guest-')) {
+            $data->userid = $uid;
+        }
+    }
+    if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+        $data->ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+    }
+    $content = getStandaloneFile('dynmap_webchat.json');
+    $gotold = false;
+    if (isset($content)) {
+        $old_messages = json_decode($content, true);
+        $gotold = true;
+    }
+
+    if (!empty($old_messages)) {
+        foreach ($old_messages as $message) {
+            if (($timestamp - $config['updaterate'] - 10000) < $message['timestamp']) {
+                $new_messages[] = $message;
+            }
+        }
+    }
+    $new_messages[] = $data;
+
+    if ($gotold) {
+        updateStandaloneFile('dynmap_webchat.json', json_encode($new_messages));
+    } else {
+        insertStandaloneFile('dynmap_webchat.json', json_encode($new_messages));
+    }
+
+    $_SESSION['lastchat'] = time() + $msginterval;
+    echo "{ \"error\" : \"none\" }";
+} elseif ($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat > time()) {
+    header('HTTP/1.1 403 Forbidden');
+} else {
+    echo "{ \"error\" : \"none\" }";
 }
 cleanupDb();
-
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_tiles.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_tiles.php
@@ -1,22 +1,22 @@
 <?php
+
 ob_start();
-require_once('MySQL_funcs.php');
-include('MySQL_config.php');
-include('MySQL_access.php');
+require_once 'MySQL_funcs.php';
+require 'MySQL_config.php';
+require 'MySQL_access.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 $path = $_REQUEST['tile'];
@@ -30,56 +30,54 @@ if ((!isset($path)) || strstr($path, "..")) {
 $parts = explode("/", $path);
 
 if (count($parts) != 4) {
-   header('Location: ../images/blank.png');
-   cleanupDb();
-   exit;
+    header('Location: ../images/blank.png');
+    cleanupDb();
+    exit;
 }
- 
+
 $uid = '[' . strtolower($userid) . ']';
 
 $world = $parts[0];
 
-if(isset($worldaccess[$world])) {
+if (isset($worldaccess[$world])) {
     $ss = stristr($worldaccess[$world], $uid);
-	if($ss === false) {
-           header('Location: ../images/blank.png');
-           cleanupDb();
-           exit;
-	}
+    if ($ss === false) {
+        header('Location: ../images/blank.png');
+        cleanupDb();
+        exit;
+    }
 }
-$variant='STANDARD';
+$variant = 'STANDARD';
 
-  $prefix = $parts[1];
-  $plen = strlen($prefix);
-  if(($plen > 4) && (substr($prefix, $plen - 4) === "_day")) {
-	$prefix = substr($prefix, 0, $plen - 4);
-        $variant = 'DAY';
-  }
-  $mapid = $world . "." . $prefix;
-  if(isset($mapaccess[$mapid])) {
+$prefix = $parts[1];
+$plen = strlen($prefix);
+if (($plen > 4) && (substr($prefix, $plen - 4) === "_day")) {
+    $prefix = substr($prefix, 0, $plen - 4);
+    $variant = 'DAY';
+}
+$mapid = $world . "." . $prefix;
+if (isset($mapaccess[$mapid])) {
     $ss = stristr($mapaccess[$mapid], $uid);
-	if($ss === false) {
-           header('Location: ../images/blank.png');
-           cleanupDb();
-           exit;
-	}
-  }
+    if ($ss === false) {
+        header('Location: ../images/blank.png');
+        cleanupDb();
+        exit;
+    }
+}
 
 $fparts = explode("_", $parts[3]);
 if (count($fparts) == 3) { // zoom_x_y
-   $zoom = strlen($fparts[0]);
-   $x = intval($fparts[1]);
-   $y = intval($fparts[2]);
-}
-else if (count($fparts) == 2) { // x_y
-   $zoom = 0;
-   $x = intval($fparts[0]);
-   $y = intval($fparts[1]);
-}
-else {
-   header('Location: ../images/blank.png');
-   cleanupDb();
-   exit;
+    $zoom = strlen($fparts[0]);
+    $x = intval($fparts[1]);
+    $y = intval($fparts[2]);
+} elseif (count($fparts) == 2) { // x_y
+    $zoom = 0;
+    $x = intval($fparts[0]);
+    $y = intval($fparts[1]);
+} else {
+    header('Location: ../images/blank.png');
+    cleanupDb();
+    exit;
 }
 initDbIfNeeded();
 
@@ -88,22 +86,19 @@ $stmt->bind_param('sssiii', $world, $prefix, $variant, $x, $y, $zoom);
 $res = $stmt->execute();
 $stmt->bind_result($timage, $format, $thash, $tlast);
 if ($stmt->fetch()) {
-   if ($format == 0) {
-      header('Content-Type: image/png');
-   }
-   else {
-      header('Content-Type: image/jpeg');
-   }
-   header('ETag: \'' . $thash . '\'');
-   header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $tlast/1000) . ' GMT'); 
-   echo $timage;
-}
-else {
-   header('Location: ../images/blank.png');
+    if ($format == 0) {
+        header('Content-Type: image/png');
+    } else {
+        header('Content-Type: image/jpeg');
+    }
+    header('ETag: \'' . $thash . '\'');
+    header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $tlast / 1000) . ' GMT');
+    echo $timage;
+} else {
+    header('Location: ../images/blank.png');
 }
 
 $stmt->close();
 cleanupDb();
 
 exit;
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_update.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_update.php
@@ -1,52 +1,53 @@
 <?php
+
 ob_start();
-require_once('MySQL_funcs.php');
-include('MySQL_config.php');
-include('MySQL_access.php');
+require_once 'MySQL_funcs.php';
+require 'MySQL_config.php';
+require 'MySQL_access.php';
 ob_end_clean();
 
 $world = $_REQUEST['world'];
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 header('Content-type: application/json; charset=utf-8');
 
-if(strpos($world, '/') || strpos($world, '\\')) {
+if (strpos($world, '/') || strpos($world, '\\')) {
     echo "{ \"error\": \"invalid-world\" }";
     return;
 }
 
-if ($loginenabled)
-	$fname = 'updates_' . $world . '.php';
-else
-	$fname = 'updates_' . $world . '.json';
+if ($loginenabled) {
+    $fname = 'updates_' . $world . '.php';
+} else {
+    $fname = 'updates_' . $world . '.json';
+}
 
 $useridlc = strtolower($userid);
 $uid = '[' . $useridlc . ']';
 
-if(isset($worldaccess[$world])) {
+if (isset($worldaccess[$world])) {
     $ss = stristr($worldaccess[$world], $uid);
-	if($ss === false) {
-	    echo "{ \"error\": \"access-denied\" }";
-		return;
-	}
+    if ($ss === false) {
+        echo "{ \"error\": \"access-denied\" }";
+        return;
+    }
 }
 
 $serverid = 0;
-if(isset($_REQUEST['serverid'])) {
-  $serverid = $_REQUEST['serverid'];
+if (isset($_REQUEST['serverid'])) {
+    $serverid = $_REQUEST['serverid'];
 }
 
 $content = getStandaloneFile('dynmap_' . $world . '.json');
@@ -60,48 +61,41 @@ if (!isset($content)) {
 
 
 if (!$loginenabled) {
-	echo $content;
-}
-else if(isset($json->loginrequired) && $json->loginrequired && !$loggedin) {
+    echo $content;
+} elseif (isset($json->loginrequired) && $json->loginrequired && !$loggedin) {
     echo "{ \"error\": \"login-required\" }";
-}
-else {
-	$json = json_decode($content);
-	$json->loggedin = $loggedin;
-	if (isset($json->protected) && $json->protected) {
-	    $ss = stristr($seeallmarkers, $uid);
-		if($ss === false) {
-			if(isset($playervisible[$useridlc])) {
-				$plist = $playervisible[$useridlc];
-				$pcnt = count($json->players);
-				for($i = 0; $i < $pcnt; $i++) {
-					$p = $json->players[$i];
-					if(!stristr($plist, '[' . $p->account . ']')) { 
-						$p->world = "-some-other-bogus-world-";
-						$p->x = 0.0;
-						$p->y = 64.0;
-						$p->z = 0.0;
-					}
-				}
-			}
-			else {
-				$pcnt = count($json->players);
-				for($i = 0; $i < $pcnt; $i++) {
-					$p = $json->players[$i];
-					if(strcasecmp($userid, $p->account) != 0) {
-						$p->world = "-some-other-bogus-world-";
-						$p->x = 0.0;
-						$p->y = 64.0;
-						$p->z = 0.0;
-					}
-				}
-			}
-		}
-	}
-	echo json_encode($json);
+} else {
+    $json = json_decode($content);
+    $json->loggedin = $loggedin;
+    if (isset($json->protected) && $json->protected) {
+        $ss = stristr($seeallmarkers, $uid);
+        if ($ss === false) {
+            if (isset($playervisible[$useridlc])) {
+                $plist = $playervisible[$useridlc];
+                $pcnt = count($json->players);
+                for ($i = 0; $i < $pcnt; $i++) {
+                    $p = $json->players[$i];
+                    if (!stristr($plist, '[' . $p->account . ']')) {
+                        $p->world = "-some-other-bogus-world-";
+                        $p->x = 0.0;
+                        $p->y = 64.0;
+                        $p->z = 0.0;
+                    }
+                }
+            } else {
+                $pcnt = count($json->players);
+                for ($i = 0; $i < $pcnt; $i++) {
+                    $p = $json->players[$i];
+                    if (strcasecmp($userid, $p->account) != 0) {
+                        $p->world = "-some-other-bogus-world-";
+                        $p->x = 0.0;
+                        $p->y = 64.0;
+                        $p->z = 0.0;
+                    }
+                }
+            }
+        }
+    }
+    echo json_encode($json);
 }
 cleanupDb();
-
- 
-?>
-

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_access.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_access.php
@@ -1,9 +1,9 @@
 <?php
-require_once('PostgreSQL_funcs.php');
+
+require_once 'PostgreSQL_funcs.php';
 
 if ($loginenabled) {
     $rslt = getStandaloneFile('dynmap_access.php');
-	var_dump($rslt);
-	eval($rslt);
+    var_dump($rslt);
+    eval($rslt);
 }
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_configuration.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_configuration.php
@@ -1,22 +1,22 @@
 <?php
+
 ob_start();
-require_once('PostgreSQL_funcs.php');
-include('PostgreSQL_config.php');
-include('PostgreSQL_access.php');
+require_once 'PostgreSQL_funcs.php';
+require 'PostgreSQL_config.php';
+require 'PostgreSQL_access.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 $content = getStandaloneFile('dynmap_config.json');
@@ -26,53 +26,45 @@ header('Content-type: application/json; charset=utf-8');
 $json = json_decode($content);
 
 if (!$loginenabled) {
-	echo $content;
-}
-else if($json->loginrequired && !$loggedin) {
+    echo $content;
+} elseif ($json->loginrequired && !$loggedin) {
     echo "{ \"error\": \"login-required\" }";
-}
-else {
-	$uid = '[' . strtolower($userid) . ']';
-	$json->loggedin = $loggedin;
-	$wcnt = count($json->worlds);
-	$newworlds = array();
-	for($i = 0; $i < $wcnt; $i++) {
-		$w = $json->worlds[$i];
-		if($w->protected) {
-		    $ss = stristr($worldaccess[$w->name], $uid);
-			if($ss !== false) {
-				$newworlds[] = $w;
-			}
-			else {
-				$w = null;
-			}
-		}
-		else {
-			$newworlds[] = $w;
-		}
-		if($w != null) {
-			$mcnt = count($w->maps);
-			$newmaps = array();
-			for($j = 0; $j < $mcnt; $j++) {
-				$m = $w->maps[$j];
-				if($m->protected) {
-				    $ss = stristr($mapaccess[$w->name . '.' . $m->prefix], $uid);
-					if($ss !== false) {
-						$newmaps[] = $m;
-					}
-				}
-				else {
-					$newmaps[] = $m;
-				}
-			}
-			$w->maps = $newmaps;		
-		}
-	}
-	$json->worlds = $newworlds;
-	
-	echo json_encode($json);
+} else {
+    $uid = '[' . strtolower($userid) . ']';
+    $json->loggedin = $loggedin;
+    $wcnt = count($json->worlds);
+    $newworlds = array();
+    for ($i = 0; $i < $wcnt; $i++) {
+        $w = $json->worlds[$i];
+        if ($w->protected) {
+            $ss = stristr($worldaccess[$w->name], $uid);
+            if ($ss !== false) {
+                $newworlds[] = $w;
+            } else {
+                $w = null;
+            }
+        } else {
+            $newworlds[] = $w;
+        }
+        if ($w != null) {
+            $mcnt = count($w->maps);
+            $newmaps = array();
+            for ($j = 0; $j < $mcnt; $j++) {
+                $m = $w->maps[$j];
+                if ($m->protected) {
+                    $ss = stristr($mapaccess[$w->name . '.' . $m->prefix], $uid);
+                    if ($ss !== false) {
+                        $newmaps[] = $m;
+                    }
+                } else {
+                    $newmaps[] = $m;
+                }
+            }
+            $w->maps = $newmaps;
+        }
+    }
+    $json->worlds = $newworlds;
+
+    echo json_encode($json);
 }
 cleanupDb();
- 
-?>
-

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_funcs.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_funcs.php
@@ -1,118 +1,124 @@
 <?php
 
-function cleanupDb() {
-   if (isset($db)) {
-      $db->close();
-      $db = NULL;
-   }
+function cleanupDb()
+{
+    if (isset($db)) {
+        $db->close();
+        $db = null;
+    }
 }
 
-function abortDb($errormsg) {
-   header('HTTP/1.0 500 Error');
-   echo "<h1>500 Error</h1>";
-   echo $errormsg;
-   cleanupDb();
-   exit;
+function abortDb($errormsg)
+{
+    header('HTTP/1.0 500 Error');
+    echo "<h1>500 Error</h1>";
+    echo $errormsg;
+    cleanupDb();
+    exit;
 }
 
-function initDbIfNeeded() {
-   global $db, $dbhost, $dbuserid, $dbpassword, $dbname, $dbport;
-   
-   $pos = strpos($dbname, '?');
+function initDbIfNeeded()
+{
+    global $db, $dbhost, $dbuserid, $dbpassword, $dbname, $dbport;
 
-   if ($pos) {
-      $dbname = substr($dbname, 0, $pos);
-   }
-   
-   if (!$db) {
-      $db = new PDO("pgsql:host=$dbhost;port=$dbport;dbname=$dbname", $dbuserid , $dbpassword, array(PDO::ATTR_PERSISTENT => true));
-      $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-      if (!$db) {
-         abortDb("Error opening database");
-	  }
-   }
+    $pos = strpos($dbname, '?');
+
+    if ($pos) {
+        $dbname = substr($dbname, 0, $pos);
+    }
+
+    if (!$db) {
+        $db = new PDO("pgsql:host=$dbhost;port=$dbport;dbname=$dbname", $dbuserid, $dbpassword, array(PDO::ATTR_PERSISTENT => true));
+        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        if (!$db) {
+            abortDb("Error opening database");
+        }
+    }
 }
 
 
-function getStandaloneFileByServerId($fname, $sid) {
-   global $db, $dbprefix;
-   
-   initDbIfNeeded();
-   $stmt = $db->prepare('SELECT Content from ' . $dbprefix . 'StandaloneFiles WHERE FileName=:fname AND ServerID=:sid');
-   $stmt->bindParam(':fname', $fname, PDO::PARAM_STR);
-   $stmt->bindParam(':sid', $sid, PDO::PARAM_INT);
-   $res = $stmt->execute();
-   $content = $stmt->fetch(PDO::FETCH_BOTH);
-   if ($res && $content) {
+function getStandaloneFileByServerId($fname, $sid)
+{
+    global $db, $dbprefix;
+
+    initDbIfNeeded();
+    $stmt = $db->prepare('SELECT Content from ' . $dbprefix . 'StandaloneFiles WHERE FileName=:fname AND ServerID=:sid');
+    $stmt->bindParam(':fname', $fname, PDO::PARAM_STR);
+    $stmt->bindParam(':sid', $sid, PDO::PARAM_INT);
+    $res = $stmt->execute();
+    $content = $stmt->fetch(PDO::FETCH_BOTH);
+    if ($res && $content) {
         $rslt = stream_get_contents($content[0]); //stupid streams...
-   }
-   else {
-        $rslt = NULL;
-   }
-   $stmt->closeCursor();
-   return $rslt;
+    } else {
+        $rslt = null;
+    }
+    $stmt->closeCursor();
+    return $rslt;
 }
 
-function getStandaloneFile($fname) {
-   global $serverid;
-   
-   if (!isset($serverid)) {
-      $serverid = 0;
-      if(isset($_REQUEST['serverid'])) {
-         $serverid = $_REQUEST['serverid'];
-      }
-   }
-   return getStandaloneFileByServerId($fname, $serverid);
+function getStandaloneFile($fname)
+{
+    global $serverid;
+
+    if (!isset($serverid)) {
+        $serverid = 0;
+        if (isset($_REQUEST['serverid'])) {
+            $serverid = $_REQUEST['serverid'];
+        }
+    }
+    return getStandaloneFileByServerId($fname, $serverid);
 }
 
-function updateStandaloneFileByServerId($fname, $sid, $content) {
-   global $db, $dbprefix;
-   
-   initDbIfNeeded();
-   $stmt = $db->prepare('UPDATE ' . $dbprefix . 'StandaloneFiles SET Content=:content WHERE FileName=:fname AND ServerID=:sid');
-   $stmt->bindParam(':content', $content, PDO::PARAM_STR);
-   $stmt->bindParam(':fname',   $fname,   PDO::PARAM_STR);
-   $stmt->bindParam(':sid',     $sid,     PDO::PARAM_INT);
-   $res = $stmt->execute();
-   $stmt->closeCursor();
-   if (!$res) {
-      $res = insertStandaloneFileByServerId($fname, $sid, $content);
-   }
-   return $res;
+function updateStandaloneFileByServerId($fname, $sid, $content)
+{
+    global $db, $dbprefix;
+
+    initDbIfNeeded();
+    $stmt = $db->prepare('UPDATE ' . $dbprefix . 'StandaloneFiles SET Content=:content WHERE FileName=:fname AND ServerID=:sid');
+    $stmt->bindParam(':content', $content, PDO::PARAM_STR);
+    $stmt->bindParam(':fname', $fname, PDO::PARAM_STR);
+    $stmt->bindParam(':sid', $sid, PDO::PARAM_INT);
+    $res = $stmt->execute();
+    $stmt->closeCursor();
+    if (!$res) {
+        $res = insertStandaloneFileByServerId($fname, $sid, $content);
+    }
+    return $res;
 }
 
-function updateStandaloneFile($fname, $content) {
-   global $serverid;
-   
-   if (!isset($serverid)) {
-      $serverid = 0;
-      if(isset($_REQUEST['serverid'])) {
-         $serverid = $_REQUEST['serverid'];
-      }
-   }
-   return updateStandaloneFileByServerId($fname, $serverid, $content);
+function updateStandaloneFile($fname, $content)
+{
+    global $serverid;
+
+    if (!isset($serverid)) {
+        $serverid = 0;
+        if (isset($_REQUEST['serverid'])) {
+            $serverid = $_REQUEST['serverid'];
+        }
+    }
+    return updateStandaloneFileByServerId($fname, $serverid, $content);
 }
 
-function insertStandaloneFileByServerId($fname, $sid, $content) {
-   global $db, $dbprefix;
-   
-   initDbIfNeeded();
-   $stmt = $db->prepare('INSERT INTO ' . $dbprefix . 'StandaloneFiles (Content,FileName,ServerID) VALUES (?,?,?);');
-   $res = $stmt->execute(array($content, $fname, $sid));
-   $stmt->close();
-   return $res;
+function insertStandaloneFileByServerId($fname, $sid, $content)
+{
+    global $db, $dbprefix;
+
+    initDbIfNeeded();
+    $stmt = $db->prepare('INSERT INTO ' . $dbprefix . 'StandaloneFiles (Content,FileName,ServerID) VALUES (?,?,?);');
+    $res = $stmt->execute(array($content, $fname, $sid));
+    $stmt->close();
+    return $res;
 }
 
-function insertStandaloneFile($fname, $content) {
-   global $serverid;
-   
-   if (!isset($serverid)) {
-      $serverid = 0;
-      if(isset($_REQUEST['serverid'])) {
-         $serverid = $_REQUEST['serverid'];
-      }
-   }
-   return insertStandaloneFileByServerId($fname, $serverid, $content);
-}
+function insertStandaloneFile($fname, $content)
+{
+    global $serverid;
 
-?>
+    if (!isset($serverid)) {
+        $serverid = 0;
+        if (isset($_REQUEST['serverid'])) {
+            $serverid = $_REQUEST['serverid'];
+        }
+    }
+    return insertStandaloneFileByServerId($fname, $serverid, $content);
+}

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_getlogin.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_getlogin.php
@@ -1,8 +1,8 @@
 <?php
-require_once('PostgreSQL_funcs.php');
+
+require_once 'PostgreSQL_funcs.php';
 
 if ($loginenabled) {
     $rslt = getStandaloneFile("dynmap_login.php");
-	eval($rslt);
+    eval($rslt);
 }
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_login.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_login.php
@@ -1,75 +1,69 @@
 <?php
+
 ob_start();
-require_once('PostgreSQL_funcs.php');
-include('PostgreSQL_config.php');
-include('PostgreSQL_getlogin.php');
+require_once 'PostgreSQL_funcs.php';
+require 'PostgreSQL_config.php';
+require 'PostgreSQL_getlogin.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_POST['j_username'])) {
-  $userid = $_POST['j_username'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_POST['j_username'])) {
+    $userid = $_POST['j_username'];
+} else {
+    $userid = '-guest-';
 }
 $good = false;
 
-if(strcmp($userid, '-guest-')) {
-  if(isset($_POST['j_password'])) {
-    $password = $_POST['j_password'];
-  }
-  else {
-    $password = '';
-  }
-  $ctx = hash_init('sha256');
-  hash_update($ctx, $pwdsalt);
-  hash_update($ctx, $password);
-  $hash = hash_final($ctx);
-  $useridlc = strtolower($userid);
-  if (strcasecmp($hash, $pwdhash[$useridlc]) == 0) {
-     $_SESSION['userid'] = $userid;
-     $good = true; 
-  }
-  else {
-     $_SESSION['userid'] = '-guest-';
-  }
-}
-else {
-  $_SESSION['userid'] = '-guest-';
-  $good = true;
+if (strcmp($userid, '-guest-')) {
+    if (isset($_POST['j_password'])) {
+        $password = $_POST['j_password'];
+    } else {
+        $password = '';
+    }
+    $ctx = hash_init('sha256');
+    hash_update($ctx, $pwdsalt);
+    hash_update($ctx, $password);
+    $hash = hash_final($ctx);
+    $useridlc = strtolower($userid);
+    if (strcasecmp($hash, $pwdhash[$useridlc]) == 0) {
+        $_SESSION['userid'] = $userid;
+        $good = true;
+    } else {
+        $_SESSION['userid'] = '-guest-';
+    }
+} else {
+    $_SESSION['userid'] = '-guest-';
+    $good = true;
 }
 $content = getStandaloneFile('dynmap_reg.php');
 
 /* Prune pending registrations, if needed */
 $lines = explode('\n', $content);
 $newlines[] = array();
-if(!empty($lines)) {
-	$cnt = count($lines) - 1;
-	$changed = false;
-	for($i=1; $i < $cnt; $i++) {
-		list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
-		if($uid == $useridlc) continue;
-		if(array_key_exists($uid, $pendingreg)) {
-			$newlines[] = $uid . '=' . $pc . '=' . $hsh;
-		}
-		else {
-			$changed = true;
-		}
-	}
-	if($changed) {
+if (!empty($lines)) {
+    $cnt = count($lines) - 1;
+    $changed = false;
+    for ($i = 1; $i < $cnt; $i++) {
+        list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
+        if ($uid == $useridlc) {
+            continue;
+        }
+        if (array_key_exists($uid, $pendingreg)) {
+            $newlines[] = $uid . '=' . $pc . '=' . $hsh;
+        } else {
+            $changed = true;
+        }
+    }
+    if ($changed) {
         updateStandaloneFile('dynmap_reg.php', implode("\n", $newlines));
-	}
+    }
 }
 
-if($good) {
-   echo "{ \"result\": \"success\" }"; 
-}
-else {
-   echo "{ \"result\": \"loginfailed\" }"; 
+if ($good) {
+    echo "{ \"result\": \"success\" }";
+} else {
+    echo "{ \"result\": \"loginfailed\" }";
 }
 
 cleanupDb();
- 
-?>
-

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_markers.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_markers.php
@@ -1,22 +1,22 @@
 <?php
+
 ob_start();
-require_once('PostgreSQL_funcs.php');
-include('PostgreSQL_config.php');
-include('PostgreSQL_access.php');
+require_once 'PostgreSQL_funcs.php';
+require 'PostgreSQL_config.php';
+require 'PostgreSQL_access.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 $path = $_REQUEST['marker'];
@@ -29,7 +29,7 @@ if ((!isset($path)) || strstr($path, "..")) {
 
 $parts = explode("/", $path);
 
-if(($parts[0] != "faces") && ($parts[0] != "_markers_")) {
+if (($parts[0] != "faces") && ($parts[0] != "_markers_")) {
     header('HTTP/1.0 500 Error');
     echo "<h1>500 Error</h1>";
     echo "Bad marker: " . $path;
@@ -39,67 +39,59 @@ if(($parts[0] != "faces") && ($parts[0] != "_markers_")) {
 initDbIfNeeded();
 
 if ($parts[0] == "faces") {
-	if (count($parts) != 3) {
-	    header('HTTP/1.0 500 Error');
-    	echo "<h1>500 Error</h1>";
-    	echo "Bad face: " . $path;
-    	cleanupDb();
-    	exit();
-	}
-	$ft = 0;
-	if ($parts[1] == "8x8") {
-		$ft = 0;
-	}
-	else if ($parts[1] == '16x16') {
-	    $ft = 1;
-   	}
-   	else if ($parts[1] == '32x32') {
-   	    $ft = 2;
-	}
-	else if ($parts[1] == 'body') {
-		$ft = 3;
-	}
-	$pn = explode(".", $parts[2]);
-	$stmt = $db->prepare('SELECT Image from ' . $dbprefix . 'Faces WHERE PlayerName=? AND TypeID=?');
-	$res = $stmt->execute(array($pn[0], $ft));
-	$timage = $stmt->fetch();
-	if ($res && $timage) {
-          header('Content-Type: image/png');
-	  echo stream_get_contents($timage[0]);
-	}
-	else {
-		header('Location: ../images/blank.png');
-	}
-}
-else { // _markers_
-	$in = explode(".", $parts[1]);
-	$name = implode(".", array_slice($in, 0, count($in) - 1));
-	$ext = $in[count($in) - 1];
-	if (($ext == "json") && (strpos($name, "marker_") == 0)) {
-		$world = substr($name, 7);
-		$stmt = $db->prepare('SELECT Content from ' . $dbprefix . 'MarkerFiles WHERE FileName=?');
-		$res = $stmt->execute(array($world));
-		$timage = $stmt->fetch();
-  		header('Content-Type: application/json');
-		if ($res && $timage) {
-			echo stream_get_contents($timage[0]); //PDO returns arrays, even for single colums, and bytea is returned as stream.
-		}
-		else {
-			echo "{ }";
-		}
-	}
-	else {
-		$stmt = $db->prepare('SELECT Image from ' . $dbprefix . 'MarkerIcons WHERE IconName=?');
-		$res = $stmt->execute(array($name));
+    if (count($parts) != 3) {
+        header('HTTP/1.0 500 Error');
+        echo "<h1>500 Error</h1>";
+        echo "Bad face: " . $path;
+        cleanupDb();
+        exit();
+    }
+    $ft = 0;
+    if ($parts[1] == "8x8") {
+        $ft = 0;
+    } elseif ($parts[1] == '16x16') {
+        $ft = 1;
+    } elseif ($parts[1] == '32x32') {
+        $ft = 2;
+    } elseif ($parts[1] == 'body') {
+        $ft = 3;
+    }
+    $pn = explode(".", $parts[2]);
+    $stmt = $db->prepare('SELECT Image from ' . $dbprefix . 'Faces WHERE PlayerName=? AND TypeID=?');
+    $res = $stmt->execute(array($pn[0], $ft));
+    $timage = $stmt->fetch();
+    if ($res && $timage) {
+        header('Content-Type: image/png');
+        echo stream_get_contents($timage[0]);
+    } else {
+        header('Location: ../images/blank.png');
+    }
+} else { // _markers_
+    $in = explode(".", $parts[1]);
+    $name = implode(".", array_slice($in, 0, count($in) - 1));
+    $ext = $in[count($in) - 1];
+    if (($ext == "json") && (strpos($name, "marker_") == 0)) {
+        $world = substr($name, 7);
+        $stmt = $db->prepare('SELECT Content from ' . $dbprefix . 'MarkerFiles WHERE FileName=?');
+        $res = $stmt->execute(array($world));
         $timage = $stmt->fetch();
-		if ($res && $timage) {
-      		header('Content-Type: image/png');
-			echo stream_get_contents($timage[0]);
-		}
-		else {
-			header('Location: ../images/blank.png');
-		}
-	}
+        header('Content-Type: application/json');
+        if ($res && $timage) {
+            echo stream_get_contents($timage[0]); //PDO returns arrays, even for single colums, and bytea is returned as stream.
+        } else {
+            echo "{ }";
+        }
+    } else {
+        $stmt = $db->prepare('SELECT Image from ' . $dbprefix . 'MarkerIcons WHERE IconName=?');
+        $res = $stmt->execute(array($name));
+        $timage = $stmt->fetch();
+        if ($res && $timage) {
+            header('Content-Type: image/png');
+            echo stream_get_contents($timage[0]);
+        } else {
+            header('Location: ../images/blank.png');
+        }
+    }
 }
 
 $stmt->closeCursor();
@@ -107,4 +99,3 @@ $stmt->closeCursor();
 cleanupDb();
 
 exit;
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_sendmessage.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_sendmessage.php
@@ -1,75 +1,69 @@
 <?php
+
 ob_start();
-require_once('PostgreSQL_funcs.php');
-include('PostgreSQL_config.php');
+require_once 'PostgreSQL_funcs.php';
+require 'PostgreSQL_config.php';
 ob_end_clean();
 
 session_start();
 
 $content = getStandaloneFile('dynmap_config.json');
 if (isset($content)) {
-   $config = json_decode($content, true);
-   $msginterval = $config['webchat-interval'];
-}
-else {
-   $msginterval = 2000;
+    $config = json_decode($content, true);
+    $msginterval = $config['webchat-interval'];
+} else {
+    $msginterval = 2000;
 }
 
-if(isset($_SESSION['lastchat']))
+if (isset($_SESSION['lastchat'])) {
     $lastchat = $_SESSION['lastchat'];
-else
+} else {
     $lastchat = 0;
-
-if($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat < time())
-{
-	$micro = microtime(true);
-	$timestamp = round($micro*1000.0);
-	
-	$data = json_decode(trim(file_get_contents('php://input')));
-	$data->timestamp = $timestamp;
-	$data->ip = $_SERVER['REMOTE_ADDR'];
-	if(isset($_SESSION['userid'])) {
-		$uid = $_SESSION['userid'];
-		if(strcmp($uid, '-guest-')) {
-		   $data->userid = $uid;
-		}
-	}
-	if(isset($_SERVER['HTTP_X_FORWARDED_FOR']))
-		$data->ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
-	$content = getStandaloneFile('dynmap_webchat.json');
-	$gotold = false;
-	if (isset($content)) {
-		$old_messages = json_decode($content, true);
-		$gotold = true;
-	}
-	
-	if(!empty($old_messages))
-	{
-		foreach($old_messages as $message)
-		{
-			if(($timestamp - $config['updaterate'] - 10000) < $message['timestamp'])
-				$new_messages[] = $message;
-		}
-	}
-	$new_messages[] = $data;
-
-	if ($gotold) {
-	    updateStandaloneFile('dynmap_webchat.json', json_encode($new_messages));
-	}
-	else {
-	    insertStandaloneFile('dynmap_webchat.json', json_encode($new_messages));
-	}
-	
-	$_SESSION['lastchat'] = time()+$msginterval;
-	echo "{ \"error\" : \"none\" }";
 }
-elseif($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat > time())
-{
-	header('HTTP/1.1 403 Forbidden');
-}
-else {
-	echo "{ \"error\" : \"none\" }";
+
+if ($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat < time()) {
+    $micro = microtime(true);
+    $timestamp = round($micro * 1000.0);
+
+    $data = json_decode(trim(file_get_contents('php://input')));
+    $data->timestamp = $timestamp;
+    $data->ip = $_SERVER['REMOTE_ADDR'];
+    if (isset($_SESSION['userid'])) {
+        $uid = $_SESSION['userid'];
+        if (strcmp($uid, '-guest-')) {
+            $data->userid = $uid;
+        }
+    }
+    if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+        $data->ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+    }
+    $content = getStandaloneFile('dynmap_webchat.json');
+    $gotold = false;
+    if (isset($content)) {
+        $old_messages = json_decode($content, true);
+        $gotold = true;
+    }
+
+    if (!empty($old_messages)) {
+        foreach ($old_messages as $message) {
+            if (($timestamp - $config['updaterate'] - 10000) < $message['timestamp']) {
+                $new_messages[] = $message;
+            }
+        }
+    }
+    $new_messages[] = $data;
+
+    if ($gotold) {
+        updateStandaloneFile('dynmap_webchat.json', json_encode($new_messages));
+    } else {
+        insertStandaloneFile('dynmap_webchat.json', json_encode($new_messages));
+    }
+
+    $_SESSION['lastchat'] = time() + $msginterval;
+    echo "{ \"error\" : \"none\" }";
+} elseif ($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat > time()) {
+    header('HTTP/1.1 403 Forbidden');
+} else {
+    echo "{ \"error\" : \"none\" }";
 }
 cleanupDb();
-
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_tiles.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_tiles.php
@@ -1,22 +1,22 @@
 <?php
+
 ob_start();
-require_once('PostgreSQL_funcs.php');
-include('PostgreSQL_config.php');
-include('PostgreSQL_access.php');
+require_once 'PostgreSQL_funcs.php';
+require 'PostgreSQL_config.php';
+require 'PostgreSQL_access.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 $path = $_REQUEST['tile'];
@@ -30,85 +30,80 @@ if ((!isset($path)) || strstr($path, "..")) {
 $parts = explode("/", $path);
 
 if (count($parts) != 4) {
-   header('Location: ../images/blank.png');
-   cleanupDb();
-   exit;
+    header('Location: ../images/blank.png');
+    cleanupDb();
+    exit;
 }
- 
+
 $uid = '[' . strtolower($userid) . ']';
 
 $world = $parts[0];
 
-if(isset($worldaccess[$world])) {
+if (isset($worldaccess[$world])) {
     $ss = stristr($worldaccess[$world], $uid);
-	if($ss === false) {
-           header('Location: ../images/blank.png');
-           cleanupDb();
-           exit;
-	}
+    if ($ss === false) {
+        header('Location: ../images/blank.png');
+        cleanupDb();
+        exit;
+    }
 }
-$variant='STANDARD';
+$variant = 'STANDARD';
 
-  $prefix = $parts[1];
-  $plen = strlen($prefix);
-  if(($plen > 4) && (substr($prefix, $plen - 4) === "_day")) {
-	$prefix = substr($prefix, 0, $plen - 4);
-        $variant = 'DAY';
-  }
-  $mapid = $world . "." . $prefix;
-  if(isset($mapaccess[$mapid])) {
+$prefix = $parts[1];
+$plen = strlen($prefix);
+if (($plen > 4) && (substr($prefix, $plen - 4) === "_day")) {
+    $prefix = substr($prefix, 0, $plen - 4);
+    $variant = 'DAY';
+}
+$mapid = $world . "." . $prefix;
+if (isset($mapaccess[$mapid])) {
     $ss = stristr($mapaccess[$mapid], $uid);
-	if($ss === false) {
-           header('Location: ../images/blank.png');
-           cleanupDb();
-           exit;
-	}
-  }
+    if ($ss === false) {
+        header('Location: ../images/blank.png');
+        cleanupDb();
+        exit;
+    }
+}
 
 $fparts = explode("_", $parts[3]);
 if (count($fparts) == 3) { // zoom_x_y
-   $zoom = strlen($fparts[0]);
-   $x = intval($fparts[1]);
-   $y = intval($fparts[2]);
-}
-else if (count($fparts) == 2) { // x_y
-   $zoom = 0;
-   $x = intval($fparts[0]);
-   $y = intval($fparts[1]);
-}
-else {
-   header('Location: ../images/blank.png');
-   cleanupDb();
-   exit;
+    $zoom = strlen($fparts[0]);
+    $x = intval($fparts[1]);
+    $y = intval($fparts[2]);
+} elseif (count($fparts) == 2) { // x_y
+    $zoom = 0;
+    $x = intval($fparts[0]);
+    $y = intval($fparts[1]);
+} else {
+    header('Location: ../images/blank.png');
+    cleanupDb();
+    exit;
 }
 initDbIfNeeded();
 
 $stmt = $db->prepare('SELECT t.Image,t.Format,t.HashCode,t.LastUpdate FROM ' . $dbprefix . 'Maps m JOIN ' . $dbprefix . 'Tiles t ON m.ID=t.MapID WHERE m.WorldID=? AND m.MapID=? AND m.Variant=? AND t.x=? AND t.y=? and t.zoom=?');
-$stmt->bindParam(1,$world, PDO::PARAM_STR);
-$stmt->bindParam(2,$prefix, PDO::PARAM_STR);
-$stmt->bindParam(3,$variant, PDO::PARAM_STR);
-$stmt->bindParam(4,$x, PDO::PARAM_INT);
-$stmt->bindParam(5,$y, PDO::PARAM_INT);
-$stmt->bindParam(6,$zoom, PDO::PARAM_INT);
+$stmt->bindParam(1, $world, PDO::PARAM_STR);
+$stmt->bindParam(2, $prefix, PDO::PARAM_STR);
+$stmt->bindParam(3, $variant, PDO::PARAM_STR);
+$stmt->bindParam(4, $x, PDO::PARAM_INT);
+$stmt->bindParam(5, $y, PDO::PARAM_INT);
+$stmt->bindParam(6, $zoom, PDO::PARAM_INT);
 $res = $stmt->execute();
 list($timage, $format, $thash, $tlast) = $stmt->fetch();
 if ($res && $timage) {
-   if ($format == 0) {
-      header('Content-Type: image/png');
-   }
-   else {
-      header('Content-Type: image/jpeg');
-   }
-   header('ETag: \'' . $thash . '\'');
-   header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $tlast/1000) . ' GMT'); 
-   echo stream_get_contents($timage);
-}
-else {
-   header('Location: ../images/blank.png');
+    if ($format == 0) {
+        header('Content-Type: image/png');
+    } else {
+        header('Content-Type: image/jpeg');
+    }
+    header('ETag: \'' . $thash . '\'');
+    header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $tlast / 1000) . ' GMT');
+    echo stream_get_contents($timage);
+} else {
+    header('Location: ../images/blank.png');
 }
 
 $stmt->closeCursor();
 cleanupDb();
 
 exit;
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_update.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_update.php
@@ -1,52 +1,53 @@
 <?php
+
 ob_start();
-require_once('PostgreSQL_funcs.php');
-include('PostgreSQL_config.php');
-include('PostgreSQL_access.php');
+require_once 'PostgreSQL_funcs.php';
+require 'PostgreSQL_config.php';
+require 'PostgreSQL_access.php';
 ob_end_clean();
 
 $world = $_REQUEST['world'];
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 header('Content-type: application/json; charset=utf-8');
 
-if(strpos($world, '/') || strpos($world, '\\') || empty($world)) {
+if (strpos($world, '/') || strpos($world, '\\') || empty($world)) {
     echo "{ \"error\": \"invalid-world\" }";
     return;
 }
 
-if ($loginenabled)
-	$fname = 'updates_' . $world . '.php';
-else
-	$fname = 'updates_' . $world . '.json';
+if ($loginenabled) {
+    $fname = 'updates_' . $world . '.php';
+} else {
+    $fname = 'updates_' . $world . '.json';
+}
 
 $useridlc = strtolower($userid);
 $uid = '[' . $useridlc . ']';
 
-if(isset($worldaccess[$world])) {
+if (isset($worldaccess[$world])) {
     $ss = stristr($worldaccess[$world], $uid);
-	if($ss === false) {
-	    echo "{ \"error\": \"access-denied\" }";
-		return;
-	}
+    if ($ss === false) {
+        echo "{ \"error\": \"access-denied\" }";
+        return;
+    }
 }
 
 $serverid = 0;
-if(isset($_REQUEST['serverid'])) {
-  $serverid = $_REQUEST['serverid'];
+if (isset($_REQUEST['serverid'])) {
+    $serverid = $_REQUEST['serverid'];
 }
 
 $content = getStandaloneFile('dynmap_' . $world . '.json');
@@ -60,48 +61,41 @@ if (!isset($content)) {
 
 
 if (!$loginenabled) {
-	echo $content;
-}
-else if(isset($json->loginrequired) && $json->loginrequired && !$loggedin) {
+    echo $content;
+} elseif (isset($json->loginrequired) && $json->loginrequired && !$loggedin) {
     echo "{ \"error\": \"login-required\" }";
-}
-else {
-	$json = json_decode($content);
-	$json->loggedin = $loggedin;
-	if (isset($json->protected) && $json->protected) {
-	    $ss = stristr($seeallmarkers, $uid);
-		if($ss === false) {
-			if(isset($playervisible[$useridlc])) {
-				$plist = $playervisible[$useridlc];
-				$pcnt = count($json->players);
-				for($i = 0; $i < $pcnt; $i++) {
-					$p = $json->players[$i];
-					if(!stristr($plist, '[' . $p->account . ']')) { 
-						$p->world = "-some-other-bogus-world-";
-						$p->x = 0.0;
-						$p->y = 64.0;
-						$p->z = 0.0;
-					}
-				}
-			}
-			else {
-				$pcnt = count($json->players);
-				for($i = 0; $i < $pcnt; $i++) {
-					$p = $json->players[$i];
-					if(strcasecmp($userid, $p->account) != 0) {
-						$p->world = "-some-other-bogus-world-";
-						$p->x = 0.0;
-						$p->y = 64.0;
-						$p->z = 0.0;
-					}
-				}
-			}
-		}
-	}
-	echo json_encode($json);
+} else {
+    $json = json_decode($content);
+    $json->loggedin = $loggedin;
+    if (isset($json->protected) && $json->protected) {
+        $ss = stristr($seeallmarkers, $uid);
+        if ($ss === false) {
+            if (isset($playervisible[$useridlc])) {
+                $plist = $playervisible[$useridlc];
+                $pcnt = count($json->players);
+                for ($i = 0; $i < $pcnt; $i++) {
+                    $p = $json->players[$i];
+                    if (!stristr($plist, '[' . $p->account . ']')) {
+                        $p->world = "-some-other-bogus-world-";
+                        $p->x = 0.0;
+                        $p->y = 64.0;
+                        $p->z = 0.0;
+                    }
+                }
+            } else {
+                $pcnt = count($json->players);
+                for ($i = 0; $i < $pcnt; $i++) {
+                    $p = $json->players[$i];
+                    if (strcasecmp($userid, $p->account) != 0) {
+                        $p->world = "-some-other-bogus-world-";
+                        $p->x = 0.0;
+                        $p->y = 64.0;
+                        $p->z = 0.0;
+                    }
+                }
+            }
+        }
+    }
+    echo json_encode($json);
 }
 cleanupDb();
-
- 
-?>
-

--- a/DynmapCore/src/main/resources/extracted/web/standalone/SQLite_markers.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/SQLite_markers.php
@@ -1,20 +1,20 @@
 <?php
+
 ob_start();
-include('dynmap_access.php');
+require 'dynmap_access.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 $path = $_REQUEST['marker'];
@@ -27,7 +27,7 @@ if ((!isset($path)) || strstr($path, "..")) {
 
 $parts = explode("/", $path);
 
-if(($parts[0] != "faces") && ($parts[0] != "_markers_")) {
+if (($parts[0] != "faces") && ($parts[0] != "_markers_")) {
     header('HTTP/1.0 500 Error');
     echo "<h1>500 Error</h1>";
     echo "Bad marker: " . $path;
@@ -37,72 +37,64 @@ if(($parts[0] != "faces") && ($parts[0] != "_markers_")) {
 $db = new SQLite3($dbfile, SQLITE3_OPEN_READONLY);
 
 if ($parts[0] == "faces") {
-	if (count($parts) != 3) {
-	    header('HTTP/1.0 500 Error');
-    	echo "<h1>500 Error</h1>";
-    	echo "Bad face: " . $path;
-    	exit();
-	}
-	$ft = 0;
-	if ($parts[1] == "8x8") {
-		$ft = 0;
-	}
-	else if ($parts[1] == '16x16') {
-	    $ft = 1;
-   	}
-   	else if ($parts[1] == '32x32') {
-   	    $ft = 2;
-	}
-	else if ($parts[1] == 'body') {
-		$ft = 3;
-	}
-	$pn = explode(".", $parts[2]);
-	$stmt = $db->prepare('SELECT Image from Faces WHERE PlayerName=:pn AND TypeID=:ft');
-	$stmt->bindValue(":pn", $pn[0], SQLITE3_TEXT);
-	$stmt->bindValue(":ft", $ft, SQLITE3_INTEGER);
-	$res = $stmt->execute();
-	$row = $res->fetchArray();
-	if (isset($row[0])) {
-      header('Content-Type: image/png');
-	  echo $row[0];
-	}
-	else {
-		header('Location: ../images/blank.png');
-		exit;
-	}
-}
-else { // _markers_
-	$in = explode(".", $parts[1]);
-	$name = implode(".", array_slice($in, 0, count($in) - 1));
-	$ext = $in[count($in) - 1];
-	if (($ext == "json") && (strpos($name, "marker_") == 0)) {
-		$world = substr($name, 7);
-		$stmt = $db->prepare('SELECT Content from MarkerFiles WHERE FileName=:fn');
-		$stmt->bindValue(':fn', $world, SQLITE3_TEXT);
-		$res = $stmt->execute();
-		$row = $res->fetchArray();
-  		header('Content-Type: application/json');
-		if (isset($row[0])) {
-			echo $row[0];
-		}
-		else {
-			echo "{ }";
-		}
-	}
-	else {
-		$stmt = $db->prepare('SELECT Image from MarkerIcons WHERE IconName=:in');
-		$stmt->bindValue(":in", $name, SQLITE3_TEXT);
-		$res = $stmt->execute();
-		$row = $res->fetchArray();
-		if (isset($row[0])) {
-      		header('Content-Type: image/png');
-			echo $row[0];
-		}
-		else {
-			header('Location: ../images/blank.png');
-			exit;
-		}
-	}
+    if (count($parts) != 3) {
+        header('HTTP/1.0 500 Error');
+        echo "<h1>500 Error</h1>";
+        echo "Bad face: " . $path;
+        exit();
+    }
+    $ft = 0;
+    if ($parts[1] == "8x8") {
+        $ft = 0;
+    } elseif ($parts[1] == '16x16') {
+        $ft = 1;
+    } elseif ($parts[1] == '32x32') {
+        $ft = 2;
+    } elseif ($parts[1] == 'body') {
+        $ft = 3;
+    }
+    $pn = explode(".", $parts[2]);
+    $stmt = $db->prepare('SELECT Image from Faces WHERE PlayerName=:pn AND TypeID=:ft');
+    $stmt->bindValue(":pn", $pn[0], SQLITE3_TEXT);
+    $stmt->bindValue(":ft", $ft, SQLITE3_INTEGER);
+    $res = $stmt->execute();
+    $row = $res->fetchArray();
+    if (isset($row[0])) {
+        header('Content-Type: image/png');
+        echo $row[0];
+    } else {
+        header('Location: ../images/blank.png');
+        exit;
+    }
+} else { // _markers_
+    $in = explode(".", $parts[1]);
+    $name = implode(".", array_slice($in, 0, count($in) - 1));
+    $ext = $in[count($in) - 1];
+    if (($ext == "json") && (strpos($name, "marker_") == 0)) {
+        $world = substr($name, 7);
+        $stmt = $db->prepare('SELECT Content from MarkerFiles WHERE FileName=:fn');
+        $stmt->bindValue(':fn', $world, SQLITE3_TEXT);
+        $res = $stmt->execute();
+        $row = $res->fetchArray();
+        header('Content-Type: application/json');
+        if (isset($row[0])) {
+            echo $row[0];
+        } else {
+            echo "{ }";
+        }
+    } else {
+        $stmt = $db->prepare('SELECT Image from MarkerIcons WHERE IconName=:in');
+        $stmt->bindValue(":in", $name, SQLITE3_TEXT);
+        $res = $stmt->execute();
+        $row = $res->fetchArray();
+        if (isset($row[0])) {
+            header('Content-Type: image/png');
+            echo $row[0];
+        } else {
+            header('Location: ../images/blank.png');
+            exit;
+        }
+    }
 }
 
 $res->finalize();
@@ -111,4 +103,3 @@ $db->close();
 
 
 exit;
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/SQLite_tiles.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/SQLite_tiles.php
@@ -1,20 +1,20 @@
 <?php
+
 ob_start();
-include('dynmap_access.php');
+require 'dynmap_access.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 $path = $_REQUEST['tile'];
@@ -28,52 +28,50 @@ if ((!isset($path)) || strstr($path, "..")) {
 $parts = explode("/", $path);
 
 if (count($parts) != 4) {
-   header('Location: ../images/blank.png');
-   exit;
+    header('Location: ../images/blank.png');
+    exit;
 }
- 
+
 $uid = '[' . strtolower($userid) . ']';
 
 $world = $parts[0];
 
-if(isset($worldaccess[$world])) {
+if (isset($worldaccess[$world])) {
     $ss = stristr($worldaccess[$world], $uid);
-	if($ss === false) {
-           header('Location: ../images/blank.png');
-           exit;
-	}
+    if ($ss === false) {
+        header('Location: ../images/blank.png');
+        exit;
+    }
 }
-$variant='STANDARD';
+$variant = 'STANDARD';
 
-  $prefix = $parts[1];
-  $plen = strlen($prefix);
-  if(($plen > 4) && (substr($prefix, $plen - 4) === "_day")) {
-	$prefix = substr($prefix, 0, $plen - 4);
-        $variant = 'DAY';
-  }
-  $mapid = $world . "." . $prefix;
-  if(isset($mapaccess[$mapid])) {
+$prefix = $parts[1];
+$plen = strlen($prefix);
+if (($plen > 4) && (substr($prefix, $plen - 4) === "_day")) {
+    $prefix = substr($prefix, 0, $plen - 4);
+    $variant = 'DAY';
+}
+$mapid = $world . "." . $prefix;
+if (isset($mapaccess[$mapid])) {
     $ss = stristr($mapaccess[$mapid], $uid);
-	if($ss === false) {
-           header('Location: ../images/blank.png');
-           exit;
-	}
-  }
+    if ($ss === false) {
+        header('Location: ../images/blank.png');
+        exit;
+    }
+}
 
 $fparts = explode("_", $parts[3]);
 if (count($fparts) == 3) { // zoom_x_y
-   $zoom = strlen($fparts[0]);
-   $x = intval($fparts[1]);
-   $y = intval($fparts[2]);
-}
-else if (count($fparts) == 2) { // x_y
-   $zoom = 0;
-   $x = intval($fparts[0]);
-   $y = intval($fparts[1]);
-}
-else {
-   header('Location: ../images/blank.png');
-   exit;
+    $zoom = strlen($fparts[0]);
+    $x = intval($fparts[1]);
+    $y = intval($fparts[2]);
+} elseif (count($fparts) == 2) { // x_y
+    $zoom = 0;
+    $x = intval($fparts[0]);
+    $y = intval($fparts[1]);
+} else {
+    header('Location: ../images/blank.png');
+    exit;
 }
 
 $db = new SQLite3($dbfile, SQLITE3_OPEN_READONLY);
@@ -88,25 +86,23 @@ $stmt->bindValue(':zoom', $zoom, SQLITE3_INTEGER);
 $res = $stmt->execute();
 $row = $res->fetchArray();
 if (isset($row[1])) {
-   $format = $row[1];
-   if ($format == 0) {
-      header('Content-Type: image/png');
-   }
-   else {
-      header('Content-Type: image/jpeg');
-   }
-   header('ETag: \'' . $row[2] . '\'');
-   header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $row[3]/1000) . ' GMT'); 
-   if ($row[4] > 0) {
-      $v = substr($row[0], 0, $row[4]);
-   } else {
-      $v = rtrim($row[0], "\0");
-   }
-   header('Content-Length: ' . strlen($v));
-   echo $v;
-}
-else {
-   header('Location: ../images/blank.png');
+    $format = $row[1];
+    if ($format == 0) {
+        header('Content-Type: image/png');
+    } else {
+        header('Content-Type: image/jpeg');
+    }
+    header('ETag: \'' . $row[2] . '\'');
+    header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $row[3] / 1000) . ' GMT');
+    if ($row[4] > 0) {
+        $v = substr($row[0], 0, $row[4]);
+    } else {
+        $v = rtrim($row[0], "\0");
+    }
+    header('Content-Length: ' . strlen($v));
+    echo $v;
+} else {
+    header('Location: ../images/blank.png');
 }
 
 $res->finalize();
@@ -114,4 +110,3 @@ $stmt->close();
 $db->close();
 
 exit;
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/configuration.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/configuration.php
@@ -1,74 +1,65 @@
 <?php
+
 ob_start();
-include('dynmap_access.php');
+require 'dynmap_access.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 $lines = file('dynmap_config.php');
 array_shift($lines);
 array_pop($lines);
-$json = json_decode(implode(' ',$lines));
+$json = json_decode(implode(' ', $lines));
 
 header('Content-type: text/plain; charset=utf-8');
 
-if($json->loginrequired && !$loggedin) {
+if ($json->loginrequired && !$loggedin) {
     echo "{ \"error\": \"login-required\" }";
+} else {
+    $uid = '[' . strtolower($userid) . ']';
+    $json->loggedin = $loggedin;
+    $wcnt = count($json->worlds);
+    for ($i = 0; $i < $wcnt; $i++) {
+        $w = $json->worlds[$i];
+        if ($w->protected) {
+            $ss = stristr($worldaccess[$w->name], $uid);
+            if ($ss !== false) {
+                $newworlds[] = $w;
+            } else {
+                $w = null;
+            }
+        } else {
+            $newworlds[] = $w;
+        }
+        if ($w != null) {
+            $mcnt = count($w->maps);
+            $newmaps = array();
+            for ($j = 0; $j < $mcnt; $j++) {
+                $m = $w->maps[$j];
+                if ($m->protected) {
+                    $ss = stristr($mapaccess[$w->name . '.' . $m->prefix], $uid);
+                    if ($ss !== false) {
+                        $newmaps[] = $m;
+                    }
+                } else {
+                    $newmaps[] = $m;
+                }
+            }
+            $w->maps = $newmaps;
+        }
+    }
+    $json->worlds = $newworlds;
+
+    echo json_encode($json);
 }
-else {
-	$uid = '[' . strtolower($userid) . ']';
-	$json->loggedin = $loggedin;
-	$wcnt = count($json->worlds);
-	for($i = 0; $i < $wcnt; $i++) {
-		$w = $json->worlds[$i];
-		if($w->protected) {
-		    $ss = stristr($worldaccess[$w->name], $uid);
-			if($ss !== false) {
-				$newworlds[] = $w;
-			}
-			else {
-				$w = null;
-			}
-		}
-		else {
-			$newworlds[] = $w;
-		}
-		if($w != null) {
-			$mcnt = count($w->maps);
-			$newmaps = array();
-			for($j = 0; $j < $mcnt; $j++) {
-				$m = $w->maps[$j];
-				if($m->protected) {
-				    $ss = stristr($mapaccess[$w->name . '.' . $m->prefix], $uid);
-					if($ss !== false) {
-						$newmaps[] = $m;
-					}
-				}
-				else {
-					$newmaps[] = $m;
-				}
-			}
-			$w->maps = $newmaps;		
-		}
-	}
-	$json->worlds = $newworlds;
-	
-	echo json_encode($json);
-}
-
-
- 
-?>
-

--- a/DynmapCore/src/main/resources/extracted/web/standalone/login.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/login.php
@@ -1,78 +1,72 @@
 <?php
+
 ob_start();
-include('dynmap_login.php');
+require 'dynmap_login.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_POST['j_username'])) {
-  $userid = $_POST['j_username'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_POST['j_username'])) {
+    $userid = $_POST['j_username'];
+} else {
+    $userid = '-guest-';
 }
 $good = false;
 
-if(strcmp($userid, '-guest-')) {
-  if(isset($_POST['j_password'])) {
-    $password = $_POST['j_password'];
-  }
-  else {
-    $password = '';
-  }
-  $ctx = hash_init('sha256');
-  hash_update($ctx, $pwdsalt);
-  hash_update($ctx, $password);
-  $hash = hash_final($ctx);
-  $useridlc = strtolower($userid);
-  if (strcasecmp($hash, $pwdhash[$useridlc]) == 0) {
-     $_SESSION['userid'] = $userid;
-     $good = true; 
-  }
-  else {
-     $_SESSION['userid'] = '-guest-';
-  }
-}
-else {
-  $_SESSION['userid'] = '-guest-';
-  $good = true;
+if (strcmp($userid, '-guest-')) {
+    if (isset($_POST['j_password'])) {
+        $password = $_POST['j_password'];
+    } else {
+        $password = '';
+    }
+    $ctx = hash_init('sha256');
+    hash_update($ctx, $pwdsalt);
+    hash_update($ctx, $password);
+    $hash = hash_final($ctx);
+    $useridlc = strtolower($userid);
+    if (strcasecmp($hash, $pwdhash[$useridlc]) == 0) {
+        $_SESSION['userid'] = $userid;
+        $good = true;
+    } else {
+        $_SESSION['userid'] = '-guest-';
+    }
+} else {
+    $_SESSION['userid'] = '-guest-';
+    $good = true;
 }
 /* Prune pending registrations, if needed */
 $newlines[] = '<?php /*';
-if(is_readable('dynmap_reg.php'))
-	$lines = file('dynmap_reg.php');
-else
-	$lines = array();
-if(!empty($lines)) {
-	$cnt = count($lines) - 1;
-	$changed = false;
-	for($i=1; $i < $cnt; $i++) {
-		list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
-		if($uid == $useridlc) continue;
-		if(array_key_exists($uid, $pendingreg)) {
-			$newlines[] = $uid . '=' . $pc . '=' . $hsh;
-		}
-		else {
-			$changed = true;
-		}
-	}
-	if($changed) {
-		if(count($newlines) < 2) {	/* Nothing? */
-			unlink('dynmap_reg.php');
-		}
-		else {
-			$newlines[] = '*/ ?>';
-			file_put_contents('dynmap_reg.php', implode("\n", $newlines));
-		}
-	}
+if (is_readable('dynmap_reg.php')) {
+    $lines = file('dynmap_reg.php');
+} else {
+    $lines = array();
+}
+if (!empty($lines)) {
+    $cnt = count($lines) - 1;
+    $changed = false;
+    for ($i = 1; $i < $cnt; $i++) {
+        list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
+        if ($uid == $useridlc) {
+            continue;
+        }
+        if (array_key_exists($uid, $pendingreg)) {
+            $newlines[] = $uid . '=' . $pc . '=' . $hsh;
+        } else {
+            $changed = true;
+        }
+    }
+    if ($changed) {
+        if (count($newlines) < 2) {    /* Nothing? */
+            unlink('dynmap_reg.php');
+        } else {
+            $newlines[] = '*/ ?>';
+            file_put_contents('dynmap_reg.php', implode("\n", $newlines));
+        }
+    }
 }
 
-if($good) {
-   echo "{ \"result\": \"success\" }"; 
+if ($good) {
+    echo "{ \"result\": \"success\" }";
+} else {
+    echo "{ \"result\": \"loginfailed\" }";
 }
-else {
-   echo "{ \"result\": \"loginfailed\" }"; 
-}
- 
-?>
-

--- a/DynmapCore/src/main/resources/extracted/web/standalone/markers.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/markers.php
@@ -1,10 +1,11 @@
 <?php
+
 ob_start();
-include('dynmap_access.php');
+require 'dynmap_access.php';
 ob_end_clean();
 
-if(!isset($markerspath)) {
-  $markerspath = "../tiles/";
+if (!isset($markerspath)) {
+    $markerspath = "../tiles/";
 }
 
 //Use this to force specific tiles path, versus using passed value
@@ -12,16 +13,15 @@ if(!isset($markerspath)) {
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 $path = $_REQUEST['marker'];
@@ -36,7 +36,7 @@ $fname = $markerspath . $path;
 
 $parts = explode("/", $path);
 
-if(($parts[0] != "faces") && ($parts[0] != "_markers_")) {
+if (($parts[0] != "faces") && ($parts[0] != "_markers_")) {
     header('HTTP/1.0 500 Error');
     echo "<h1>500 Error</h1>";
     echo "Bad marker: " . $path;
@@ -46,26 +46,25 @@ if(($parts[0] != "faces") && ($parts[0] != "_markers_")) {
 $uid = '[' . strtolower($userid) . ']';
 
 if (!is_readable($fname)) {
-  if(strstr($path, ".jpg") || strstr($path, ".png")) {
-	  $fname = "../images/blank.png";
-  }
-  else {
-    header('HTTP/1.0 404 Not Found');
-    echo "<h1>404 Not Found</h1>";
-    echo "Not found: " . $path;
-    exit();
-  }  
+    if (strstr($path, ".jpg") || strstr($path, ".png")) {
+        $fname = "../images/blank.png";
+    } else {
+        header('HTTP/1.0 404 Not Found');
+        echo "<h1>404 Not Found</h1>";
+        echo "Not found: " . $path;
+        exit();
+    }
 }
 $fp = fopen($fname, 'rb');
-if (strstr($path, ".png"))
-  header("Content-Type: image/png");
-else if (strstr($path, ".jpg"))
-  header("Content-Type: image/jpeg");
-else
-  header("Content-Type: application/text");
+if (strstr($path, ".png")) {
+    header("Content-Type: image/png");
+} elseif (strstr($path, ".jpg")) {
+    header("Content-Type: image/jpeg");
+} else {
+    header("Content-Type: application/text");
+}
 
 header("Content-Length: " . filesize($fname));
 
 fpassthru($fp);
 exit;
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/register.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/register.php
@@ -1,38 +1,35 @@
 <?php
+
 ob_start();
-require('dynmap_login.php');
+require 'dynmap_login.php';
 ob_end_clean();
 
 session_start();
 
-if(isset($_POST['j_password'])) {
-  $password = $_POST['j_password'];
+if (isset($_POST['j_password'])) {
+    $password = $_POST['j_password'];
+} else {
+    $password = '';
 }
-else {
-  $password = '';
+if (isset($_POST['j_verify_password'])) {
+    $verify = $_POST['j_verify_password'];
+} else {
+    $verify = '';
 }
-if(isset($_POST['j_verify_password'])) {
-  $verify = $_POST['j_verify_password'];
-}
-else {
-  $verify = '';
-}
-if(strcmp($password, $verify)) {
-  echo "{ \"result\": \"verifyfailed\" }"; 
-  return;
+if (strcmp($password, $verify)) {
+    echo "{ \"result\": \"verifyfailed\" }";
+    return;
 }
 
-if(isset($_POST['j_username'])) {
-  $userid = $_POST['j_username'];
+if (isset($_POST['j_username'])) {
+    $userid = $_POST['j_username'];
+} else {
+    $userid = '-guest-';
 }
-else {
-  $userid = '-guest-';
-}
-if(isset($_POST['j_passcode'])) {
-  $passcode = $_POST['j_passcode'];
-}
-else {
-  $passcode = '';
+if (isset($_POST['j_passcode'])) {
+    $passcode = $_POST['j_passcode'];
+} else {
+    $passcode = '';
 }
 $good = false;
 
@@ -42,39 +39,38 @@ $_SESSION['userid'] = '-guest-';
 
 $good = false;
 
-if(strcmp($useridlc, '-guest-')) {
-  if(isset($pendingreg[$useridlc])) {
-     if(!strcmp($passcode, $pendingreg[$useridlc])) {
-        $ctx = hash_init('sha256');
-        hash_update($ctx, $pwdsalt);
-        hash_update($ctx, $password);
-        $hash = hash_final($ctx);
-        $_SESSION['userid'] = $userid;
-        $good = true;
+if (strcmp($useridlc, '-guest-')) {
+    if (isset($pendingreg[$useridlc])) {
+        if (!strcmp($passcode, $pendingreg[$useridlc])) {
+            $ctx = hash_init('sha256');
+            hash_update($ctx, $pwdsalt);
+            hash_update($ctx, $password);
+            $hash = hash_final($ctx);
+            $_SESSION['userid'] = $userid;
+            $good = true;
 
-		$newlines[] = '<?php /*';
-		$lines = file('dynmap_reg.php');
-		if(!empty($lines)) {
-			$cnt = count($lines) - 1;
-			for($i=1; $i < $cnt; $i++) {
-				list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
-				if($uid == $useridlc) continue;
-				if(array_key_exists($uid, $pendingreg)) {
-					$newlines[] = $uid . '=' . $pc . '=' . $hsh;
-				}
-			}
-		}
-		$newlines[] = $useridlc . '=' . $passcode . '=' . $hash;
-		$newlines[] = '*/ ?>';
-		file_put_contents('dynmap_reg.php', implode("\n", $newlines));
-     }
-  }
+            $newlines[] = '<?php /*';
+            $lines = file('dynmap_reg.php');
+            if (!empty($lines)) {
+                $cnt = count($lines) - 1;
+                for ($i = 1; $i < $cnt; $i++) {
+                    list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
+                    if ($uid == $useridlc) {
+                        continue;
+                    }
+                    if (array_key_exists($uid, $pendingreg)) {
+                        $newlines[] = $uid . '=' . $pc . '=' . $hsh;
+                    }
+                }
+            }
+            $newlines[] = $useridlc . '=' . $passcode . '=' . $hash;
+            $newlines[] = '*/ ?>';
+            file_put_contents('dynmap_reg.php', implode("\n", $newlines));
+        }
+    }
 }
-if($good) {
-   echo "{ \"result\": \"success\" }"; 
+if ($good) {
+    echo "{ \"result\": \"success\" }";
+} else {
+    echo "{ \"result\": \"registerfailed\" }";
 }
-else {
-   echo "{ \"result\": \"registerfailed\" }"; 
-}
-   
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/sendmessage.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/sendmessage.php
@@ -1,63 +1,58 @@
 <?php
+
 session_start();
 
-if(is_readable('dynmap_config.json')) {
-   $config =  json_decode(file_get_contents('dynmap_config.json'), true);
-   $msginterval = $config['webchat-interval'];
-}
-else if(is_readable('dynmap_config.php')) {
-   $lines = file('dynmap_config.php');
-   array_shift($lines);
-   array_pop($lines);
-   $config = json_decode(implode(' ',$lines), true);
-   $msginterval = $config['webchat-interval'];
-}
-else {
-   $msginterval = 2000;
+if (is_readable('dynmap_config.json')) {
+    $config =  json_decode(file_get_contents('dynmap_config.json'), true);
+    $msginterval = $config['webchat-interval'];
+} elseif (is_readable('dynmap_config.php')) {
+    $lines = file('dynmap_config.php');
+    array_shift($lines);
+    array_pop($lines);
+    $config = json_decode(implode(' ', $lines), true);
+    $msginterval = $config['webchat-interval'];
+} else {
+    $msginterval = 2000;
 }
 
-if(isset($_SESSION['lastchat']))
+if (isset($_SESSION['lastchat'])) {
     $lastchat = $_SESSION['lastchat'];
-else
+} else {
     $lastchat = 0;
+}
 
-if($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat < time())
-{
-	$micro = microtime(true);
-	$timestamp = round($micro*1000.0);
-	
-	$data = json_decode(trim(file_get_contents('php://input')));
-	$data->timestamp = $timestamp;
-	$data->ip = $_SERVER['REMOTE_ADDR'];
-	if(isset($_SESSION['userid'])) {
-		$uid = $_SESSION['userid'];
-		if(strcmp($uid, '-guest-')) {
-		   $data->userid = $uid;
-		}
-	}
-	if(isset($_SERVER['HTTP_X_FORWARDED_FOR']))
-		$data->ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
-	if(is_readable('dynmap_webchat.json')) {
-		$old_messages = json_decode(file_get_contents('dynmap_webchat.json'), true);
-	}
-	if(!empty($old_messages))
-	{
-		foreach($old_messages as $message)
-		{
-			if(($timestamp - $config['updaterate'] - 10000) < $message['timestamp'])
-				$new_messages[] = $message;
-		}
-	}
-	$new_messages[] = $data;
-	file_put_contents('dynmap_webchat.json', json_encode($new_messages));
-	$_SESSION['lastchat'] = time()+$msginterval;
-	echo "{ \"error\" : \"none\" }";
+if ($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat < time()) {
+    $micro = microtime(true);
+    $timestamp = round($micro * 1000.0);
+
+    $data = json_decode(trim(file_get_contents('php://input')));
+    $data->timestamp = $timestamp;
+    $data->ip = $_SERVER['REMOTE_ADDR'];
+    if (isset($_SESSION['userid'])) {
+        $uid = $_SESSION['userid'];
+        if (strcmp($uid, '-guest-')) {
+            $data->userid = $uid;
+        }
+    }
+    if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+        $data->ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+    }
+    if (is_readable('dynmap_webchat.json')) {
+        $old_messages = json_decode(file_get_contents('dynmap_webchat.json'), true);
+    }
+    if (!empty($old_messages)) {
+        foreach ($old_messages as $message) {
+            if (($timestamp - $config['updaterate'] - 10000) < $message['timestamp']) {
+                $new_messages[] = $message;
+            }
+        }
+    }
+    $new_messages[] = $data;
+    file_put_contents('dynmap_webchat.json', json_encode($new_messages));
+    $_SESSION['lastchat'] = time() + $msginterval;
+    echo "{ \"error\" : \"none\" }";
+} elseif ($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat > time()) {
+    header('HTTP/1.1 403 Forbidden');
+} else {
+    echo "{ \"error\" : \"none\" }";
 }
-elseif($_SERVER['REQUEST_METHOD'] == 'POST' && $lastchat > time())
-{
-	header('HTTP/1.1 403 Forbidden');
-}
-else {
-	echo "{ \"error\" : \"none\" }";
-}
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/tiles.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/tiles.php
@@ -1,10 +1,11 @@
 <?php
+
 ob_start();
-include('dynmap_access.php');
+require 'dynmap_access.php';
 ob_end_clean();
 
-if(!isset($tilespath)) {
-  $tilespath = "../tiles/";
+if (!isset($tilespath)) {
+    $tilespath = "../tiles/";
 }
 
 //Use this to force specific tiles path, versus using passed value
@@ -12,16 +13,15 @@ if(!isset($tilespath)) {
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 $path = $_REQUEST['tile'];
@@ -40,46 +40,45 @@ $uid = '[' . strtolower($userid) . ']';
 
 $world = $parts[0];
 
-if(isset($worldaccess[$world])) {
+if (isset($worldaccess[$world])) {
     $ss = stristr($worldaccess[$world], $uid);
-	if($ss === false) {
-		$fname = "../images/blank.png";
-	}
+    if ($ss === false) {
+        $fname = "../images/blank.png";
+    }
 }
-if(count($parts) > 2) {
-  $prefix = $parts[1];
-  $plen = strlen($prefix);
-  if(($plen > 4) && (substr($prefix, $plen - 4) === "_day")) {
-	$prefix = substr($prefix, 0, $plen - 4);
-  }
-  $mapid = $world . "." . $prefix;
-  if(isset($mapaccess[$mapid])) {
-    $ss = stristr($mapaccess[$mapid], $uid);
-	if($ss === false) {
-		$fname = "../images/blank.png";
-	}
-  }
+if (count($parts) > 2) {
+    $prefix = $parts[1];
+    $plen = strlen($prefix);
+    if (($plen > 4) && (substr($prefix, $plen - 4) === "_day")) {
+        $prefix = substr($prefix, 0, $plen - 4);
+    }
+    $mapid = $world . "." . $prefix;
+    if (isset($mapaccess[$mapid])) {
+        $ss = stristr($mapaccess[$mapid], $uid);
+        if ($ss === false) {
+            $fname = "../images/blank.png";
+        }
+    }
 }
 
 if (!is_readable($fname)) {
-  if(strstr($path, ".jpg") || strstr($path, ".png")) {
-	  $fname = "../images/blank.png";
-  }
-  else {
-      echo "{ \"result\": \"bad-tile\" }";
-      exit; 
-  }  
+    if (strstr($path, ".jpg") || strstr($path, ".png")) {
+        $fname = "../images/blank.png";
+    } else {
+        echo "{ \"result\": \"bad-tile\" }";
+        exit;
+    }
 }
 $fp = fopen($fname, 'rb');
-if (strstr($path, ".png"))
-  header("Content-Type: image/png");
-else if (strstr($path, ".jpg"))
-  header("Content-Type: image/jpeg");
-else
-  header("Content-Type: application/text");
+if (strstr($path, ".png")) {
+    header("Content-Type: image/png");
+} elseif (strstr($path, ".jpg")) {
+    header("Content-Type: image/jpeg");
+} else {
+    header("Content-Type: application/text");
+}
 
 header("Content-Length: " . filesize($fname));
 
 fpassthru($fp);
 exit;
-?>

--- a/DynmapCore/src/main/resources/extracted/web/standalone/update.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/update.php
@@ -1,102 +1,95 @@
 <?php
 
 ob_start();
-include('dynmap_access.php');
+require 'dynmap_access.php';
 ob_end_clean();
 
 $world = $_REQUEST['world'];
 
 session_start();
 
-if(isset($_SESSION['userid'])) {
-  $userid = $_SESSION['userid'];
-}
-else {
-  $userid = '-guest-';
+if (isset($_SESSION['userid'])) {
+    $userid = $_SESSION['userid'];
+} else {
+    $userid = '-guest-';
 }
 
 $loggedin = false;
-if(strcmp($userid, '-guest-')) {
-  $loggedin = true;
+if (strcmp($userid, '-guest-')) {
+    $loggedin = true;
 }
 
 header('Content-type: text/plain; charset=utf-8');
 
-if(strpos($world, '/') || strpos($world, '\\')) {
+if (strpos($world, '/') || strpos($world, '\\')) {
     echo "{ \"error\": \"invalid-world\" }";
     return;
 }
 
-if(isset($webpath))
-	$fname = $webpath . '/standalone/updates_' . $world . '.php';
-else
-	$fname = 'updates_' . $world . '.php';
+if (isset($webpath)) {
+    $fname = $webpath . '/standalone/updates_' . $world . '.php';
+} else {
+    $fname = 'updates_' . $world . '.php';
+}
 
-if(!is_readable($fname)) {
+if (!is_readable($fname)) {
     header('HTTP/1.0 404 Not Found');
-	return;
+    return;
 }
 
 $useridlc = strtolower($userid);
 $uid = '[' . $useridlc . ']';
 
-if(isset($worldaccess[$world])) {
+if (isset($worldaccess[$world])) {
     $ss = stristr($worldaccess[$world], $uid);
-	if($ss === false) {
-	    echo "{ \"error\": \"access-denied\" }";
-		return;
-	}
+    if ($ss === false) {
+        echo "{ \"error\": \"access-denied\" }";
+        return;
+    }
 }
 
 $lines = file($fname);
-if(!$lines) {
+if (!$lines) {
     header('HTTP/1.0 404 Not Found');
-	return;
+    return;
 }
 array_shift($lines);
 array_pop($lines);
-$json = json_decode(implode(' ',$lines));
+$json = json_decode(implode(' ', $lines));
 
 
-if(isset($json->loginrequired) && $json->loginrequired && !$loggedin) {
+if (isset($json->loginrequired) && $json->loginrequired && !$loggedin) {
     echo "{ \"error\": \"login-required\" }";
+} else {
+    $json->loggedin = $loggedin;
+    if (isset($json->protected) && $json->protected) {
+        $ss = stristr($seeallmarkers, $uid);
+        if ($ss === false) {
+            if (isset($playervisible[$useridlc])) {
+                $plist = $playervisible[$useridlc];
+                $pcnt = count($json->players);
+                for ($i = 0; $i < $pcnt; $i++) {
+                    $p = $json->players[$i];
+                    if (!stristr($plist, '[' . $p->account . ']')) {
+                        $p->world = "-some-other-bogus-world-";
+                        $p->x = 0.0;
+                        $p->y = 64.0;
+                        $p->z = 0.0;
+                    }
+                }
+            } else {
+                $pcnt = count($json->players);
+                for ($i = 0; $i < $pcnt; $i++) {
+                    $p = $json->players[$i];
+                    if (strcasecmp($userid, $p->account) != 0) {
+                        $p->world = "-some-other-bogus-world-";
+                        $p->x = 0.0;
+                        $p->y = 64.0;
+                        $p->z = 0.0;
+                    }
+                }
+            }
+        }
+    }
+    echo json_encode($json);
 }
-else {
-	$json->loggedin = $loggedin;
-	if (isset($json->protected) && $json->protected) {
-	    $ss = stristr($seeallmarkers, $uid);
-		if($ss === false) {
-			if(isset($playervisible[$useridlc])) {
-				$plist = $playervisible[$useridlc];
-				$pcnt = count($json->players);
-				for($i = 0; $i < $pcnt; $i++) {
-					$p = $json->players[$i];
-					if(!stristr($plist, '[' . $p->account . ']')) { 
-						$p->world = "-some-other-bogus-world-";
-						$p->x = 0.0;
-						$p->y = 64.0;
-						$p->z = 0.0;
-					}
-				}
-			}
-			else {
-				$pcnt = count($json->players);
-				for($i = 0; $i < $pcnt; $i++) {
-					$p = $json->players[$i];
-					if(strcasecmp($userid, $p->account) != 0) {
-						$p->world = "-some-other-bogus-world-";
-						$p->x = 0.0;
-						$p->y = 64.0;
-						$p->z = 0.0;
-					}
-				}
-			}
-		}
-	}
-	echo json_encode($json);
-}
-
-
- 
-?>
-

--- a/DynmapCore/src/main/resources/extracted/web/up.php
+++ b/DynmapCore/src/main/resources/extracted/web/up.php
@@ -1,6 +1,6 @@
 <?php
 
-define ('HOSTNAME', 'http://localhost:8123/up/');
+define('HOSTNAME', 'http://localhost:8123/up/');
 
 session_start();
 
@@ -12,52 +12,50 @@ $valid_url_regex = '/.*/';
 // ############################################################################
 
 $path = $_GET['path'];
-$url = HOSTNAME.$path;
+$url = HOSTNAME . $path;
 
 
-$ch = curl_init( $url );
+$ch = curl_init($url);
 
 $client_headers = array();
-$client_headers[] = 'X-Forwarded-For: '.$_SERVER['REMOTE_ADDR'];
-curl_setopt($ch, CURLOPT_HTTPHEADER, $client_headers);  
+$client_headers[] = 'X-Forwarded-For: ' . $_SERVER['REMOTE_ADDR'];
+curl_setopt($ch, CURLOPT_HTTPHEADER, $client_headers);
 
-if ( strtolower($_SERVER['REQUEST_METHOD']) == 'post' ) {
-  $postText = trim(file_get_contents('php://input'));
-  curl_setopt( $ch, CURLOPT_POST, true );
-  curl_setopt( $ch, CURLOPT_POSTFIELDS, $postText );
+if (strtolower($_SERVER['REQUEST_METHOD']) == 'post') {
+    $postText = trim(file_get_contents('php://input'));
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $postText);
 }
 
 
 $cookie = array();
-foreach ( $_COOKIE as $key => $value ) {
-  $cookie[] = $key . '=' . $value;
+foreach ($_COOKIE as $key => $value) {
+    $cookie[] = $key . '=' . $value;
 }
 $cookie[] = SID;
-$cookie = implode( '; ', $cookie );
-curl_setopt( $ch, CURLOPT_COOKIE, $cookie );
-  
+$cookie = implode('; ', $cookie);
+curl_setopt($ch, CURLOPT_COOKIE, $cookie);
+
 //curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, true );
-curl_setopt( $ch, CURLOPT_HEADER, true );
-curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
-  
-curl_setopt( $ch, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT'] );
-  
-list( $header, $contents ) = preg_split( '/([\r\n][\r\n])\\1/', curl_exec( $ch ), 2 );
-  
-$status = curl_getinfo( $ch );
-  
-curl_close( $ch );
+curl_setopt($ch, CURLOPT_HEADER, true);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+curl_setopt($ch, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
+
+list($header, $contents) = preg_split('/([\r\n][\r\n])\\1/', curl_exec($ch), 2);
+
+$status = curl_getinfo($ch);
+
+curl_close($ch);
 
 // Split header text into an array.
-$header_text = preg_split( '/[\r\n]+/', $header );
-  
-// Propagate headers to response.
-foreach ( $header_text as $header ) {
-  if ( preg_match( '/^(?:Content-Type|Content-Language|Set-Cookie):/i', $header ) ) {
-    header( $header );
-  }
-}
-  
-print $contents;
+$header_text = preg_split('/[\r\n]+/', $header);
 
-?>
+// Propagate headers to response.
+foreach ($header_text as $header) {
+    if (preg_match('/^(?:Content-Type|Content-Language|Set-Cookie):/i', $header)) {
+        header($header);
+    }
+}
+
+print $contents;


### PR DESCRIPTION
Run formatting tools against the PHP source code to meet PSR12 standards

The tools used to format the code, for anyone interested in validating
the changes are:
* [PHP-CS-FIXER](https://github.com/FriendsOfPHP/PHP-CS-Fixer)
* [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Fixing-Errors-Automatically)

Nothing was changed functionally, though there does not appear to be any tests
to automatically verify this. I've run this on my personal server and have not run
into any issues.

I am new to this codebase so I am unable to tell what version of PHP is intended to be supported.
I'm being conservative and assuming 5.6 for now.

### Reasoning
I am a PHP developer by trade and was hoping to start contributing back to this incredible project.
When I opened the source code in my editor I saw a large number of linting errors. The goal here
was to get the PHP source code compliant with PSR12 so that future contributors would have an
easy entry into the codebase.