### PR TITLE
Remove Broken Dynmap reload command

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -1159,7 +1159,6 @@ public class DynmapCore implements DynmapCommonAPI {
         "cancelrender",
         "radiusrender",
         "updaterender",
-        "reload",
         "stats",
         "triggerstats",
         "resetstats",
@@ -1590,11 +1589,11 @@ public class DynmapCore implements DynmapCommonAPI {
                 } else {
                     sender.sendMessage("World name is required");
                 }
-            } else if (c.equals("reload") && checkPlayerPermission(sender, "reload")) {
+            } /*else if (c.equals("reload") && checkPlayerPermission(sender, "reload")) {
                 sender.sendMessage("Reloading Dynmap...");
                 getServer().reload();
                 sender.sendMessage("Dynmap reloaded");
-            } else if (c.equals("stats") && checkPlayerPermission(sender, "stats")) {
+            } */else if (c.equals("stats") && checkPlayerPermission(sender, "stats")) {
                 if(args.length == 1)
                     mapManager.printStats(sender, null);
                 else


### PR DESCRIPTION
This isn't a fix for the reload command it just removes it from being exposed to the user to prevent them from running the command and breaking it  till the reload command can be fixed.