### PR TITLE
Fix for #2564 and Backwards Compatibility for #3436

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/hdmap/HDMap.java
+++ b/DynmapCore/src/main/java/org/dynmap/hdmap/HDMap.java
@@ -46,7 +46,11 @@ public class HDMap extends MapType {
 
     public static final String IMGFORMAT_PNG = "png";
     public static final String IMGFORMAT_JPG = "jpg";
-    
+
+    private String renderClass;
+    public String getRenderClass(){
+        return renderClass;
+    }
     
     public HDMap(DynmapCore core, ConfigurationNode configuration) {
         this.core = core;
@@ -140,6 +144,7 @@ public class HDMap extends MapType {
         this.mapzoomin = configuration.getInteger("mapzoomin", 2);
         this.mapzoomout = configuration.getInteger("mapzoomout", this.mapzoomout);
         this.boostzoom = configuration.getInteger("boostzoom", 0);
+        this.renderClass = configuration.getString("class");
         if(this.boostzoom < 0) this.boostzoom = 0;
         if(this.boostzoom > 3) this.boostzoom = 3;
         // Map zoom in must be at least as big as boost zoom
@@ -228,6 +233,9 @@ public class HDMap extends MapType {
             if(mt instanceof HDMap) {
                 HDMap hdmt = (HDMap)mt;
                 if((hdmt.perspective == this.perspective) && (hdmt.boostzoom == this.boostzoom)) {  /* Same perspective */
+                    if(!hdmt.getRenderClass().equals(this.getRenderClass())){
+                        continue;
+                    }
                     maps.add(hdmt);
                 }
             }
@@ -242,6 +250,9 @@ public class HDMap extends MapType {
             if(mt instanceof HDMap) {
                 HDMap hdmt = (HDMap)mt;
                 if((hdmt.perspective == this.perspective)  && (hdmt.boostzoom == this.boostzoom)) {  /* Same perspective */
+                    if(!hdmt.getRenderClass().equals(this.getRenderClass())){
+                        continue;
+                    }
                     if(hdmt.lighting.isNightAndDayEnabled())
                         lst.add(hdmt.getName() + "(night/day)");
                     else

--- a/DynmapCore/src/main/java/org/dynmap/hdmap/HDMapManager.java
+++ b/DynmapCore/src/main/java/org/dynmap/hdmap/HDMapManager.java
@@ -130,6 +130,8 @@ public class HDMapManager {
                     /* If limited to one map, and this isn't it, skip */
                     if((mapname != null) && (!hdmap.getName().equals(mapname)))
                         continue;
+                    if(!hdmap.getRenderClass().startsWith("org.dynmap"))
+                        continue;
                     shaders.add(hdmap.getShader().getStateInstance(hdmap, cache, mapiter, scale));
                 }
             }

--- a/DynmapCore/src/main/java/org/dynmap/storage/MapStorageTile.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/MapStorageTile.java
@@ -55,6 +55,7 @@ public abstract class MapStorageTile {
      *
      * @param hash - hash code of uncompressed image
      * @param encImage - output stream for encoded image
+     * @param timestamp - timestamp used to prevent raceconditions for zoom out processing
      * @return true if write succeeded
      */
     public abstract boolean write(long hash, BufferOutputStream encImage, long timestamp);
@@ -63,6 +64,7 @@ public abstract class MapStorageTile {
      * 
      * @param hash - hash code of uncompressed image
      * @param image - image to be encoded
+     * @param timestamp - timestamp used to prevent raceconditions for zoom out processing
      * @return true if write succeeded
      */
     public boolean write(long hash, BufferedImage image, long timestamp) {
@@ -72,6 +74,26 @@ public abstract class MapStorageTile {
         }
         return false;
     }
+    /**
+     * Write tile
+     *
+     * @param hash - hash code of uncompressed image
+     * @param encImage - output stream for encoded image
+     * @return true if write succeeded
+     */
+    public abstract boolean write(long hash, BufferOutputStream encImage);
+
+    /**
+     * Write tile from image
+     *
+     * @param hash - hash code of uncompressed image
+     * @param image - image to be encoded
+     * @return true if write succeeded
+     */
+    public boolean write(long hash, BufferedImage image) {
+        return write(hash, image, System.currentTimeMillis());
+    }
+
     /**
      * Delete tile
      *

--- a/DynmapCore/src/main/java/org/dynmap/storage/filetree/FileTreeMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/filetree/FileTreeMapStorage.java
@@ -170,6 +170,11 @@ public class FileTreeMapStorage extends MapStorage {
         }
 
         @Override
+        public boolean write(long hash, BufferOutputStream encImage) {
+            return write(hash, encImage, System.currentTimeMillis());
+        }
+
+        @Override
         public boolean getWriteLock() {
             return FileTreeMapStorage.this.getWriteLock(baseFilename);
         }

--- a/DynmapCore/src/main/java/org/dynmap/storage/mariadb/MariaDBMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/mariadb/MariaDBMapStorage.java
@@ -201,6 +201,11 @@ public class MariaDBMapStorage extends MapStorage {
         }
 
         @Override
+        public boolean write(long hash, BufferOutputStream encImage) {
+            return write(hash, encImage, System.currentTimeMillis());
+        }
+
+        @Override
         public boolean getWriteLock() {
             return MariaDBMapStorage.this.getWriteLock(uri);
         }

--- a/DynmapCore/src/main/java/org/dynmap/storage/mysql/MySQLMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/mysql/MySQLMapStorage.java
@@ -202,6 +202,11 @@ public class MySQLMapStorage extends MapStorage {
         }
 
         @Override
+        public boolean write(long hash, BufferOutputStream encImage) {
+            return write(hash, encImage, System.currentTimeMillis());
+        }
+
+        @Override
         public boolean getWriteLock() {
             return MySQLMapStorage.this.getWriteLock(uri);
         }

--- a/DynmapCore/src/main/java/org/dynmap/storage/postgresql/PostgreSQLMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/postgresql/PostgreSQLMapStorage.java
@@ -205,6 +205,11 @@ public class PostgreSQLMapStorage extends MapStorage {
         }
 
         @Override
+        public boolean write(long hash, BufferOutputStream encImage) {
+            return write(hash, encImage, System.currentTimeMillis());
+        }
+
+        @Override
         public boolean getWriteLock() {
             return PostgreSQLMapStorage.this.getWriteLock(uri);
         }

--- a/DynmapCore/src/main/java/org/dynmap/storage/sqllte/SQLiteMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/sqllte/SQLiteMapStorage.java
@@ -198,6 +198,11 @@ public class SQLiteMapStorage extends MapStorage {
         }
 
         @Override
+        public boolean write(long hash, BufferOutputStream encImage) {
+            return write(hash, encImage, System.currentTimeMillis());
+        }
+
+        @Override
         public boolean getWriteLock() {
             return SQLiteMapStorage.this.getWriteLock(uri);
         }


### PR DESCRIPTION
Provides a potential fix for #2564 by checking for the provided "renderer" for the specific map.
The fix is to check within `HDMapManager.getShaderStateForTile()` for the "render class" that is used for the map and ignore it if its not comming from org.dynmap --> there probably is a nicer way to do this so I am open to suggestions on a different solution.

While analysing #2564 I noticed that with the latest compiled version from source I was unable to get ChunkyMap running. This is due to the changes made with #3436 which was missing backwards compatiblity for renderes not using the latest tile write Methods.

Furthermore I noticed that by reordering the map configuration of #2564 to
```YML
worlds:
  - name: world
    maps:
      - class: org.dynmap.hdmap.HDMap
        name: surface
        title: Surface Day
        icon: images/block_surface.png
        prefix: surface
        perspective: iso_SE_30_hires
        shader: customshader
        lighting: shadows
      - class: de.lemaik.chunkymap.dynmap.ChunkyMap
        name: chunky
        title: World
        prefix: chunky
        perspective: iso_SE_30_hires
        shader: customshader
        samplesPerPixel: 10
        chunkyThreads: 8
        chunkPadding: 2
        texturepack: texturepacks/texturepack.zip

```
Dynmap stopped the rendering after the "surface" map finished. The ChunkyMap render engine was not started for this map configuration. 
I was able to Fix this by verifiying the "render class" in the Methods `HDMap.getMapsSharingRender()` and `HDMap.getMapNamesSharingRender()` stopping the renderer from falsely interpreting the tiles as rendered in case a different "render class" was used