### PR TITLE
Add requested Feature to check for MySQL Connector

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/storage/mysql/MySQLMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/mysql/MySQLMapStorage.java
@@ -292,22 +292,25 @@ public class MySQLMapStorage extends MapStorage {
         
         connectionString = "jdbc:mysql://" + hostname + ":" + port + "/" + database + flags;
         Log.info("Opening MySQL database " + hostname + ":" + port + "/" + database + " as map store");
-        try {
-            Class.forName("com.mysql.cj.jdbc.Driver");
-        } catch (ClassNotFoundException cnfxLatestDriver){
-            Log.warning("MySQL-JDBC Did not find 'com.mysql.cj.jdbc.Driver' trying 'com.mysql.jdbc.Driver' next");
-            try {
-                Class.forName("com.mysql.jdbc.Driver");
-            } catch (ClassNotFoundException cnfx) {
-                Log.severe("MySQL-JDBC classes not found - MySQL data source not usable");
-                return false;
-            }
+
+        if(!hasClass("com.mysql.cj.jdbc.Driver") && !hasClass("com.mysql.jdbc.Driver")){
+            Log.severe("MySQL-JDBC classes not found - MySQL data source not usable");
+            return false;
         }
         // Initialize/update tables, if needed
         if(!initializeTables()) {
             return false;
         }
         return writeConfigPHP(core);
+    }
+
+    private boolean hasClass(String classname){
+        try{
+            Class.forName(classname);
+            return true;
+        } catch (ClassNotFoundException cnfx){
+            return false;
+        }
     }
 
     private boolean writeConfigPHP(DynmapCore core) {

--- a/DynmapCore/src/main/java/org/dynmap/storage/mysql/MySQLMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/mysql/MySQLMapStorage.java
@@ -293,14 +293,19 @@ public class MySQLMapStorage extends MapStorage {
         connectionString = "jdbc:mysql://" + hostname + ":" + port + "/" + database + flags;
         Log.info("Opening MySQL database " + hostname + ":" + port + "/" + database + " as map store");
         try {
-            Class.forName("com.mysql.jdbc.Driver");
-            // Initialize/update tables, if needed
-            if(!initializeTables()) {
+            Class.forName("com.mysql.cj.jdbc.Driver");
+        } catch (ClassNotFoundException cnfxLatestDriver){
+            Log.warning("MySQL-JDBC Did not find 'com.mysql.cj.jdbc.Driver' trying 'com.mysql.jdbc.Driver' next");
+            try {
+                Class.forName("com.mysql.jdbc.Driver");
+            } catch (ClassNotFoundException cnfx) {
+                Log.severe("MySQL-JDBC classes not found - MySQL data source not usable");
                 return false;
             }
-        } catch (ClassNotFoundException cnfx) {
-            Log.severe("MySQL-JDBC classes not found - MySQL data source not usable");
-            return false; 
+        }
+        // Initialize/update tables, if needed
+        if(!initializeTables()) {
+            return false;
         }
         return writeConfigPHP(core);
     }


### PR DESCRIPTION
Currently Dynmap checks if the class 'com.mysql.jdbc.Driver' exists. For Latest Paper Version this class is marked as deprecated, so this Check will throw an additional error message in the server log.

Luckyly we can just check for  "com.mysql.cj.jdbc.Driver" which is the latest MySQL connector (and supplied by paper).

I have moved the Class check into a function to make it easier to add additional class checks for MySQL Connectors if necessary.

Also related to #3397