### PR TITLE
fix: explicitly set sign lines

### DIFF
--- a/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
@@ -398,6 +398,10 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
                             if(p != null) dp = new BukkitPlayer(p);
                             core.listenerManager.processSignChangeEvent(EventType.SIGN_CHANGE, b.getType().name(),
                                 getWorld(l.getWorld()).getName(), l.getBlockX(), l.getBlockY(), l.getBlockZ(), lines, dp);
+
+                            for (int i = 0; i < 4; i++) {
+                                evt.setLine(i, lines[i]);
+                            }
                         }
                     }, DynmapPlugin.this);
                     break;


### PR DESCRIPTION
Minecraft allows for plugins to retrieve the text of a newly created or
modified sign through the `SignChangeEvent.getLines()` method. In
vanilla, the lines returned can be mutated, however a
`SignChangeEvent.setLine(idx, text)` method exists.

PaperMC has internally switched most user-facing text to using the
Adventure Text components, to better support text styling and optimize
serializations. For backwards compatibility with most plugins, PaperMC
retains deprecated `getLines` and `setLine` methods by providing a
legacy serialization view of the Aventure components, however mutations
of the returned list are ignored.

This changeset calls `setLine` after all event listeners ran, allowing
PaperMC to preserve the sign mutations.