### PR TITLE
fix(radius) - gmfamily - process radius as int everywhere (#3478)

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/DynmapMapCommands.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapMapCommands.java
@@ -158,7 +158,7 @@ public class DynmapMapCommands {
         		VisibilityLimit limit = w.visibility_limits.get(i);
         		if (limit instanceof RoundVisibilityLimit) {
         			RoundVisibilityLimit rlimit = (RoundVisibilityLimit) limit;
-        			sender.sendMessage(String.format(" %d: limittype=visible, type=round, center=%d/%d, radius=%f", i, rlimit.x_center, rlimit.z_center, rlimit.radius));
+        			sender.sendMessage(String.format(" %d: limittype=visible, type=round, center=%d/%d, radius=%d", i, rlimit.x_center, rlimit.z_center, rlimit.radius));
         		}
         		else if (limit instanceof RectangleVisibilityLimit) {
         			RectangleVisibilityLimit rlimit = (RectangleVisibilityLimit) limit;
@@ -171,7 +171,7 @@ public class DynmapMapCommands {
         		VisibilityLimit limit = w.hidden_limits.get(i);
         		if (limit instanceof RoundVisibilityLimit) {
         			RoundVisibilityLimit rlimit = (RoundVisibilityLimit) limit;
-        			sender.sendMessage(String.format(" %d: limittype=hidden, type=round, center=%d/%d, radius=%f", i + viscnt, rlimit.x_center, rlimit.z_center, rlimit.radius));
+        			sender.sendMessage(String.format(" %d: limittype=hidden, type=round, center=%d/%d, radius=%d", i + viscnt, rlimit.x_center, rlimit.z_center, rlimit.radius));
         		}
         		else if (limit instanceof RectangleVisibilityLimit) {
         			RectangleVisibilityLimit rlimit = (RectangleVisibilityLimit) limit;
@@ -205,7 +205,7 @@ public class DynmapMapCommands {
         int corner1[] = null;
         int corner2[] = null;
         int center[] = null;
-        double radius = 0.0;
+        int radius = 0;
         HiddenChunkStyle style = null;
         // Other args are field:value
         for (int argid = 2; argid < args.length; argid++) {

--- a/DynmapCore/src/main/java/org/dynmap/utils/RoundVisibilityLimit.java
+++ b/DynmapCore/src/main/java/org/dynmap/utils/RoundVisibilityLimit.java
@@ -2,9 +2,9 @@ package org.dynmap.utils;
 
 public class RoundVisibilityLimit implements VisibilityLimit {
     public int x_center, z_center;
-    public double radius; //Using squared_radius instead of radius for tiny optimization
+    public int radius; //Using squared_radius instead of radius for tiny optimization
 
-    public RoundVisibilityLimit(int x_center, int z_center, double radius) {
+    public RoundVisibilityLimit(int x_center, int z_center, int radius) {
         this.x_center = x_center;
         this.z_center = z_center;
         this.radius = radius;


### PR DESCRIPTION
This should fix - globally - the issue #3478. The previous proposed PR is incomplete (only parse radius provided by command as Integer but dont fix the radius representation in all functions -> the world.txt still contains ".0" values at end of all radius).