### PR TITLE
Always run LoadPlayerImages task in the thread pool

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/PlayerFaces.java
+++ b/DynmapCore/src/main/java/org/dynmap/PlayerFaces.java
@@ -301,10 +301,7 @@ public class PlayerFaces {
             @Override
             public void playerEvent(DynmapPlayer p) {
                 Runnable job = new LoadPlayerImages(p.getName(), p.getSkinURL(), p.getUUID(), core.skinUrlProvider);
-                if(fetchskins)
-                    MapManager.scheduleDelayedJob(job, 0);
-                else
-                    job.run();
+                MapManager.scheduleDelayedJob(job, 0);
             }
         });
         storage = core.getDefaultMapStorage();


### PR DESCRIPTION
Currently `LoadPlayerImages` tasks are only run in the thread pool if `fetchskins` is enabled, otherwise they are immediately run synchronously.

This can become a problem in some situations, such as when Dynmap is configured to store player images in a MySQL database which is currently inaccessible due to temporary network issues. In those cases, the sync task will block the main thread for potentially lengthy periods of time when attempting to save the resulting player images.

This PR removes the `fetchskins` check and always runs the task in the thread pool, which seems harmless.