### PR TITLE
Fix DynmapTileLayer sharing object instances

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/js/dynmaputils.js
+++ b/DynmapCore/src/main/resources/extracted/web/js/dynmaputils.js
@@ -75,10 +75,17 @@ var DynmapLayerControl = L.Control.Layers.extend({
 
 
 var DynmapTileLayer = L.TileLayer.extend({
-	_namedTiles: {},
-	_cachedTileUrls: {},
-	_loadQueue: [],
-	_loadingTiles: [],
+	_namedTiles: null,
+	_cachedTileUrls: null,
+	_loadQueue: null,
+	_loadingTiles: null,
+
+	initialize: function() {
+		this._namedTiles = {};
+		this._cachedTileUrls = {};
+		this._loadQueue = [];
+		this._loadingTiles = [];
+	},
 
 	createTile: function(coords, done) {
 		var me = this,

--- a/DynmapCore/src/main/resources/extracted/web/js/hdmap.js
+++ b/DynmapCore/src/main/resources/extracted/web/js/hdmap.js
@@ -35,6 +35,7 @@ var HDMapType = DynmapTileLayer.extend({
 		this.projection = new HDProjection($.extend({map: this}, options));
 
 		L.Util.setOptions(this, options);
+		DynmapTileLayer.prototype.initialize.call(this, options);
 	},
 	getTileName: function(coords) {
 		var info = this.getTileInfo(coords);


### PR DESCRIPTION
The leaflet update #3467 introduced a bug where all instances of `DynmapTileLayer` share the same instances of internal objects such as the tile URL cache. This can result in maps with the same name across worlds (such as "flat") using images from the wrong world if the URLs for that world were previously cached.

This PR fixes this by creating internal objects inside an `initialize` method instead of defining them directly in the `.extend` call.

Should fix #3506 and [this comment](https://github.com/webbukkit/dynmap/pull/3504#issuecomment-933160031)