### PR TITLE
dependency: Update SkinsRestorer

### DIFF
--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -5,7 +5,7 @@ repositories {
         url 'https://jitpack.io'
     }
     maven {
-        url 'https://repo.codemc.org/repository/maven-snapshots'
+        url 'https://repo.codemc.org/repository/maven-releases/'
     }
 }
 
@@ -15,7 +15,7 @@ dependencies {
     implementation 'me.lucko.luckperms:luckperms-api:4.3'
     implementation 'net.luckperms:api:5.0'
     implementation('com.github.MilkBowl:VaultAPI:1.7') { transitive = false }
-    compileOnly 'net.skinsrestorer:skinsrestorer:14.1.0-SNAPSHOT@jar'
+    compileOnly 'net.skinsrestorer:skinsrestorer-api:14.1.+'
     implementation project(":dynmap-api")
     implementation project(path: ":DynmapCore", configuration: "shadow")
     implementation group: 'ru.tehkode', name: 'PermissionsEx', version: '1.19.1'

--- a/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
@@ -110,7 +110,6 @@ import org.dynmap.renderer.DynmapBlockState;
 import org.dynmap.utils.MapChunkCache;
 import org.dynmap.utils.Polygon;
 import org.dynmap.utils.VisibilityLimit;
-import net.skinsrestorer.bukkit.SkinsRestorer;
 
 public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
     private DynmapCore core;
@@ -959,18 +958,24 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
         SkinsRestorerSkinUrlProvider skinUrlProvider = null;
 
         if (core.configuration.getBoolean("skinsrestorer-integration", false)) {
-            try {
-                SkinsRestorer skinsRestorer = (SkinsRestorer) getServer().getPluginManager().getPlugin("SkinsRestorer");
 
-                if (skinsRestorer == null) {
-                    Log.warning("SkinsRestorer integration can't be enabled because SkinsRestorer not installed");
-                } else {
+            Plugin skinsRestorer = getServer().getPluginManager().getPlugin("SkinsRestorer");
+
+            if (skinsRestorer == null) {
+                Log.warning("SkinsRestorer integration can't be enabled because SkinsRestorer is not installed");
+            } else {
+                try {
                     skinUrlProvider = new SkinsRestorerSkinUrlProvider();
-                    Log.info("SkinsRestorer API v14 integration enabled");
+                    Log.info("SkinsRestorer API integration enabled");
+                } catch (NoClassDefFoundError e) {
+                    skinUrlProvider = null;
+                    Log.warning("You are using unsupported version of SkinsRestorer. Use v14.1 or newer.");
+                    Log.warning("Disabled SkinsRestorer integration for this session");
+                } catch (Throwable e) {
+                    // SkinsRestorer probably updated its API
+                    skinUrlProvider = null;
+                    Log.warning("Error while enabling SkinsRestorer integration", e);
                 }
-            } catch(NoClassDefFoundError e) {
-                Log.warning("You are using unsupported version of SkinsRestorer. Use v14 or newer.");
-                Log.warning("Disabled SkinsRestorer integration for this session");
             }
         }
 

--- a/spigot/src/main/java/org/dynmap/bukkit/SkinsRestorerSkinUrlProvider.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/SkinsRestorerSkinUrlProvider.java
@@ -5,8 +5,7 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.json.simple.JSONObject;
 import net.skinsrestorer.api.SkinsRestorerAPI;
-import net.skinsrestorer.bukkit.SkinsRestorer;
-import net.skinsrestorer.shared.utils.ReflectionUtil;
+import net.skinsrestorer.api.reflection.ReflectionUtil;
 
 import java.net.MalformedURLException;
 import java.net.URL;


### PR DESCRIPTION
SkinsRestorer once again updated their API, which makes Dynmap crash on launch if user enables SkinsRestorer integration in config. Thanks @generrosity for bringing my attention to this.

By SkinsRestorer bStats, less than 3.5% of servers run currently supported SkinsRestorer version (It's even hidden in "others"), all others have newer versions with 92+% of servers running version that crashes dynmap. SkinsRestorer enabled new API in version 14.1, and (probably) disabled old in 14.1.6.

I've just bumped the version and kept already implemented checking for when SkinsRestorer is enabled, but not present, or when version older than 14 is installed. It will work nicely with 14.1+, but unfortunately, there is no easy way to check for 14.0 version (Dynmap will display default skins there, and some SkinsRestorer's stack trace in console is present), but again - that's just a few instances thanks to their aggresive auto updater. 

This PR was tested on Paper 1.18 with several SkinsRestorer versions, including pre v14, some v14.0 and several v14.1 (pre and post 14.1.6)