### PR TITLE
Fix boosted top-down-view map glitches

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/hdmap/IsoHDPerspective.java
+++ b/DynmapCore/src/main/java/org/dynmap/hdmap/IsoHDPerspective.java
@@ -1248,8 +1248,8 @@ public class IsoHDPerspective implements HDPerspective {
         for(int x = 0; x < tileWidth * sizescale; x++) {
             ps.px = x;
             for(int y = 0; y < tileHeight * sizescale; y++) {
-                ps.top.x = ps.bottom.x = xbase + ((double)x)/sizescale + 0.5;    /* Start at center of pixel at Y=height+0.5, bottom at Y=-0.5 */
-                ps.top.y = ps.bottom.y = ybase + ((double)y)/sizescale + 0.5;
+                ps.top.x = ps.bottom.x = xbase + (x + 0.5) / sizescale;    /* Start at center of pixel at Y=height+0.5, bottom at Y=-0.5 */
+                ps.top.y = ps.bottom.y = ybase + (y + 0.5) / sizescale;
                 ps.top.z = height + 0.5; ps.bottom.z = miny - 0.5;
                 map_to_world.transform(ps.top);            /* Transform to world coordinates */
                 map_to_world.transform(ps.bottom);


### PR DESCRIPTION
Presently, when using the resolution boosting option on a top-down HDMap (such as one using a `iso_S_90_*` perspective), various blocks/fluids — including, in particular, water — are rendered in a glitchy manner.

This is due to the pixel-centering offset of `0.5` being added *after* performing boost-related coordinate scaling. Because of that, certain raytracing rays end up at integer-valued coordinates, which the intersection testing code does not react well to. (Also, high-resolution tiles may be irritatingly misaligned w.r.t. block boundaries.)

By adding `0.5` in pixel space instead, these issues are resolved.

I estimate this change to be very low-risk (unless the behavior change is deemed undesirable).