### PR TITLE
fabric/build.gradle: replace compile with implementation

### DIFF
--- a/fabric-1.14.4/build.gradle
+++ b/fabric-1.14.4/build.gradle
@@ -19,7 +19,7 @@ group = parent.group
 
 configurations {
     shadow
-    compile.extendsFrom(shadow)
+    implementation.extendsFrom(shadow)
 }
 
 dependencies {

--- a/fabric-1.15.2/build.gradle
+++ b/fabric-1.15.2/build.gradle
@@ -19,7 +19,7 @@ group = parent.group
 
 configurations {
     shadow
-    compile.extendsFrom(shadow)
+    implementation.extendsFrom(shadow)
 }
 
 dependencies {

--- a/fabric-1.16.4/build.gradle
+++ b/fabric-1.16.4/build.gradle
@@ -19,7 +19,7 @@ group = parent.group
 
 configurations {
     shadow
-    compile.extendsFrom(shadow)
+    implementation.extendsFrom(shadow)
 }
 
 dependencies {

--- a/fabric-1.17.1/build.gradle
+++ b/fabric-1.17.1/build.gradle
@@ -19,7 +19,7 @@ group = parent.group
 
 configurations {
     shadow
-    compile.extendsFrom(shadow)
+    implementation.extendsFrom(shadow)
 }
 
 dependencies {

--- a/fabric-1.18/build.gradle
+++ b/fabric-1.18/build.gradle
@@ -24,7 +24,7 @@ group = parent.group
 
 configurations {
     shadow
-    compile.extendsFrom(shadow)
+    implementation.extendsFrom(shadow)
 }
 
 dependencies {


### PR DESCRIPTION
This fixes starting the Fabric mod under IntelliJ and command line:

`./gradlew fabric-1.18:runServer`

The change should have happened when we upgraded to Gradle 7.0 but it somehow slipped since it only affects IDE runs, not building the shadowed JAR.