### PR TITLE
Add tab completions for commands

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -1877,6 +1877,10 @@ public class DynmapCore implements DynmapCommonAPI {
             return dmapcmds.getTabCompletions(sender, args, this);
         }
 
+        if (cmd.equalsIgnoreCase("dmarker")) {
+            return markerapi.getTabCompletions(sender, args, this);
+        }
+
         if (!cmd.equalsIgnoreCase("dynmap")) {
             return Collections.emptyList();
         }

--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -1881,6 +1881,10 @@ public class DynmapCore implements DynmapCommonAPI {
             return markerapi.getTabCompletions(sender, args, this);
         }
 
+        if (cmd.equalsIgnoreCase("dynmapexp")) {
+            return dynmapexpcmds.getTabCompletions(sender, args, this);
+        }
+
         if (!cmd.equalsIgnoreCase("dynmap")) {
             return Collections.emptyList();
         }

--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -1248,7 +1248,7 @@ public class DynmapCore implements DynmapCommonAPI {
         new CommandInfo("dmarker", "movehere", "id:<id>", "Move marker with ID <id> to current location."),
         new CommandInfo("dmarker", "update", "<label> icon:<icon> newlabel:<newlabel>", "Update marker with ID <id> with new label <newlabel> and new icon <icon>."),
         new CommandInfo("dmarker", "delete", "<label>", "Delete marker with label of <label>."),
-        new CommandInfo("dmarker", "delete ", "id:<id>", "Delete marker with ID of <id>."),
+        new CommandInfo("dmarker", "delete", "id:<id>", "Delete marker with ID of <id>."),
         new CommandInfo("dmarker", "list", "List details of all markers."),
         new CommandInfo("dmarker", "icons", "List details of all icons."),
         new CommandInfo("dmarker", "addset", "<label>", "Add marker set with label <label>."),
@@ -1348,7 +1348,28 @@ public class DynmapCore implements DynmapCommonAPI {
         }
         sender.sendMessage(subcmdlist);
     }
-    
+
+    /**
+     * Returns tab completion suggestions for subcommands
+     *
+     * @param sender - The command sender requesting the tab completion suggestions
+     * @param cmd    - The top level command to suggest for
+     * @param arg    - Optional partial subcommand name to filter by
+     * @return List of tab completion suggestions
+     */
+    List<String> getSubcommandSuggestions(DynmapCommandSender sender, String cmd, String arg) {
+        List<String> suggestions = new ArrayList<>();
+
+        for (CommandInfo ci : commandinfo) {
+            //TODO: Permission checks
+            if (ci.matches(cmd) && ci.subcmd.startsWith(arg) && !suggestions.contains(ci.subcmd)) {
+                suggestions.add(ci.subcmd);
+            }
+        }
+
+        return suggestions;
+    }
+
     public boolean processCommand(DynmapCommandSender sender, String cmd, String commandLabel, String[] args) {
         if (mapManager == null) { // Initialization faulure
             sender.sendMessage("Dynmap failed to initialize properly: commands not available");
@@ -1726,6 +1747,27 @@ public class DynmapCore implements DynmapCommonAPI {
 
         return true;
     }
+
+    /**
+     * Returns a list of tab completion suggestions for the given sender, command and command arguments.
+     *
+     * @param sender - The sender of the tab completion, used for permission checks
+     * @param cmd - The top level command being tab completed
+     * @param args - Array of extra command arguments
+     * @return List of tab completion suggestions
+     */
+    public List<String> getTabCompletions(DynmapCommandSender sender, String cmd, String[] args) {
+        if (mapManager == null) {
+            return Collections.emptyList();
+        }
+
+        if (args.length <= 1) {
+            return getSubcommandSuggestions(sender, cmd, args[0]);
+        }
+
+        return Collections.emptyList();
+    }
+
     public boolean checkPlayerPermission(DynmapCommandSender sender, String permission) {
         if (!(sender instanceof DynmapPlayer) || sender.isOp()) {
             return true;

--- a/DynmapCore/src/main/java/org/dynmap/DynmapMapCommands.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapMapCommands.java
@@ -172,7 +172,7 @@ public class DynmapMapCommands {
 
 	public List<String> getTabCompletions(DynmapCommandSender sender, String[] args, DynmapCore core) {
 		/* Re-parse args - handle doublequotes */
-		args = DynmapCore.parseArgs(args, sender);
+		args = DynmapCore.parseArgs(args, sender, true);
 
 		if (args == null || args.length <= 1) {
 			return Collections.emptyList();

--- a/DynmapCore/src/main/java/org/dynmap/DynmapMapCommands.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapMapCommands.java
@@ -1,11 +1,16 @@
 package org.dynmap;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 
 import org.dynmap.common.DynmapCommandSender;
 import org.dynmap.common.DynmapPlayer;
@@ -22,6 +27,76 @@ import org.dynmap.utils.VisibilityLimit;
  * Handler for world and map edit commands (via /dmap)
  */
 public class DynmapMapCommands {
+	private Map<String, Map<String, Supplier<String[]>>> tabCompletions = null;
+
+	/**
+	 * Generates a map of field:value argument tab completion suggestions for every /dmap subcommand
+	 */
+	private void initTabCompletions() {
+		//Static values
+		String[] emptyValue = new String[]{};
+		String[] booleanValue = new String[]{"true", "false"};
+		String[] hideStyles = Arrays.stream(HiddenChunkStyle.values()).map(HiddenChunkStyle::getValue)
+				.toArray(String[]::new);
+		String[] perspectives = MapManager.mapman.hdmapman.perspectives.keySet().toArray(new String[0]);
+		String[] shaders = MapManager.mapman.hdmapman.shaders.keySet().toArray(new String[0]);
+		String[] lightings = MapManager.mapman.hdmapman.lightings.keySet().toArray(new String[0]);
+		String[] imageFormats = Arrays.stream(MapType.ImageFormat.values())
+				.map(MapType.ImageFormat::getID).toArray(String[]::new);
+
+		Supplier<String[]> emptySupplier = () -> emptyValue;
+		Supplier<String[]> booleanSupplier = () -> booleanValue;
+		Supplier<String[]> hideStyleSupplier = () -> hideStyles;
+		Supplier<String[]> perspectiveSupplier = () -> perspectives;
+		Supplier<String[]> shaderSupplier = () -> shaders;
+		Supplier<String[]> lightingSupplier = () -> lightings;
+		Supplier<String[]> imageFormatSupplier = () -> imageFormats;
+
+		//Arguments for /dmap worldset
+		Map<String, Supplier<String[]>> worldSetArgs = new LinkedHashMap<>();
+		worldSetArgs.put("enabled", booleanSupplier);
+		worldSetArgs.put("title", emptySupplier);
+		worldSetArgs.put("order", emptySupplier);
+		worldSetArgs.put("center", emptySupplier);
+		worldSetArgs.put("sendposition", booleanSupplier);
+		worldSetArgs.put("sendhealth", booleanSupplier);
+		worldSetArgs.put("showborder", booleanSupplier);
+		worldSetArgs.put("protected", booleanSupplier);
+		worldSetArgs.put("extrazoomout", emptySupplier);
+		worldSetArgs.put("tileupdatedelay", emptySupplier);
+
+		//Arguments for /dmap worldaddlimit
+		Map<String, Supplier<String[]>> worldAddLimitArgs = new LinkedHashMap<>();
+		worldAddLimitArgs.put("type", () -> new String[]{"round", "rect"});
+		worldAddLimitArgs.put("limittype", () -> new String[]{"visible", "hidden"});
+		worldAddLimitArgs.put("style", hideStyleSupplier);
+		worldAddLimitArgs.put("corner1", emptySupplier);
+		worldAddLimitArgs.put("corner2", emptySupplier);
+		worldAddLimitArgs.put("center", emptySupplier);
+		worldAddLimitArgs.put("radius", emptySupplier);
+
+		//Arguments for /dmap mapadd/mapset
+		Map<String, Supplier<String[]>> mapSetArgs = new LinkedHashMap<>();
+		mapSetArgs.put("title", emptySupplier);
+		mapSetArgs.put("icon", emptySupplier);
+		mapSetArgs.put("order", emptySupplier);
+		mapSetArgs.put("prefix", emptySupplier);
+		mapSetArgs.put("perspective", perspectiveSupplier);
+		mapSetArgs.put("shader", shaderSupplier);
+		mapSetArgs.put("lighting", lightingSupplier);
+		mapSetArgs.put("img-format", imageFormatSupplier);
+		mapSetArgs.put("protected", booleanSupplier);
+		mapSetArgs.put("append-to-world", emptySupplier);
+		mapSetArgs.put("mapzoomin", emptySupplier);
+		mapSetArgs.put("mapzoomout", emptySupplier);
+		mapSetArgs.put("boostzoom", emptySupplier);
+		mapSetArgs.put("tileupdatedelay", emptySupplier);
+
+		tabCompletions = new HashMap<>();
+		tabCompletions.put("worldaddlimit", worldAddLimitArgs);
+		tabCompletions.put("worldset", worldSetArgs);
+		tabCompletions.put("mapset", mapSetArgs); //Also used for mapadd
+	}
 
     private boolean checkIfActive(DynmapCore core, DynmapCommandSender sender) {
         if ((!core.getPauseFullRadiusRenders()) || (!core.getPauseUpdateRenders())) {
@@ -94,6 +169,78 @@ public class DynmapMapCommands {
         }
         return rslt;
     }
+
+	public List<String> getTabCompletions(DynmapCommandSender sender, String[] args, DynmapCore core) {
+		/* Re-parse args - handle doublequotes */
+		args = DynmapCore.parseArgs(args, sender);
+
+		if (args == null || args.length <= 1) {
+			return Collections.emptyList();
+		}
+
+		if (tabCompletions == null) {
+			initTabCompletions();
+		}
+
+		String cmd = args[0];
+
+		if (cmd.equalsIgnoreCase("worldlist")
+				&& core.checkPlayerPermission(sender, "dmap.worldlist")) {
+			List<String> suggestions = core.getWorldSuggestions(args[args.length - 1]);
+			suggestions.removeAll(Arrays.asList(args)); //Remove suggestions present in other arguments
+
+			return suggestions;
+		} else if ((cmd.equalsIgnoreCase("maplist")
+				&& core.checkPlayerPermission(sender, "dmap.maplist"))
+				|| (cmd.equalsIgnoreCase("worldgetlimits")
+				&& core.checkPlayerPermission(sender, "dmap.worldlist"))) {
+			if (args.length == 2) {
+				return core.getWorldSuggestions(args[1]);
+			}
+		} else if (cmd.equalsIgnoreCase("worldremovelimit")
+				&& core.checkPlayerPermission(sender, "dmap.worldset")) {
+			if (args.length == 2) {
+				return core.getWorldSuggestions(args[1]);
+			}
+		} else if (cmd.equalsIgnoreCase("worldaddlimit")
+				&& core.checkPlayerPermission(sender, "dmap.worldset")) {
+			if (args.length == 2) {
+				return core.getWorldSuggestions(args[1]);
+			} else {
+				return core.getFieldValueSuggestions(args, tabCompletions.get("worldaddlimit"));
+			}
+		} else if (cmd.equalsIgnoreCase("worldset")
+				&& core.checkPlayerPermission(sender, "dmap.worldset")) {
+			if (args.length == 2) {
+				return core.getWorldSuggestions(args[1]);
+			} else {
+				return core.getFieldValueSuggestions(args, tabCompletions.get("worldset"));
+			}
+		} else if (cmd.equalsIgnoreCase("mapdelete")
+				&& core.checkPlayerPermission(sender, "dmap.mapdelete")) {
+			if (args.length == 2) {
+				return core.getMapSuggestions(args[1]);
+			}
+		} else if (cmd.equalsIgnoreCase("worldreset")
+				&& core.checkPlayerPermission(sender, "dmap.worldreset")) {
+			if (args.length == 2) {
+				return core.getWorldSuggestions(args[1]);
+			}
+		} else if (cmd.equalsIgnoreCase("mapset")
+				&& core.checkPlayerPermission(sender, "dmap.mapset")) {
+			if (args.length == 2) {
+				return core.getMapSuggestions(args[1]);
+			} else {
+				return core.getFieldValueSuggestions(args, tabCompletions.get("mapset"));
+			}
+		} else if (cmd.equalsIgnoreCase("mapadd")) {
+			if (args.length > 2) {
+				return core.getFieldValueSuggestions(args, tabCompletions.get("mapset"));
+			}
+		}
+
+		return Collections.emptyList();
+	}
     
     private boolean handleWorldList(DynmapCommandSender sender, String[] args, DynmapCore core) {
         if(!core.checkPlayerPermission(sender, "dmap.worldlist"))

--- a/DynmapCore/src/main/java/org/dynmap/exporter/DynmapExpCommands.java
+++ b/DynmapCore/src/main/java/org/dynmap/exporter/DynmapExpCommands.java
@@ -1,7 +1,13 @@
 package org.dynmap.exporter;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.dynmap.DynmapCore;
 import org.dynmap.DynmapLocation;
@@ -89,6 +95,53 @@ public class DynmapExpCommands {
         }
 
         return rslt;
+    }
+
+    public List<String> getTabCompletions(DynmapCommandSender sender, String[] args, DynmapCore core) {
+        /* Re-parse args - handle doublequotes */
+		args = DynmapCore.parseArgs(args, sender);
+
+		if (args == null || args.length <= 1) {
+			return Collections.emptyList();
+		}
+
+		String cmd = args[0];
+
+        if(cmd.equalsIgnoreCase("set")) {
+            List<String> keys = new ArrayList<>(
+                    Arrays.asList("x0", "x1", "y0", "y1", "z0", "z1", "world", "shader", "byChunk",
+                                  "byBlockID", "byBlockIDData", "byTexture"));
+
+            if (args.length % 2 == 0) { // Args contain only complete key value argument pairs (plus subcommand)
+                // Remove previous used keys
+                for (int i = 1; i < args.length; i += 2) {
+                    keys.remove(args[i]);
+                }
+
+                return keys;
+            } else { // Incomplete key value argument pair, suggest values
+                final String lastKey = args[args.length - 2];
+                final String lastValue = args[args.length - 1];
+
+                switch(lastKey) {
+                    case "world":
+                        return core.getWorldSuggestions(lastValue);
+                    case "shader":
+                        return MapManager.mapman.hdmapman.shaders.keySet().stream()
+                                .filter(value -> value.startsWith(lastValue))
+                                .collect(Collectors.toList());
+                    case "byChunk":
+                    case "byBlockID":
+                    case "byBlockIDData":
+                    case "byTexture":
+                        return Stream.of("true", "false")
+                                .filter(value -> value.startsWith(lastValue))
+                                .collect(Collectors.toList());
+                }
+            }
+        }
+
+        return Collections.emptyList();
     }
 
     private boolean handleInfo(DynmapCommandSender sender, String[] args, ExportContext ctx, DynmapCore core) {

--- a/DynmapCore/src/main/java/org/dynmap/exporter/DynmapExpCommands.java
+++ b/DynmapCore/src/main/java/org/dynmap/exporter/DynmapExpCommands.java
@@ -99,7 +99,7 @@ public class DynmapExpCommands {
 
     public List<String> getTabCompletions(DynmapCommandSender sender, String[] args, DynmapCore core) {
         /* Re-parse args - handle doublequotes */
-		args = DynmapCore.parseArgs(args, sender);
+		args = DynmapCore.parseArgs(args, sender, true);
 
 		if (args == null || args.length <= 1) {
 			return Collections.emptyList();

--- a/DynmapCore/src/main/java/org/dynmap/markers/impl/MarkerAPIImpl.java
+++ b/DynmapCore/src/main/java/org/dynmap/markers/impl/MarkerAPIImpl.java
@@ -1503,7 +1503,7 @@ public class MarkerAPIImpl implements MarkerAPI, Event.Listener<DynmapWorld> {
 
     public List<String> getTabCompletions(DynmapCommandSender sender, String[] args, DynmapCore core) {
         /* Re-parse args - handle doublequotes */
-        args = DynmapCore.parseArgs(args, sender);
+        args = DynmapCore.parseArgs(args, sender, true);
 
         if (args == null || args.length <= 1) {
             return Collections.emptyList();

--- a/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -1103,6 +1104,21 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
         	return false;
     }
 
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command cmd, String alias, String[] args) {
+        DynmapCommandSender dsender;
+        if(sender instanceof Player) {
+            dsender = new BukkitPlayer((Player)sender);
+        }
+        else {
+            dsender = new BukkitCommandSender(sender);
+        }
+
+        if (core != null)
+        	return core.getTabCompletions(dsender, cmd.getName(), args);
+        else
+        	return Collections.emptyList();
+    }
     
     @Override
     public final MarkerAPI getMarkerAPI() {


### PR DESCRIPTION
This is an initial attempt at implementing tab completions for Dynmap's commands (as requested in #3461).

Whilst this PR only implements them fully on the Spigot platform, the logic for generating the list of suggestions is located in DynmapCore, so anyone with sufficient knowledge of other platforms should be able to implement them there. The logic closely follows the existing `processCommand` logic, and aims to handle as many argument combinations as is practical.

This PR makes no changes to the structure, handling or argument order of commands.

**Additions:**
- A `getTabCompletions` method in DynmapCore, which accepts a `DynmapCommandSender` and the entered command and arguments. It returns suggestions as a `List<String>`, which is the structure spigot expects for tab completions (and other platforms hopefully support in some form).
- Further `getTabCompletions` and `initFieldTabCompletions` methods on the classes handling other top level Dynmap commands.
- An `onTabCompletion` method in the spigot DynmapPlugin class, called by spigot and returns the completions generated by DynmapCore.
- Various utility methods in DynmapCore for generating different types of suggestions relevant to multiple commands.
- An `allowUnclosedQuotes` boolean argument for `DynmapCore::parseArgs`. When true, arguments with unclosed quotes will not display an error in chat, and any input within the unclosed quote is added to the argument list minus the trailing space.
  - Other existing calls to `parseArgs` are unchanged, and an overload with the original signature has been added defaulting to false.

**Implemented completions:**
- Subcommands for `/dynmap` (`and /dynmap help`),  `/dmarker`, `/dmap` and `/dynmapexp`
  - Uses the existing `commandinfo` list
- World, map, world:map and player completions for the `/dynmap` and `/dmap` subcommands that take them
  - `/dynmap hide` and `/dynmap show` will suggest visible and hidden players respectively.
  - Other player commands will suggest all online players.
- Completions for regular and `field:value` arguments in `/dmap` and `/dmarker` subcommands
  - Arguments already present with a value are not suggested again.
  - Arguments with finite values will suggest their values after the `:` has been typed.
    - `perspective:`, `lighting:`, `shader:` and `img-format:` will suggest defined perspectives,  lightings, shaders and image formats respectively.
    - `type:` in `/dmap worldaddlimit` will suggest `"round"/"rect"`.
    - `limittype:` in `/dmap worldaddlimit` will suggest `"hidden"/"visible"`.
    - `style:` in `/dmap worldaddlimit` will suggest `"ocean"/"stone"/"air"`.
    -  Boolean fields such as `sendhealth:` and `protected:` will suggest `"true"/"false"`.
    - `set:` and `newset:` in `/dmarker` commands will suggest existing marker sets
    - `icon:` and `deficon:` in `/dmarker` commands will suggest defined icons
  - Values with spaces will be suggested with quotes.
  - Quoted values will be suggested without having to type the quotes.
- Completions for `/dynmapexp set` arguments

**Outstanding things:**
- Limit subcommand suggestions to ones the sender has permission to use.
  - Adding a permission field to `CommandInfo` could work as that'd also allow filtering the existing help text by permissions too.
