### PR TITLE
Bumped spellcheck GitHub action to version 0.20.0

### DIFF
--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -11,4 +11,4 @@ jobs:
     - name: actions/checkout
       uses: actions/checkout@v2
     - name: rojopolis/spellcheck - actually doing something
-      uses: rojopolis/spellcheck-github-actions@0.16.0
+      uses: rojopolis/spellcheck-github-actions@0.20.0


### PR DESCRIPTION
I have recently released 0.20.0 of the spellcheck GitHub action, I can see that you are using 0.16.0, so an update could be useful to you. Let me know if you have any issues with the proposal and I will try to accommodate.

I can recommend [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, if you want a PR proposing a basic configuration, please let me know.