### PR TITLE
Cleanup Fabric Gradle projects

### DIFF
--- a/fabric-1.14.4/build.gradle
+++ b/fabric-1.14.4/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'fabric-loom' version '0.10.65'
 }
 
-archivesBaseName = project.archives_base_name
+archivesBaseName = "Dynmap"
 version = parent.version
 group = parent.group
 

--- a/fabric-1.14.4/build.gradle
+++ b/fabric-1.14.4/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.6-SNAPSHOT'
+	id 'fabric-loom' version '0.10.65'
 }
 
 archivesBaseName = project.archives_base_name

--- a/fabric-1.14.4/build.gradle
+++ b/fabric-1.14.4/build.gradle
@@ -43,8 +43,8 @@ jar {
 }
 
 remapJar {
-    archiveName = "${archivesBaseName}-${version}-fabric-${project.minecraft_version}.jar"
-    destinationDir = file '../target'
+    archiveFileName = "${archivesBaseName}-${project.version}-fabric-${project.minecraft_version}.jar"
+    destinationDirectory = file '../target'
 }
 
 remapJar.doLast {

--- a/fabric-1.14.4/build.gradle
+++ b/fabric-1.14.4/build.gradle
@@ -1,14 +1,6 @@
-buildscript {
-    repositories {
-        maven { url = 'https://maven.fabricmc.net/' }
-        jcenter()
-        mavenCentral()
-    }
-    dependencies {
-        classpath group: 'net.fabricmc', name: 'fabric-loom', version: '0.6-SNAPSHOT'
-    }
+plugins {
+	id 'fabric-loom' version '0.6-SNAPSHOT'
 }
-apply plugin: 'fabric-loom'
 
 archivesBaseName = project.archives_base_name
 version = parent.version

--- a/fabric-1.14.4/build.gradle
+++ b/fabric-1.14.4/build.gradle
@@ -10,9 +10,6 @@ buildscript {
 }
 apply plugin: 'fabric-loom'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 archivesBaseName = project.archives_base_name
 version = parent.version
 group = parent.group
@@ -43,13 +40,6 @@ processResources {
     filesMatching('fabric.mod.json') {
         expand "version": project.version
     }
-}
-
-// ensure that the encoding is set to UTF-8, no matter what the system default is
-// this fixes some edge cases with special characters not displaying correctly
-// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-tasks.withType(JavaCompile) {
-    options.encoding = "UTF-8"
 }
 
 java {

--- a/fabric-1.14.4/build.gradle
+++ b/fabric-1.14.4/build.gradle
@@ -12,20 +12,14 @@ configurations {
 }
 
 dependencies {
-    //to change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-
-    // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
     compileOnly group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
 
     shadow project(path: ':DynmapCore', configuration: 'shadow')
-
-    // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
-    // You may need to force-disable transitiveness on them.
 }
 
 processResources {

--- a/fabric-1.14.4/build.gradle
+++ b/fabric-1.14.4/build.gradle
@@ -52,12 +52,11 @@ tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources"
-    from sourceSets.main.allSource
+java {
+    // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+    // if it is present.
+    // If you remove this line, sources will not be generated.
+    withSourcesJar()
 }
 
 jar {

--- a/fabric-1.14.4/gradle.properties
+++ b/fabric-1.14.4/gradle.properties
@@ -1,11 +1,4 @@
-# Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
-# Fabric Properties
-# check these on https://fabricmc.net/use
 minecraft_version=1.14.4
 yarn_mappings=1.14.4+build.18
 loader_version=0.12.12
-# Mod Properties
-# Dependencies
-# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 fabric_version=0.28.5+1.14

--- a/fabric-1.14.4/gradle.properties
+++ b/fabric-1.14.4/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # check these on https://fabricmc.net/use
 minecraft_version=1.14.4
 yarn_mappings=1.14.4+build.18
-loader_version=0.10.1+build.209
+loader_version=0.12.12
 # Mod Properties
 archives_base_name=Dynmap
 # Dependencies

--- a/fabric-1.14.4/gradle.properties
+++ b/fabric-1.14.4/gradle.properties
@@ -6,7 +6,6 @@ minecraft_version=1.14.4
 yarn_mappings=1.14.4+build.18
 loader_version=0.12.12
 # Mod Properties
-archives_base_name=Dynmap
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 fabric_version=0.28.5+1.14

--- a/fabric-1.14.4/src/main/resources/fabric.mod.json
+++ b/fabric-1.14.4/src/main/resources/fabric.mod.json
@@ -26,7 +26,7 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.7.4",
+    "fabricloader": ">=0.12.12",
     "fabric": ">=0.17.0",
     "minecraft": "1.14.4"
   }

--- a/fabric-1.15.2/build.gradle
+++ b/fabric-1.15.2/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'fabric-loom' version '0.10.65'
 }
 
-archivesBaseName = project.archives_base_name
+archivesBaseName = "Dynmap"
 version = parent.version
 group = parent.group
 

--- a/fabric-1.15.2/build.gradle
+++ b/fabric-1.15.2/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.6-SNAPSHOT'
+	id 'fabric-loom' version '0.10.65'
 }
 
 archivesBaseName = project.archives_base_name

--- a/fabric-1.15.2/build.gradle
+++ b/fabric-1.15.2/build.gradle
@@ -43,8 +43,8 @@ jar {
 }
 
 remapJar {
-    archiveName = "${archivesBaseName}-${version}-fabric-${project.minecraft_version}.jar"
-    destinationDir = file '../target'
+    archiveFileName = "${archivesBaseName}-${project.version}-fabric-${project.minecraft_version}.jar"
+    destinationDirectory = file '../target'
 }
 
 remapJar.doLast {

--- a/fabric-1.15.2/build.gradle
+++ b/fabric-1.15.2/build.gradle
@@ -1,14 +1,6 @@
-buildscript {
-    repositories {
-        maven { url = 'https://maven.fabricmc.net/' }
-        jcenter()
-        mavenCentral()
-    }
-    dependencies {
-        classpath group: 'net.fabricmc', name: 'fabric-loom', version: '0.6-SNAPSHOT'
-    }
+plugins {
+	id 'fabric-loom' version '0.6-SNAPSHOT'
 }
-apply plugin: 'fabric-loom'
 
 archivesBaseName = project.archives_base_name
 version = parent.version

--- a/fabric-1.15.2/build.gradle
+++ b/fabric-1.15.2/build.gradle
@@ -10,9 +10,6 @@ buildscript {
 }
 apply plugin: 'fabric-loom'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 archivesBaseName = project.archives_base_name
 version = parent.version
 group = parent.group
@@ -43,13 +40,6 @@ processResources {
     filesMatching('fabric.mod.json') {
         expand "version": project.version
     }
-}
-
-// ensure that the encoding is set to UTF-8, no matter what the system default is
-// this fixes some edge cases with special characters not displaying correctly
-// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-tasks.withType(JavaCompile) {
-    options.encoding = "UTF-8"
 }
 
 java {

--- a/fabric-1.15.2/build.gradle
+++ b/fabric-1.15.2/build.gradle
@@ -12,20 +12,14 @@ configurations {
 }
 
 dependencies {
-    //to change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-
-    // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
     compileOnly group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
 
     shadow project(path: ':DynmapCore', configuration: 'shadow')
-
-    // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
-    // You may need to force-disable transitiveness on them.
 }
 
 processResources {

--- a/fabric-1.15.2/build.gradle
+++ b/fabric-1.15.2/build.gradle
@@ -52,12 +52,11 @@ tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources"
-    from sourceSets.main.allSource
+java {
+    // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+    // if it is present.
+    // If you remove this line, sources will not be generated.
+    withSourcesJar()
 }
 
 jar {

--- a/fabric-1.15.2/gradle.properties
+++ b/fabric-1.15.2/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # check these on https://fabricmc.net/use
 minecraft_version=1.15.2
 yarn_mappings=1.15.2+build.17
-loader_version=0.10.1+build.209
+loader_version=0.12.12
 # Mod Properties
 archives_base_name=Dynmap
 # Dependencies

--- a/fabric-1.15.2/gradle.properties
+++ b/fabric-1.15.2/gradle.properties
@@ -6,7 +6,6 @@ minecraft_version=1.15.2
 yarn_mappings=1.15.2+build.17
 loader_version=0.12.12
 # Mod Properties
-archives_base_name=Dynmap
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 fabric_version=0.23.0+build.328-1.15

--- a/fabric-1.15.2/gradle.properties
+++ b/fabric-1.15.2/gradle.properties
@@ -1,4 +1,4 @@
 minecraft_version=1.15.2
 yarn_mappings=1.15.2+build.17
 loader_version=0.12.12
-fabric_version=0.23.0+build.328-1.15
+fabric_version=0.28.5+1.15

--- a/fabric-1.15.2/gradle.properties
+++ b/fabric-1.15.2/gradle.properties
@@ -1,11 +1,4 @@
-# Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
-# Fabric Properties
-# check these on https://fabricmc.net/use
 minecraft_version=1.15.2
 yarn_mappings=1.15.2+build.17
 loader_version=0.12.12
-# Mod Properties
-# Dependencies
-# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 fabric_version=0.23.0+build.328-1.15

--- a/fabric-1.15.2/src/main/resources/fabric.mod.json
+++ b/fabric-1.15.2/src/main/resources/fabric.mod.json
@@ -26,7 +26,7 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.7.4",
+    "fabricloader": ">=0.12.12",
     "fabric": ">=0.17.0",
     "minecraft": "1.15.2"
   }

--- a/fabric-1.16.4/build.gradle
+++ b/fabric-1.16.4/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'fabric-loom' version '0.10.65'
 }
 
-archivesBaseName = project.archives_base_name
+archivesBaseName = "Dynmap"
 version = parent.version
 group = parent.group
 

--- a/fabric-1.16.4/build.gradle
+++ b/fabric-1.16.4/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.6-SNAPSHOT'
+	id 'fabric-loom' version '0.10.65'
 }
 
 archivesBaseName = project.archives_base_name

--- a/fabric-1.16.4/build.gradle
+++ b/fabric-1.16.4/build.gradle
@@ -43,8 +43,8 @@ jar {
 }
 
 remapJar {
-    archiveName = "${archivesBaseName}-${version}-fabric-${project.minecraft_version}.jar"
-    destinationDir = file '../target'
+    archiveFileName = "${archivesBaseName}-${project.version}-fabric-${project.minecraft_version}.jar"
+    destinationDirectory = file '../target'
 }
 
 remapJar.doLast {

--- a/fabric-1.16.4/build.gradle
+++ b/fabric-1.16.4/build.gradle
@@ -1,14 +1,6 @@
-buildscript {
-    repositories {
-        maven { url = 'https://maven.fabricmc.net/' }
-        jcenter()
-        mavenCentral()
-    }
-    dependencies {
-        classpath group: 'net.fabricmc', name: 'fabric-loom', version: '0.6-SNAPSHOT'
-    }
+plugins {
+	id 'fabric-loom' version '0.6-SNAPSHOT'
 }
-apply plugin: 'fabric-loom'
 
 archivesBaseName = project.archives_base_name
 version = parent.version

--- a/fabric-1.16.4/build.gradle
+++ b/fabric-1.16.4/build.gradle
@@ -10,9 +10,6 @@ buildscript {
 }
 apply plugin: 'fabric-loom'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 archivesBaseName = project.archives_base_name
 version = parent.version
 group = parent.group
@@ -43,13 +40,6 @@ processResources {
     filesMatching('fabric.mod.json') {
         expand "version": project.version
     }
-}
-
-// ensure that the encoding is set to UTF-8, no matter what the system default is
-// this fixes some edge cases with special characters not displaying correctly
-// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-tasks.withType(JavaCompile) {
-    options.encoding = "UTF-8"
 }
 
 java {

--- a/fabric-1.16.4/build.gradle
+++ b/fabric-1.16.4/build.gradle
@@ -12,20 +12,14 @@ configurations {
 }
 
 dependencies {
-    //to change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-
-    // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
     compileOnly group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
 
     shadow project(path: ':DynmapCore', configuration: 'shadow')
-
-    // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
-    // You may need to force-disable transitiveness on them.
 }
 
 processResources {

--- a/fabric-1.16.4/build.gradle
+++ b/fabric-1.16.4/build.gradle
@@ -52,12 +52,11 @@ tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources"
-    from sourceSets.main.allSource
+java {
+    // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+    // if it is present.
+    // If you remove this line, sources will not be generated.
+    withSourcesJar()
 }
 
 jar {

--- a/fabric-1.16.4/gradle.properties
+++ b/fabric-1.16.4/gradle.properties
@@ -6,7 +6,6 @@ minecraft_version=1.16.4
 yarn_mappings=1.16.4+build.6
 loader_version=0.12.12
 # Mod Properties
-archives_base_name=Dynmap
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 fabric_version=0.25.1+build.416-1.16

--- a/fabric-1.16.4/gradle.properties
+++ b/fabric-1.16.4/gradle.properties
@@ -1,11 +1,4 @@
-# Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
-# Fabric Properties
-# check these on https://fabricmc.net/use
 minecraft_version=1.16.4
 yarn_mappings=1.16.4+build.6
 loader_version=0.12.12
-# Mod Properties
-# Dependencies
-# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 fabric_version=0.25.1+build.416-1.16

--- a/fabric-1.16.4/gradle.properties
+++ b/fabric-1.16.4/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # check these on https://fabricmc.net/use
 minecraft_version=1.16.4
 yarn_mappings=1.16.4+build.6
-loader_version=0.10.6+build.214
+loader_version=0.12.12
 # Mod Properties
 archives_base_name=Dynmap
 # Dependencies

--- a/fabric-1.16.4/gradle.properties
+++ b/fabric-1.16.4/gradle.properties
@@ -1,4 +1,4 @@
 minecraft_version=1.16.4
 yarn_mappings=1.16.4+build.6
 loader_version=0.12.12
-fabric_version=0.25.1+build.416-1.16
+fabric_version=0.42.0+1.16

--- a/fabric-1.16.4/src/main/resources/fabric.mod.json
+++ b/fabric-1.16.4/src/main/resources/fabric.mod.json
@@ -26,7 +26,7 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.7.4",
+    "fabricloader": ">=0.12.12",
     "fabric": ">=0.17.0",
     "minecraft": "1.16.x"
   }

--- a/fabric-1.17.1/build.gradle
+++ b/fabric-1.17.1/build.gradle
@@ -36,7 +36,6 @@ java {
 }
 
 jar {
-    duplicatesStrategy = 'include'
     from "LICENSE"
     from {
         configurations.shadow.collect { it.toString().contains("guava") ? null : it.isDirectory() ? it : zipTree(it) }

--- a/fabric-1.17.1/build.gradle
+++ b/fabric-1.17.1/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'fabric-loom' version '0.10.65'
 }
 
-archivesBaseName = project.archives_base_name
+archivesBaseName = "Dynmap"
 version = parent.version
 group = parent.group
 

--- a/fabric-1.17.1/build.gradle
+++ b/fabric-1.17.1/build.gradle
@@ -43,8 +43,8 @@ jar {
 }
 
 remapJar {
-    archiveName = "${archivesBaseName}-${version}-fabric-${project.minecraft_version}.jar"
-    destinationDir = file '../target'
+    archiveFileName = "${archivesBaseName}-${project.version}-fabric-${project.minecraft_version}.jar"
+    destinationDirectory = file '../target'
 }
 
 remapJar.doLast {

--- a/fabric-1.17.1/build.gradle
+++ b/fabric-1.17.1/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.10.65'
 }
 
 archivesBaseName = project.archives_base_name

--- a/fabric-1.17.1/build.gradle
+++ b/fabric-1.17.1/build.gradle
@@ -1,14 +1,6 @@
-buildscript {
-    repositories {
-        maven { url = 'https://maven.fabricmc.net/' }
-        jcenter()
-        mavenCentral()
-    }
-    dependencies {
-        classpath group: 'net.fabricmc', name: 'fabric-loom', version: '0.8-SNAPSHOT'
-    }
+plugins {
+	id 'fabric-loom' version '0.8-SNAPSHOT'
 }
-apply plugin: 'fabric-loom'
 
 archivesBaseName = project.archives_base_name
 version = parent.version

--- a/fabric-1.17.1/build.gradle
+++ b/fabric-1.17.1/build.gradle
@@ -12,20 +12,14 @@ configurations {
 }
 
 dependencies {
-    //to change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-
-    // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
     compileOnly group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
 
     shadow project(path: ':DynmapCore', configuration: 'shadow')
-
-    // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
-    // You may need to force-disable transitiveness on them.
 }
 
 processResources {

--- a/fabric-1.17.1/build.gradle
+++ b/fabric-1.17.1/build.gradle
@@ -10,9 +10,6 @@ buildscript {
 }
 apply plugin: 'fabric-loom'
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
-
 archivesBaseName = project.archives_base_name
 version = parent.version
 group = parent.group
@@ -43,13 +40,6 @@ processResources {
     filesMatching('fabric.mod.json') {
         expand "version": project.version
     }
-}
-
-// ensure that the encoding is set to UTF-8, no matter what the system default is
-// this fixes some edge cases with special characters not displaying correctly
-// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-tasks.withType(JavaCompile) {
-    options.encoding = "UTF-8"
 }
 
 java {

--- a/fabric-1.17.1/build.gradle
+++ b/fabric-1.17.1/build.gradle
@@ -52,12 +52,11 @@ tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources"
-    from sourceSets.main.allSource
+java {
+    // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+    // if it is present.
+    // If you remove this line, sources will not be generated.
+    withSourcesJar()
 }
 
 jar {

--- a/fabric-1.17.1/gradle.properties
+++ b/fabric-1.17.1/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # check these on https://fabricmc.net/use
 minecraft_version=1.17.1
 yarn_mappings=1.17.1+build.1
-loader_version=0.11.6
+loader_version=0.12.12
 # Mod Properties
 archives_base_name=Dynmap
 # Dependencies

--- a/fabric-1.17.1/gradle.properties
+++ b/fabric-1.17.1/gradle.properties
@@ -1,11 +1,4 @@
-# Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
-# Fabric Properties
-# check these on https://fabricmc.net/use
 minecraft_version=1.17.1
 yarn_mappings=1.17.1+build.1
 loader_version=0.12.12
-# Mod Properties
-# Dependencies
-# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 fabric_version=0.36.1+1.17

--- a/fabric-1.17.1/gradle.properties
+++ b/fabric-1.17.1/gradle.properties
@@ -6,7 +6,6 @@ minecraft_version=1.17.1
 yarn_mappings=1.17.1+build.1
 loader_version=0.12.12
 # Mod Properties
-archives_base_name=Dynmap
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 fabric_version=0.36.1+1.17

--- a/fabric-1.17.1/gradle.properties
+++ b/fabric-1.17.1/gradle.properties
@@ -1,4 +1,4 @@
 minecraft_version=1.17.1
 yarn_mappings=1.17.1+build.1
 loader_version=0.12.12
-fabric_version=0.36.1+1.17
+fabric_version=0.45.1+1.17

--- a/fabric-1.17.1/src/main/resources/fabric.mod.json
+++ b/fabric-1.17.1/src/main/resources/fabric.mod.json
@@ -26,7 +26,7 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.7.4",
+    "fabricloader": ">=0.12.12",
     "fabric": ">=0.17.0",
     "minecraft": "1.17.1"
   }

--- a/fabric-1.18/build.gradle
+++ b/fabric-1.18/build.gradle
@@ -36,7 +36,6 @@ java {
 }
 
 jar {
-    duplicatesStrategy = 'include'
     from "LICENSE"
     from {
         configurations.shadow.collect { it.toString().contains("guava") ? null : it.isDirectory() ? it : zipTree(it) }

--- a/fabric-1.18/build.gradle
+++ b/fabric-1.18/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'fabric-loom' version '0.10.65'
 }
 
-archivesBaseName = project.archives_base_name
+archivesBaseName = "Dynmap"
 version = parent.version
 group = parent.group
 

--- a/fabric-1.18/build.gradle
+++ b/fabric-1.18/build.gradle
@@ -43,8 +43,8 @@ jar {
 }
 
 remapJar {
-    archiveName = "${archivesBaseName}-${version}-fabric-${project.minecraft_version}.jar"
-    destinationDir = file '../target'
+    archiveFileName = "${archivesBaseName}-${project.version}-fabric-${project.minecraft_version}.jar"
+    destinationDirectory = file '../target'
 }
 
 remapJar.doLast {

--- a/fabric-1.18/build.gradle
+++ b/fabric-1.18/build.gradle
@@ -1,18 +1,5 @@
-buildscript {
-    repositories {
-        maven { url = 'https://maven.fabricmc.net/' }
-        jcenter()
-        mavenCentral()
-    }
-    dependencies {
-        classpath group: 'net.fabricmc', name: 'fabric-loom', version: '0.10-SNAPSHOT'
-    }
-}
-apply plugin: 'fabric-loom'
-loom {
-    runConfigs.configureEach {
-        ideConfigGenerated = true
-    }
+plugins {
+	id 'fabric-loom' version '0.10-SNAPSHOT'
 }
 
 archivesBaseName = project.archives_base_name

--- a/fabric-1.18/build.gradle
+++ b/fabric-1.18/build.gradle
@@ -57,12 +57,11 @@ tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources"
-    from sourceSets.main.allSource
+java {
+    // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+    // if it is present.
+    // If you remove this line, sources will not be generated.
+    withSourcesJar()
 }
 
 jar {

--- a/fabric-1.18/build.gradle
+++ b/fabric-1.18/build.gradle
@@ -15,9 +15,6 @@ loom {
     }
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
-
 archivesBaseName = project.archives_base_name
 version = parent.version
 group = parent.group
@@ -48,13 +45,6 @@ processResources {
     filesMatching('fabric.mod.json') {
         expand "version": project.version
     }
-}
-
-// ensure that the encoding is set to UTF-8, no matter what the system default is
-// this fixes some edge cases with special characters not displaying correctly
-// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-tasks.withType(JavaCompile) {
-    options.encoding = "UTF-8"
 }
 
 java {

--- a/fabric-1.18/build.gradle
+++ b/fabric-1.18/build.gradle
@@ -12,20 +12,14 @@ configurations {
 }
 
 dependencies {
-    //to change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-
-    // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
     compileOnly group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
 
     shadow project(path: ':DynmapCore', configuration: 'shadow')
-
-    // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
-    // You may need to force-disable transitiveness on them.
 }
 
 processResources {

--- a/fabric-1.18/build.gradle
+++ b/fabric-1.18/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     compileOnly group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
 
     shadow project(path: ':DynmapCore', configuration: 'shadow')
-    shadow project(path: ':DynmapCoreAPI', configuration: 'shadow')
 
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
     // You may need to force-disable transitiveness on them.

--- a/fabric-1.18/build.gradle
+++ b/fabric-1.18/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.10-SNAPSHOT'
+	id 'fabric-loom' version '0.10.65'
 }
 
 archivesBaseName = project.archives_base_name

--- a/fabric-1.18/gradle.properties
+++ b/fabric-1.18/gradle.properties
@@ -1,4 +1,4 @@
 minecraft_version=1.18
 yarn_mappings=1.18+build.1
 loader_version=0.12.12
-fabric_version=0.43.1+1.18
+fabric_version=0.45.1+1.18

--- a/fabric-1.18/gradle.properties
+++ b/fabric-1.18/gradle.properties
@@ -1,13 +1,4 @@
-# Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
-
-# Mod Properties
-
-# Fabric Properties
-# check these on https://fabricmc.net/versions.html
 minecraft_version=1.18
 yarn_mappings=1.18+build.1
 loader_version=0.12.12
-
-#Fabric api
 fabric_version=0.43.1+1.18

--- a/fabric-1.18/gradle.properties
+++ b/fabric-1.18/gradle.properties
@@ -8,7 +8,7 @@ archives_base_name=Dynmap
 # check these on https://fabricmc.net/versions.html
 minecraft_version=1.18
 yarn_mappings=1.18+build.1
-loader_version=0.12.6
+loader_version=0.12.12
 
 #Fabric api
 fabric_version=0.43.1+1.18

--- a/fabric-1.18/gradle.properties
+++ b/fabric-1.18/gradle.properties
@@ -2,7 +2,6 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-archives_base_name=Dynmap
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html

--- a/fabric-1.18/src/main/resources/fabric.mod.json
+++ b/fabric-1.18/src/main/resources/fabric.mod.json
@@ -26,7 +26,7 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.12.6",
+    "fabricloader": ">=0.12.12",
     "fabric": ">=0.43.1",
     "minecraft": "1.18.x"
   }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ pluginManagement {
   repositories {
     gradlePluginPortal()
     maven { url "https://papermc.io/repo/repository/maven-public/" }
+    maven { url "https://maven.fabricmc.net/" }
   }
 }
 


### PR DESCRIPTION
Generic cleanup, updating the Gradle projects into something more modern and less cluttered. Lots of reduntant code and comments removed. After this cleanup all Fabric `build.gradle` files are the same, paving way for further unification. Additionally, I've updated all Fabric tooling to the newest available versions, fixing *tons* of random issues related to setting up a development environment.