### PR TITLE
Add %uuid% for player UUIDs in skin-url

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/PlayerFaces.java
+++ b/DynmapCore/src/main/java/org/dynmap/PlayerFaces.java
@@ -108,10 +108,12 @@ public class PlayerFaces {
     private class LoadPlayerImages implements Runnable {
         private SkinUrlProvider mSkinUrlProvider;
         public final String playername;
+        public final UUID playeruuid;
         public final String playerskinurl;
 
         public LoadPlayerImages(String playername, String playerskinurl, UUID playeruuid, SkinUrlProvider skinUrlProvider) {
             this.playername = playername;
+            this.playeruuid = playeruuid;
             this.playerskinurl = playerskinurl;
             mSkinUrlProvider = skinUrlProvider;
         }
@@ -131,7 +133,8 @@ public class PlayerFaces {
 
                     if (mSkinUrlProvider == null) {
                         if (!skinurl.equals("")) {
-                            url = new URL(skinurl.replace("%player%", URLEncoder.encode(playername, "UTF-8")));
+                            url = new URL(skinurl.replace("%player%", URLEncoder.encode(playername, "UTF-8"))
+                                                  .replace("%uuid%", playeruuid.toString()));
                         } else if (playerskinurl != null) {
                             url = new URL(playerskinurl);
                         }

--- a/fabric-1.14.4/src/main/resources/configuration.txt
+++ b/fabric-1.14.4/src/main/resources/configuration.txt
@@ -280,7 +280,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)

--- a/fabric-1.15.2/src/main/resources/configuration.txt
+++ b/fabric-1.15.2/src/main/resources/configuration.txt
@@ -280,7 +280,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)

--- a/fabric-1.16.4/src/main/resources/configuration.txt
+++ b/fabric-1.16.4/src/main/resources/configuration.txt
@@ -288,7 +288,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)

--- a/fabric-1.17.1/src/main/resources/configuration.txt
+++ b/fabric-1.17.1/src/main/resources/configuration.txt
@@ -288,7 +288,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)

--- a/fabric-1.18/src/main/resources/configuration.txt
+++ b/fabric-1.18/src/main/resources/configuration.txt
@@ -288,7 +288,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)

--- a/forge-1.11.2/src/main/resources/configuration.txt
+++ b/forge-1.11.2/src/main/resources/configuration.txt
@@ -288,7 +288,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)

--- a/forge-1.12.2/src/main/resources/configuration.txt
+++ b/forge-1.12.2/src/main/resources/configuration.txt
@@ -288,7 +288,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)

--- a/forge-1.13.2/src/main/resources/configuration.txt
+++ b/forge-1.13.2/src/main/resources/configuration.txt
@@ -288,7 +288,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)

--- a/forge-1.14.4/src/main/resources/configuration.txt
+++ b/forge-1.14.4/src/main/resources/configuration.txt
@@ -288,7 +288,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)

--- a/forge-1.15.2/src/main/resources/configuration.txt
+++ b/forge-1.15.2/src/main/resources/configuration.txt
@@ -288,7 +288,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)

--- a/forge-1.16.5/src/main/resources/configuration.txt
+++ b/forge-1.16.5/src/main/resources/configuration.txt
@@ -288,7 +288,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)

--- a/forge-1.17.1/src/main/resources/configuration.txt
+++ b/forge-1.17.1/src/main/resources/configuration.txt
@@ -288,7 +288,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)

--- a/forge-1.18/src/main/resources/configuration.txt
+++ b/forge-1.18/src/main/resources/configuration.txt
@@ -288,7 +288,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)

--- a/spigot/src/main/resources/configuration.txt
+++ b/spigot/src/main/resources/configuration.txt
@@ -289,7 +289,7 @@ custom-colors-support: true
 # Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
 #refreshskins: false
 
-# Customize URL used for fetching player skins (%player% is macro for name)
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
 skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
 
 # Enable skins via SkinsRestorer plugin instead of internal legacy implementation (disabled by default)


### PR DESCRIPTION
Allows using the player's UUID in the skin URL.

Very small change as the player's UUID was already passed to `LoadPlayerImages`, just not used.
Also updated configuration.txt comment to mention the %uuid% placeholder.