### PR TITLE
Fix 3D areas

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/js/markers.js
+++ b/DynmapCore/src/main/resources/extracted/web/js/markers.js
@@ -277,7 +277,7 @@ componentconstructors['markers'] = function(dynmap, configuration) {
 	}
 	
 	function create3DBoxLayer(maxx, minx, maxy, miny, maxz, minz, style) {
-		return new L.MultiPolygon([
+		return new L.Polygon([
 			[
 				latlng(minx,miny,minz),
 				latlng(maxx,miny,minz),
@@ -349,7 +349,7 @@ componentconstructors['markers'] = function(dynmap, configuration) {
 		polylist[xarray.length] = botlist;
 		polylist[xarray.length+1] = toplist;
 		
-		return new L.MultiPolygon(polylist, style);
+		return new L.Polygon(polylist, style);
 	}
 
 	function create2DOutlineLayer(xarray, maxy, miny, zarray, style) {


### PR DESCRIPTION
Fixes #3605. The `MultiPolygon` layer type used for 3D areas was removed in Leaflet 1.0.0 after being merged into `Polygon` and its use was missed during the original leaflet update.

PR just replaces `MultiPolygon` with `Polygon` and makes everything perfect again. Tested with Dynmap-WorldGuard with `use3dregions` enabled and with both cuboid and polygon region.

![image](https://user-images.githubusercontent.com/4615316/149542948-f6e2c37d-c07d-4570-b0d7-21f16997c953.png)
