### PR TITLE
Fix loading of biome colorschemes

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/ColorScheme.java
+++ b/DynmapCore/src/main/java/org/dynmap/ColorScheme.java
@@ -128,7 +128,7 @@ public class ColorScheme {
 						id = -1;
 						BiomeMap[] bm = BiomeMap.values();
 						for (int i = 0; i < bm.length; i++) {
-							if (bm[i].toString().equalsIgnoreCase(bio)) {
+							if (bm[i].getId().equalsIgnoreCase(bio)) {
 								id = i;
 								break;
 							} else if (bio.equalsIgnoreCase("BIOME_" + i)) {

--- a/DynmapCore/src/main/java/org/dynmap/common/BiomeMap.java
+++ b/DynmapCore/src/main/java/org/dynmap/common/BiomeMap.java
@@ -297,6 +297,9 @@ public class BiomeMap {
     public boolean isDefault() {
         return isDef;
     }
+    public String getId() {
+        return id;
+    }
     public String toString() {
     	return String.format("%s(%s)", id, resourcelocation);
     }


### PR DESCRIPTION
`ColorScheme` relied on `BiomeMap::toString` for matching the biome mapping identifiers in the colorschemes files.

The format of `BiomeMap::toString` was changed some time ago, so this matching failed.

This PR introduces a `BiomeMap::getId` for accessing `BiomeMap.id` and uses this new method instead of `::toString` for the matching in `ColorScheme::loadScheme`.