### PR TITLE
IP subnet in trusted proxy list

### DIFF
--- a/DynmapCore/build.gradle
+++ b/DynmapCore/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation 'org.yaml:snakeyaml:1.23'	// DON'T UPDATE - NEWER ONE TRIPS ON WINDOWS ENCODED FILES
     implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20180219.1'
     implementation 'org.postgresql:postgresql:42.2.18'
+    implementation 'commons-net:commons-net:3.8.0'
 }
 
 processResources {

--- a/DynmapCore/build.gradle
+++ b/DynmapCore/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation 'org.yaml:snakeyaml:1.23'	// DON'T UPDATE - NEWER ONE TRIPS ON WINDOWS ENCODED FILES
     implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20180219.1'
     implementation 'org.postgresql:postgresql:42.2.18'
-    implementation 'commons-net:commons-net:3.8.0'
+    implementation 'com.github.seancfoley:ipaddress:5.3.3'
 }
 
 processResources {
@@ -52,6 +52,7 @@ shadowJar {
         include(dependency('org.eclipse.jetty::'))
         include(dependency('org.eclipse.jetty.orbit:javax.servlet:'))
         include(dependency('org.postgresql:postgresql:'))
+        include(dependency('com.github.seancfoley:ipaddress:'))
         include(dependency(':DynmapCoreAPI'))
         exclude("META-INF/maven/**")
         exclude("META-INF/services/**")

--- a/DynmapCore/src/main/java/org/dynmap/InternalClientUpdateComponent.java
+++ b/DynmapCore/src/main/java/org/dynmap/InternalClientUpdateComponent.java
@@ -3,6 +3,8 @@ package org.dynmap;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
+import inet.ipaddr.AddressStringException;
+import inet.ipaddr.IPAddressString;
 import org.dynmap.servlet.ClientUpdateServlet;
 import org.dynmap.servlet.SendMessageServlet;
 import org.json.simple.JSONObject;
@@ -65,12 +67,16 @@ public class InternalClientUpdateComponent extends ClientUpdateComponent {
                 this.core = dcore;
                 if(trustedproxy != null) {
                     for(String s : trustedproxy) {
-                        this.proxyaddress.add(s.trim());
+                        try {
+                            this.proxyaddress.add(new IPAddressString(s).toAddress());
+                        } catch (AddressStringException e) {
+                            throw new IllegalArgumentException("Trusted proxy address " + s + " is not valid");
+                        }
                     }
                 }
                 else {
-                    this.proxyaddress.add("127.0.0.1");
-                    this.proxyaddress.add("0:0:0:0:0:0:0:1");
+                    this.proxyaddress.add(new IPAddressString("127.0.0.1").getAddress());
+                    this.proxyaddress.add(new IPAddressString("0:0:0:0:0:0:0:1").getAddress());
                 }
                 onMessageReceived.addListener(new Event.Listener<Message> () {
                     @Override

--- a/DynmapCore/src/main/java/org/dynmap/servlet/SendMessageServlet.java
+++ b/DynmapCore/src/main/java/org/dynmap/servlet/SendMessageServlet.java
@@ -2,7 +2,8 @@ package org.dynmap.servlet;
 
 import static org.dynmap.JSONUtils.s;
 
-import org.apache.commons.net.util.SubnetUtils;
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
 import org.dynmap.DynmapCore;
 import org.dynmap.Event;
 import org.dynmap.Log;
@@ -51,11 +52,11 @@ public class SendMessageServlet extends HttpServlet {
     public boolean chat_perms = false;
     public int lengthlimit = 256;
     public DynmapCore core;
-    public HashSet<SubnetUtils.SubnetInfo> proxyaddress = new HashSet<SubnetUtils.SubnetInfo>();
+    public HashSet<IPAddress> proxyaddress = new HashSet<IPAddress>();
 
     private boolean addressIsTrustedProxy(String address) {
-        for (SubnetUtils.SubnetInfo subnetInfo : proxyaddress) {
-            if (subnetInfo.isInRange(address)) {
+        for (IPAddress addr : proxyaddress) {
+            if (addr.contains(new IPAddressString(address).getAddress())) {
                 return true;
             }
         }


### PR DESCRIPTION
Implements #3677. This lets the user specify IP subnets such as 192.168.1.0/24 and 172.0.0.0/8 in the trusted proxy list. To do this, I have added a dependency on `com.github.seancfoley:ipaddress:5.3.3` which performs the necessary logic.

Wrote this a few days ago, I'm going to test it now on all supported platforms/versions. Which I think is probably unnecessary but it says so in the contributing document.

Until that's done, perform a code review at your leisure.