### PR TITLE
Fix and improve async chunk load

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/common/chunk/GenericMapChunkCache.java
+++ b/DynmapCore/src/main/java/org/dynmap/common/chunk/GenericMapChunkCache.java
@@ -766,7 +766,7 @@ public abstract class GenericMapChunkCache extends MapChunkCache {
 	}
 
 	/**
-	 * Read NBT data from loaded chunks - do not needs to be called from server/world
+	 * Read NBT data from loaded chunks - do not needs to be called from server/world <p>
 	 * Will throw {@link IllegalStateException} if not supporting
 	 */
 	public void getLoadedChunksAsync() {
@@ -836,7 +836,9 @@ public abstract class GenericMapChunkCache extends MapChunkCache {
 	}
 
 	/**
-	 * Prepare the chunks async
+	 * Loads all chunks in the world asynchronously.
+	 * <p>
+	 * If it is not supported, it will throw {@link IllegalStateException}
 	 */
 	public void loadChunksAsync() {
 		getLoadedChunksAsync();
@@ -923,6 +925,12 @@ public abstract class GenericMapChunkCache extends MapChunkCache {
 		return cnt;
 	}
 
+	/**
+	 * It loads chunks from the cache or from the world, and if the chunk is not visible, it fills it with stone, ocean or
+	 * empty chunk
+	 * <p>
+	 * if it's not supported, will throw {@link IllegalStateException}
+	 */
 	public void readChunksAsync() {
 		class SimplePair { //pair of the chunk and the data which is readed async
 			private final Supplier<GenericChunk> supplier;

--- a/bukkit-helper-118-2/src/main/java/org/dynmap/bukkit/helper/v118_2/AsyncChunkProvider118_2.java
+++ b/bukkit-helper-118-2/src/main/java/org/dynmap/bukkit/helper/v118_2/AsyncChunkProvider118_2.java
@@ -86,7 +86,7 @@ public class AsyncChunkProvider118_2 {
     public synchronized Supplier<NBTTagCompound> getLoadedChunk(CraftWorld world, int x, int z) {
         if (!world.isChunkLoaded(x, z)) return () -> null;
         Chunk c = world.getHandle().getChunkIfLoaded(x, z); //already safe async on vanilla
-        if ((c == null) || c.o) return () -> null;    // c.loaded
+        if ((c == null) || !c.o) return () -> null;    // c.loaded
         if (currTick != MinecraftServer.currentTick) {
             currTick = MinecraftServer.currentTick;
             currChunks = 0;

--- a/bukkit-helper-118-2/src/main/java/org/dynmap/bukkit/helper/v118_2/AsyncChunkProvider118_2.java
+++ b/bukkit-helper-118-2/src/main/java/org/dynmap/bukkit/helper/v118_2/AsyncChunkProvider118_2.java
@@ -1,31 +1,54 @@
 package org.dynmap.bukkit.helper.v118_2;
 
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.WorldServer;
+import net.minecraft.world.level.chunk.Chunk;
+import net.minecraft.world.level.chunk.IChunkAccess;
+import net.minecraft.world.level.chunk.storage.ChunkRegionLoader;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
+import org.bukkit.craftbukkit.v1_18_R2.CraftWorld;
+import org.dynmap.MapManager;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * The provider used to work with paper libs
  * Because paper libs need java 17 we can't interact with them directly
  */
+@SuppressWarnings({"JavaReflectionMemberAccess"}) //java don't know about paper
 public class AsyncChunkProvider118_2 {
     private final Thread ioThread;
     private final Method getChunk;
     private final Predicate<NBTTagCompound> ifFailed;
+    private final Method getAsyncSaveData;
+    private final Method save;
+    private int currTick = MinecraftServer.currentTick;
+    private int currChunks = 0;
+
     AsyncChunkProvider118_2 () {
         try {
             Predicate<NBTTagCompound> ifFailed1 = null;
-            Method getChunk1 = null;
+            Method getChunk1 = null, getAsyncSaveData1 = null, save1 = null;
             Thread ioThread1 = null;
             try {
                 Class<?> threadClass = Class.forName("com.destroystokyo.paper.io.PaperFileIOThread");
+                Class<?> asyncChunkData = Arrays.stream(ChunkRegionLoader.class.getClasses())
+                        .filter(c -> c.getSimpleName().equals("AsyncSaveData"))
+                        .findFirst()
+                        .orElseThrow(RuntimeException::new);
+                getAsyncSaveData1 = ChunkRegionLoader.class.getMethod("getAsyncSaveData", WorldServer.class, IChunkAccess.class);
+                save1 = ChunkRegionLoader.class.getMethod("saveChunk", WorldServer.class, IChunkAccess.class, asyncChunkData);
                 Class<?>[] classes = threadClass.getClasses();
                 Class<?> holder = Arrays.stream(classes).filter(aClass -> aClass.getSimpleName().equals("Holder")).findAny().orElseThrow(RuntimeException::new);
                 ioThread1 = (Thread) holder.getField("INSTANCE").get(null);
@@ -35,6 +58,8 @@ public class AsyncChunkProvider118_2 {
             } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException | NoSuchMethodException e) {
                 e.printStackTrace();
             }
+            getAsyncSaveData = Objects.requireNonNull(getAsyncSaveData1);
+            save = Objects.requireNonNull(save1);
             ifFailed = Objects.requireNonNull(ifFailed1);
             getChunk = Objects.requireNonNull(getChunk1);
             ioThread = Objects.requireNonNull(ioThread1);
@@ -56,5 +81,39 @@ public class AsyncChunkProvider118_2 {
             }
             return null;
         });
+    }
+
+    public synchronized Supplier<NBTTagCompound> getLoadedChunk(CraftWorld world, int x, int z) {
+        if (!world.isChunkLoaded(x, z)) return () -> null;
+        Chunk c = world.getHandle().getChunkIfLoaded(x, z); //already safe async on vanilla
+        if ((c == null) || c.o) return () -> null;    // c.loaded
+        if (currTick != MinecraftServer.currentTick) {
+            currTick = MinecraftServer.currentTick;
+            currChunks = 0;
+        }
+        //prepare data synchronously
+        CompletableFuture<?> future = CompletableFuture.supplyAsync(() -> {
+            try {
+                return getAsyncSaveData.invoke(null, world.getHandle(), c);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        }, ((CraftServer) Bukkit.getServer()).getServer());
+        //we shouldn't stress main thread
+        if (++currChunks > MapManager.mapman.getMaxChunkLoadsPerTick()) {
+            try {
+                Thread.sleep(25); //hold the lock so other threads also won't stress main thread
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        //save data asynchronously
+        return () -> {
+            try {
+                return (NBTTagCompound) save.invoke(null, world.getHandle(), c, future.get());
+            } catch (ReflectiveOperationException | ExecutionException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        };
     }
 }

--- a/bukkit-helper-119/src/main/java/org/dynmap/bukkit/helper/v119/AsyncChunkProvider119.java
+++ b/bukkit-helper-119/src/main/java/org/dynmap/bukkit/helper/v119/AsyncChunkProvider119.java
@@ -1,31 +1,53 @@
 package org.dynmap.bukkit.helper.v119;
 
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.WorldServer;
+import net.minecraft.world.level.chunk.Chunk;
+import net.minecraft.world.level.chunk.IChunkAccess;
+import net.minecraft.world.level.chunk.storage.ChunkRegionLoader;
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_19_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_19_R1.CraftWorld;
+import org.dynmap.MapManager;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * The provider used to work with paper libs
  * Because paper libs need java 17 we can't interact with them directly
  */
+@SuppressWarnings({"JavaReflectionMemberAccess"}) //java don't know about paper
 public class AsyncChunkProvider119 {
     private final Thread ioThread;
     private final Method getChunk;
     private final Predicate<NBTTagCompound> ifFailed;
-    AsyncChunkProvider119 () {
+    private final Method getAsyncSaveData;
+    private final Method save;
+    private int currTick = MinecraftServer.currentTick;
+    private int currChunks = 0;
+
+    AsyncChunkProvider119() {
         try {
             Predicate<NBTTagCompound> ifFailed1 = null;
-            Method getChunk1 = null;
+            Method getChunk1 = null, getAsyncSaveData1 = null, save1 = null;
             Thread ioThread1 = null;
             try {
                 Class<?> threadClass = Class.forName("com.destroystokyo.paper.io.PaperFileIOThread");
+                Class<?> asyncChunkData = Arrays.stream(ChunkRegionLoader.class.getClasses())
+                        .filter(c -> c.getSimpleName().equals("AsyncSaveData"))
+                        .findFirst()
+                        .orElseThrow(RuntimeException::new);
+                getAsyncSaveData1 = ChunkRegionLoader.class.getMethod("getAsyncSaveData", WorldServer.class, IChunkAccess.class);
+                save1 = ChunkRegionLoader.class.getMethod("saveChunk", WorldServer.class, IChunkAccess.class, asyncChunkData);
                 Class<?>[] classes = threadClass.getClasses();
                 Class<?> holder = Arrays.stream(classes).filter(aClass -> aClass.getSimpleName().equals("Holder")).findAny().orElseThrow(RuntimeException::new);
                 ioThread1 = (Thread) holder.getField("INSTANCE").get(null);
@@ -35,6 +57,8 @@ public class AsyncChunkProvider119 {
             } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException | NoSuchMethodException e) {
                 e.printStackTrace();
             }
+            getAsyncSaveData = Objects.requireNonNull(getAsyncSaveData1);
+            save = Objects.requireNonNull(save1);
             ifFailed = Objects.requireNonNull(ifFailed1);
             getChunk = Objects.requireNonNull(getChunk1);
             ioThread = Objects.requireNonNull(ioThread1);
@@ -56,5 +80,39 @@ public class AsyncChunkProvider119 {
             }
             return null;
         });
+    }
+
+    public synchronized Supplier<NBTTagCompound> getLoadedChunk(CraftWorld world, int x, int z) {
+        if (!world.isChunkLoaded(x, z)) return () -> null;
+        Chunk c = world.getHandle().getChunkIfLoaded(x, z); //already safe async on vanilla
+        if ((c == null) || c.o) return () -> null;    // c.loaded
+        if (currTick != MinecraftServer.currentTick) {
+            currTick = MinecraftServer.currentTick;
+            currChunks = 0;
+        }
+        //prepare data synchronously
+        CompletableFuture<?> future = CompletableFuture.supplyAsync(() -> {
+            try {
+                return getAsyncSaveData.invoke(null, world.getHandle(), c);
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
+        }, ((CraftServer) Bukkit.getServer()).getServer());
+        //we shouldn't stress main thread
+        if (++currChunks > MapManager.mapman.getMaxChunkLoadsPerTick()) {
+            try {
+                Thread.sleep(25); //hold the lock so other threads also won't stress main thread
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        //save data asynchronously
+        return () -> {
+            try {
+                return (NBTTagCompound) save.invoke(null, world.getHandle(), c, future.get());
+            } catch (ReflectiveOperationException | ExecutionException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        };
     }
 }

--- a/bukkit-helper-119/src/main/java/org/dynmap/bukkit/helper/v119/AsyncChunkProvider119.java
+++ b/bukkit-helper-119/src/main/java/org/dynmap/bukkit/helper/v119/AsyncChunkProvider119.java
@@ -85,7 +85,7 @@ public class AsyncChunkProvider119 {
     public synchronized Supplier<NBTTagCompound> getLoadedChunk(CraftWorld world, int x, int z) {
         if (!world.isChunkLoaded(x, z)) return () -> null;
         Chunk c = world.getHandle().getChunkIfLoaded(x, z); //already safe async on vanilla
-        if ((c == null) || c.o) return () -> null;    // c.loaded
+        if ((c == null) || !c.o) return () -> null;    // c.loaded
         if (currTick != MinecraftServer.currentTick) {
             currTick = MinecraftServer.currentTick;
             currChunks = 0;


### PR DESCRIPTION
I didn't see some mistakes made by me in last pr, and didn't see that paper has an improved method to save chunk data without many lags
Changes:
1. by mistake i put the check to refuse working with loaded chunks, only from disk, fixed that
2. readded the chunk limit (it's not strict, but still will prevent too much chunk saves, didn't add to chunk loads because it already has lowest priority, so the server will do the load only when server and other plugins don't need that, don't see a necesity)
3. used the paper's method to save the data asyncronously (don't remember why i didn't notice that it has it before)  