### PR TITLE
Fix broken tiles caused by implicit cast on PHP 8.

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_tiles.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/MySQL_tiles.php
@@ -94,7 +94,7 @@ if ($stmt->fetch()) {
         header('Content-Type: image/jpeg');
     }
     header('ETag: \'' . $thash . '\'');
-    header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $tlast / 1000) . ' GMT');
+    header('Last-Modified: ' . gmdate('D, d M Y H:i:s', (int) ($tlast / 1000)) . ' GMT');
     if (is_null($tnewimage)) {
         echo $timage;
     } else {

--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_tiles.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_tiles.php
@@ -99,7 +99,7 @@ if ($res && $timage) {
         header('Content-Type: image/jpeg');
     }
     header('ETag: \'' . $thash . '\'');
-    header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $tlast / 1000) . ' GMT');
+    header('Last-Modified: ' . gmdate('D, d M Y H:i:s', (int) ($tlast / 1000)) . ' GMT');
     echo stream_get_contents($timage);
 } else {
     header('Location: ../images/blank.png');


### PR DESCRIPTION
On PHP 8, getting tiles from MySQL is broken, since it will actually return HTML followed by the actual PNG content, i.e.

```
<br />
<b>Deprecated</b>:  Implicit conversion from float 1657847731.248 to int loses precision in <b>/var/www/html/standalone/MySQL_tiles_debug.php</b> on line <b>97</b><br />
<br />
<b>Warning</b>:  Cannot modify header information - headers already sent by (output started at /var/www/html/standalone/MySQL_tiles_debug.php:97) in <b>/var/www/html/standalone/MySQL_tiles_debug.php</b> on line <b>97</b><br />
?PNG

IHDR??>a?0?IDATx^?}?wcǕ????Qw3?s3?s??A??lv?Q-+[?? ?c?lKr?Ƕ?ww?x?<?3;??o????-????C?s?y??G????z?0?)La
S???0?)La
S???0?)La
S???0?)La
???.4"????0?!??Z?8??ж??jgG???}?7{?8??_jCq?|G????+?
                                                  ?Rl????a:"??CL?6
                                                                  ??J??Z?H?A
a`}???ނ??D?p"e??j?Gq\?Q?8?????i?)??                                         ]????#:]?`큟r???6":M?9*Mf????{?
                                   ?????ya??R?I#"?4$???8I?c?S?I???'?p??q??:?؉?r7"I???s??Q>'LQ???
"t?P?G?L?!
          =?=?;Py???????ڕ07???bV??g??DL?,???+[@??9
=                                                 Y???3????ـP>'LQz?,Di6)?V?&ka??t[o?v????>??ϣ?oe.?焋L?
```

This is caused by the implicit cast of `$tlast` to an integer (see https://php.watch/versions/8.1/deprecate-implicit-conversion-incompatible-float-string).