### PR TITLE
Fix writing non-ascii files to postgresql database

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_funcs.php
+++ b/DynmapCore/src/main/resources/extracted/web/standalone/PostgreSQL_funcs.php
@@ -75,7 +75,7 @@ function updateStandaloneFileByServerId($fname, $sid, $content)
 
     initDbIfNeeded();
     $stmt = $db->prepare('UPDATE ' . $dbprefix . 'StandaloneFiles SET Content=:content WHERE FileName=:fname AND ServerID=:sid');
-    $stmt->bindParam(':content', $content, PDO::PARAM_STR);
+    $stmt->bindParam(':content', $content, PDO::PARAM_LOB);
     $stmt->bindParam(':fname', $fname, PDO::PARAM_STR);
     $stmt->bindParam(':sid', $sid, PDO::PARAM_INT);
     $res = $stmt->execute();


### PR DESCRIPTION
This fixes non-ascii chat messages (for example cyrillic utf8) in PostgreSQL_sendmessage.php

Before fix PostgreSQL_sendmessage.php was returning this:

```
Fatal error:  Uncaught PDOException: SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type bytea in /opt/minecraft/plugins/dynmap/web/standalone/PostgreSQL_funcs.php:81
Stack trace:
#0 /opt/minecraft/plugins/dynmap/web/standalone/PostgreSQL_funcs.php(81): PDOStatement->execute()
#1 /opt/minecraft/plugins/dynmap/web/standalone/PostgreSQL_funcs.php(99): updateStandaloneFileByServerId()
#2 /opt/minecraft/plugins/dynmap/web/standalone/PostgreSQL_sendmessage.php(60): updateStandaloneFile()
#3 {main}
thrown in /opt/minecraft/plugins/dynmap/web/standalone/PostgreSQL_funcs.php on line 81
```