### PR TITLE
fabric: version-lock fabric.mod.json

### DIFF
--- a/fabric-1.16.4/src/main/resources/fabric.mod.json
+++ b/fabric-1.16.4/src/main/resources/fabric.mod.json
@@ -28,6 +28,6 @@
   "depends": {
     "fabricloader": ">=0.12.12",
     "fabric": ">=0.17.0",
-    "minecraft": "1.16.x"
+    "minecraft": ["1.16.4", "1.16.5"]
   }
 }

--- a/fabric-1.18.2/src/main/resources/fabric.mod.json
+++ b/fabric-1.18.2/src/main/resources/fabric.mod.json
@@ -28,6 +28,6 @@
   "depends": {
     "fabricloader": ">=0.13.3",
     "fabric": ">=0.47.8",
-    "minecraft": ">=1.18.2"
+    "minecraft": "1.18.2"
   }
 }

--- a/fabric-1.19.1/src/main/resources/fabric.mod.json
+++ b/fabric-1.19.1/src/main/resources/fabric.mod.json
@@ -28,6 +28,6 @@
   "depends": {
     "fabricloader": ">=0.14.8",
     "fabric": ">=0.58.5",
-    "minecraft": ">=1.19.1"
+    "minecraft": ["1.19.1", "1.19.2"]
   }
 }

--- a/fabric-1.19/src/main/resources/fabric.mod.json
+++ b/fabric-1.19/src/main/resources/fabric.mod.json
@@ -28,6 +28,6 @@
   "depends": {
     "fabricloader": ">=0.14.6",
     "fabric": ">=0.55.2",
-    "minecraft": "1.19.x"
+    "minecraft": "1.19"
   }
 }


### PR DESCRIPTION
This is intended to reduce user errors where e.g. someone uses the 1.19 jar on 1.19.2. Previously this would lead to unspecific mixin errors; with this change, a helpful message is shown:

> Mod 'Dynmap' (dynmap) 3.4-SNAPSHOT requires version 1.19 of 'Minecraft' (minecraft), but only the wrong version is present: 1.19.2!`