### PR TITLE
Fix colours

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/common/BiomeMap.java
+++ b/DynmapCore/src/main/java/org/dynmap/common/BiomeMap.java
@@ -19,7 +19,7 @@ public class BiomeMap {
     public static final BiomeMap EXTREME_HILLS = new BiomeMap(3, "EXTREME_HILLS", 0.2, 0.3, "minecraft:mountains");
     public static final BiomeMap FOREST = new BiomeMap(4, "FOREST", 0.7, 0.8, "minecraft:forest");
     public static final BiomeMap TAIGA = new BiomeMap(5, "TAIGA", 0.05, 0.8, "minecraft:taiga");
-    public static final BiomeMap SWAMPLAND = new BiomeMap(6, "SWAMPLAND", 0.8, 0.9, 0xE0FFAE, 0x4E0E4E, 0x4E0E4E, "minecraft:swamp");
+    public static final BiomeMap SWAMPLAND = new BiomeMap(6, "SWAMPLAND", 0.8, 0.9, 0xE0FFAE, 0x2e282a, 0x902c52, "minecraft:swamp");
     public static final BiomeMap RIVER = new BiomeMap(7, "RIVER", "minecraft:river");
     public static final BiomeMap HELL = new BiomeMap(8, "HELL", 2.0, 0.0, "minecraft:nether");
     public static final BiomeMap SKY = new BiomeMap(9, "SKY", "minecraft:the_end");
@@ -69,15 +69,12 @@ public class BiomeMap {
             new BiomeMap(34, "EXTREME_HILLS_PLUS", 0.2, 0.3, "minecraft:wooded_mountains");
             new BiomeMap(35, "SAVANNA", 1.2, 0.0, "minecraft:savanna");
             new BiomeMap(36, "SAVANNA_PLATEAU", 1.0, 0.0, "minecraft:savanna_plateau");
-            new BiomeMap(37, "MESA", 2.0, 0.0, "minecraft:badlands");
-            new BiomeMap(38, "MESA_PLATEAU_FOREST", 2.0, 0.0, "minecraft:wooded_badlands_plateau");
-            new BiomeMap(39, "MESA_PLATEAU", 2.0, 0.0, "minecraft:badlands_plateau");
+            new BiomeMap(37, "MESA", 2.0, 0.0, 0xFFFFFF, 0x624c46, 0x8e5e70, "minecraft:badlands");
             new BiomeMap(129, "SUNFLOWER_PLAINS", 0.8, 0.4, "minecraft:sunflower_plains");
             new BiomeMap(130, "DESERT_MOUNTAINS", 2.0, 0.0, "minecraft:desert_lakes");
             new BiomeMap(131, "EXTREME_HILLS_MOUNTAINS", 0.2, 0.3, "minecraft:gravelly_mountains");
             new BiomeMap(132, "FLOWER_FOREST", 0.7, 0.8, "minecraft:flower_forest");
             new BiomeMap(133, "TAIGA_MOUNTAINS", 0.05, 0.8, "minecraft:taiga_mountains");
-            new BiomeMap(134, "SWAMPLAND_MOUNTAINS", 0.8, 0.9, 0xE0FFAE, 0x4E0E4E, 0x4E0E4E, "minecraft:swamp_hills");
             new BiomeMap(140, "ICE_PLAINS_SPIKES", 0.0, 0.5, "minecraft:ice_spikes");
             new BiomeMap(149, "JUNGLE_MOUNTAINS", 1.2, 0.9, "minecraft:modified_jungle");
             new BiomeMap(151, "JUNGLE_EDGE_MOUNTAINS", 0.95, 0.8, "minecraft:modified_jungle_edge");
@@ -90,9 +87,14 @@ public class BiomeMap {
             new BiomeMap(162, "EXTREME_HILLS_PLUS_MOUNTAINS", 0.2, 0.3, "minecraft:modified_gravelly_mountains");
             new BiomeMap(163, "SAVANNA_MOUNTAINS", 1.2, 0.0, "minecraft:shattered_savanna");
             new BiomeMap(164, "SAVANNA_PLATEAU_MOUNTAINS", 1.0, 0.0, "minecraft:shattered_savanna_plateau");
-            new BiomeMap(165, "MESA_BRYCE", 2.0, 0.0, "minecraft:eroded_badlands");
-            new BiomeMap(166, "MESA_PLATEAU_FOREST_MOUNTAINS", 2.0, 0.0, "minecraft:modified_wooded_badlands_plateau");
-            new BiomeMap(167, "MESA_PLATEAU_MOUNTAINS", 2.0, 0.0, "minecraft:modified_badlands_plateau");
+            new BiomeMap(165, "MESA_BRYCE", 2.0, 0.0,0xFFFFFF, 0x624c46, 0x8e5e70, "minecraft:eroded_badlands");
+        }
+        if (HDBlockModels.checkVersionRange(mcver, "1.7.0-1.17.1")) {
+            new BiomeMap(38, "MESA_PLATEAU_FOREST", 2.0, 0.0, 0xFFFFFF, 0x624c46, 0x8e5e70, "minecraft:wooded_badlands_plateau");
+            new BiomeMap(39, "MESA_PLATEAU", 2.0, 0.0, 0xFFFFFF, 0x624c46, 0x8e5e70, "minecraft:badlands_plateau");
+            new BiomeMap(134, "SWAMPLAND_MOUNTAINS", 0.8, 0.9, 0xE0FFAE, 0x2e282a, 0x902c52, "minecraft:swamp_hills");
+            new BiomeMap(166, "MESA_PLATEAU_FOREST_MOUNTAINS", 2.0, 0.0,0xFFFFFF, 0x624c46, 0x8e5e70,  "minecraft:modified_wooded_badlands_plateau");
+            new BiomeMap(167, "MESA_PLATEAU_MOUNTAINS", 2.0, 0.0,0xFFFFFF, 0x624c46, 0x8e5e70,  "minecraft:modified_badlands_plateau");
         }
         if (HDBlockModels.checkVersionRange(mcver, "1.9.0-")) {
             new BiomeMap(127, "THE_VOID", "minecraft:the_void");
@@ -123,6 +125,9 @@ public class BiomeMap {
         if (HDBlockModels.checkVersionRange(mcver, "1.17.0-")) {
             new BiomeMap(174, "DRIPSTONE_CAVES", "minecraft:dripstone_caves");
             new BiomeMap(175, "LUSH_CAVES", "minecraft:lush_caves");
+        }
+        if (HDBlockModels.checkVersionRange(mcver, "1.18.0-")) {
+            new BiomeMap(38, "MESA_FOREST", 2.0, 0.0, 0xFFFFFF, 0x624c46, 0x8e5e70, "minecraft:wooded_badlands");
         }
         loadDone = true;
     }


### PR DESCRIPTION
Fix colors in biomes, https://github.com/webbukkit/dynmap/pull/3862 does that automatically, but for older versions this would be needed (if you don't like the more green variant of color, to use the second color that swamp is using, the color needs to be changed to #6a1c24)
New colors: 
![image](https://user-images.githubusercontent.com/63639746/195978599-8826b732-0e2a-4eb4-852b-5711348bf7f2.png)
![image](https://user-images.githubusercontent.com/63639746/195978605-705c9448-4812-4a62-8598-e3a07ac1ce04.png)
