### PR TITLE
Typo in log message

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/hdmap/HDBlockModels.java
+++ b/DynmapCore/src/main/java/org/dynmap/hdmap/HDBlockModels.java
@@ -255,7 +255,7 @@ public class HDBlockModels {
                 }
             }
         } catch (IOException iox) {
-            Log.severe("Error processing nodel files");
+            Log.severe("Error processing model files");
         } finally {
             if (in != null) {
                 try { in.close(); } catch (IOException iox) {}


### PR DESCRIPTION
Just fixing a tiny inconsequential typo in a log message (nodel -> model).