### PR TITLE
Hotfix: Fixing the version number for skinsrestorer-api

### DIFF
--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'me.lucko.luckperms:luckperms-api:4.3'
     implementation 'net.luckperms:api:5.0'
     implementation('com.github.MilkBowl:VaultAPI:1.7') { transitive = false }
-    compileOnly 'net.skinsrestorer:skinsrestorer-api:14.2.+'
+    implementation('net.skinsrestorer:skinsrestorer-api:14.2.4') { transitive = false }
     implementation project(":dynmap-api")
     implementation project(path: ":DynmapCore", configuration: "shadow")
     implementation group: 'ru.tehkode', name: 'PermissionsEx', version: '1.19.1'


### PR DESCRIPTION
Fixing the version of the skinrestorer-api from relative to fixed.
The latest version of the skinrestorer-api has moved reflection out of the api, into shared. I therefore propose this as a workaround until the breaking change can be worked out properly.