### PR TITLE
implemented catch to prevent server crash when jar in jar methods are used

### DIFF
--- a/forge-1.18.2/src/main/java/org/dynmap/forge_1_18_2/DynmapPlugin.java
+++ b/forge-1.18.2/src/main/java/org/dynmap/forge_1_18_2/DynmapPlugin.java
@@ -1023,12 +1023,25 @@ public class DynmapPlugin
         }
         @Override
         public File getModContainerFile(String name) {
-        	ModFileInfo mfi = LoadingModList.get().getModFileById(name);    // Try case sensitive lookup
+            ModFileInfo mfi = LoadingModList.get().getModFileById(name);    // Try case sensitive lookup
             if (mfi != null) {
-            	File f = mfi.getFile().getFilePath().toFile();
-                return f;
+                try {
+                    File f = mfi.getFile().getFilePath().toFile();
+                    return f;
+                }
+                catch (UnsupportedOperationException ex) {
+                    //TODO Implement proper jar in jar method for fetching data
+/*
+                    Log.info("Searching for: " + name);
+                    for (IModInfo e: ModList.get().getMods()) {
+                        Log.info("in: " + e.getModId().toString());
+                        Log.info("resource: "+ ModList.get().getModFileById(e.getModId()).getFile().findResource(String.valueOf(mfi.getFile().getFilePath()))); //requires forge 1.18.2-40.1.60+ (update build.gradle)
+                    }
+*/
+                    Log.warning("jar in jar method found, skipping: " + ex.getMessage());
+                }
             }
-        	return null;
+            return null;
         }
         @Override
         public List<String> getModList() {

--- a/forge-1.19.2/src/main/java/org/dynmap/forge_1_19_2/DynmapPlugin.java
+++ b/forge-1.19.2/src/main/java/org/dynmap/forge_1_19_2/DynmapPlugin.java
@@ -1023,12 +1023,25 @@ public class DynmapPlugin
         }
         @Override
         public File getModContainerFile(String name) {
-        	ModFileInfo mfi = LoadingModList.get().getModFileById(name);    // Try case sensitive lookup
+            ModFileInfo mfi = LoadingModList.get().getModFileById(name);    // Try case sensitive lookup
             if (mfi != null) {
-            	File f = mfi.getFile().getFilePath().toFile();
-                return f;
+                try {
+                    File f = mfi.getFile().getFilePath().toFile();
+                    return f;
+                }
+                catch (UnsupportedOperationException ex) {
+                    //TODO Implement proper jar in jar method for fetching data
+/*
+                    Log.info("Searching for: " + name);
+                    for (IModInfo e: ModList.get().getMods()) {
+                        Log.info("in: " + e.getModId().toString());
+                        Log.info("resource: "+ ModList.get().getModFileById(e.getModId()).getFile().findResource(String.valueOf(mfi.getFile().getFilePath())));
+                    }
+*/
+                    Log.warning("jar in jar method found, skipping: " + ex.getMessage());
+                }
             }
-        	return null;
+            return null;
         }
         @Override
         public List<String> getModList() {

--- a/forge-1.19.3/src/main/java/org/dynmap/forge_1_19_2/DynmapPlugin.java
+++ b/forge-1.19.3/src/main/java/org/dynmap/forge_1_19_2/DynmapPlugin.java
@@ -1025,12 +1025,25 @@ public class DynmapPlugin
         }
         @Override
         public File getModContainerFile(String name) {
-        	ModFileInfo mfi = LoadingModList.get().getModFileById(name);    // Try case sensitive lookup
+            ModFileInfo mfi = LoadingModList.get().getModFileById(name);    // Try case sensitive lookup
             if (mfi != null) {
-            	File f = mfi.getFile().getFilePath().toFile();
-                return f;
+                try {
+                    File f = mfi.getFile().getFilePath().toFile();
+                    return f;
+                }
+                catch (UnsupportedOperationException ex) {
+                    //TODO Implement proper jar in jar method for fetching data
+/*
+                    Log.info("Searching for: " + name);
+                    for (IModInfo e: ModList.get().getMods()) {
+                        Log.info("in: " + e.getModId().toString());
+                        Log.info("resource: "+ ModList.get().getModFileById(e.getModId()).getFile().findResource(String.valueOf(mfi.getFile().getFilePath())));
+                    }
+*/
+                    Log.warning("jar in jar method found, skipping: " + ex.getMessage());
+                }
             }
-        	return null;
+            return null;
         }
         @Override
         public List<String> getModList() {

--- a/forge-1.19/src/main/java/org/dynmap/forge_1_19/DynmapPlugin.java
+++ b/forge-1.19/src/main/java/org/dynmap/forge_1_19/DynmapPlugin.java
@@ -1023,12 +1023,25 @@ public class DynmapPlugin
         }
         @Override
         public File getModContainerFile(String name) {
-        	ModFileInfo mfi = LoadingModList.get().getModFileById(name);    // Try case sensitive lookup
+            ModFileInfo mfi = LoadingModList.get().getModFileById(name);    // Try case sensitive lookup
             if (mfi != null) {
-            	File f = mfi.getFile().getFilePath().toFile();
-                return f;
+                try {
+                    File f = mfi.getFile().getFilePath().toFile();
+                    return f;
+                }
+                catch (UnsupportedOperationException ex) {
+                    //TODO Implement proper jar in jar method for fetching data
+/*
+                    Log.info("Searching for: " + name);
+                    for (IModInfo e: ModList.get().getMods()) {
+                        Log.info("in: " + e.getModId().toString());
+                        Log.info("resource: "+ ModList.get().getModFileById(e.getModId()).getFile().findResource(String.valueOf(mfi.getFile().getFilePath())));
+                    }
+*/
+                    Log.warning("jar in jar method found, skipping: " + ex.getMessage());
+                }
             }
-        	return null;
+            return null;
         }
         @Override
         public List<String> getModList() {


### PR DESCRIPTION
Forge added the option to nest Jar files, which dynmap doesn't support, added a patch so the server no longer crashes when this is the issue, a full implementation to read the data from the nested jars needs to be implemented but I couldn't get it to work.