### PR TITLE
Update markers.js

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/js/markers.js
+++ b/DynmapCore/src/main/resources/extracted/web/js/markers.js
@@ -27,7 +27,7 @@ componentconstructors['markers'] = function(dynmap, configuration) {
 			
 	function loadmarkers(world) {
 		removeAllMarkers();
-		var url = concatURL(dynmap.options.url.markers, '_markers_/marker_' + encodeURIComponent(world) + '.json');
+		var url = concatURL(dynmap.options.url.markers, '_markers_/marker_' + world + '.json');
 		
 		$.getJSON(url, function(data) {
 			var ts = data.timestamp;


### PR DESCRIPTION
fixed issue with standalone webserver marker resolve with spaces in world name, double urlencode changed %20 to %2520 which didn't resolve to the proper address