### PR TITLE
Update dynmap_style.css

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/css/dynmap_style.css
+++ b/DynmapCore/src/main/resources/extracted/web/css/dynmap_style.css
@@ -411,7 +411,7 @@
 
 .dynmap .sublist .item > a {
     display: block;
-
+    
     text-indent: -99999px;
     outline: none;
 }
@@ -806,10 +806,10 @@
 }
 
 .chatinput {
-
+    position: absolute;
 	width: 608px;
 	height: 16px;
-
+    bottom: 8px;
 	outline: none;
 	color: #fff;
 	background-color: #000000;
@@ -829,6 +829,9 @@
 }
 
 .loginbutton {
+    position: absolute;
+	bottom: 0px;
+	right: 4px;
 	color: #000;
 	font-family: sans-serif;
 	font-size: 11px;


### PR DESCRIPTION
patched issue where the chatbar would drop if login or customlink was enabled, but now the custom link and login overlap if they are set to be in the same area, I don't have enough frontend-knowledge to fix this sadly.