### PR TITLE
feat: add `readonly` map option

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/MapManager.java
+++ b/DynmapCore/src/main/java/org/dynmap/MapManager.java
@@ -629,10 +629,12 @@ public class MapManager {
                     renderedmaps.addAll(map.getMapsSharingRender(world));
 
                     /* Now, prime the render queue */
-                    for (MapTile mt : map.getTiles(world, (int)loc.x, (int)loc.y, (int)loc.z)) {
-                        if (!found.getFlag(mt.tileOrdinalX(), mt.tileOrdinalY())) {
-                            found.setFlag(mt.tileOrdinalX(), mt.tileOrdinalY(), true);
-                            renderQueue.add(mt);
+                    if (map.isReadOnly() == false) {
+                        for (MapTile mt : map.getTiles(world, (int)loc.x, (int)loc.y, (int)loc.z)) {
+                            if (!found.getFlag(mt.tileOrdinalX(), mt.tileOrdinalY())) {
+                                found.setFlag(mt.tileOrdinalX(), mt.tileOrdinalY(), true);
+                                renderQueue.add(mt);
+                            }
                         }
                     }
                     if(!updaterender) { /* Only add other seed points for fullrender */
@@ -1072,6 +1074,10 @@ public class MapManager {
             tiles.clear();
             for(DynmapWorld w : worlds) {
                 for(MapTypeState mts : w.mapstate) {
+                    if (mts.type.isReadOnly()) {
+                        continue;
+                    }
+
                     if(mts.getNextInvalidTileCoord(coord)) {
                         mts.type.addMapTiles(tiles, w, coord.x, coord.y);
                         mts.validateTile(coord.x, coord.y);
@@ -1903,6 +1909,10 @@ public class MapManager {
                 }
                 if(world == null) continue;
                 for (MapTypeState mts : world.mapstate) {
+                    if (mts.type.isReadOnly()) {
+                        continue;
+                    }
+
                     List<TileFlags.TileCoord> tiles = mts.type.getTileCoords(world, evt.x, evt.y, evt.z);
                     invalidates += mts.invalidateTiles(tiles);
                 }
@@ -1935,6 +1945,10 @@ public class MapManager {
                 if(world == null) continue;
                 int invalidates = 0;
                 for (MapTypeState mts : world.mapstate) {
+                    if (mts.type.isReadOnly()) {
+                        continue;
+                    }
+
                     List<TileFlags.TileCoord> tiles = mts.type.getTileCoords(world, evt.xmin, evt.ymin, evt.zmin, evt.xmax, evt.ymax, evt.zmax);
                     invalidates += mts.invalidateTiles(tiles);
                 }

--- a/DynmapCore/src/main/java/org/dynmap/MapType.java
+++ b/DynmapCore/src/main/java/org/dynmap/MapType.java
@@ -10,6 +10,10 @@ import org.json.simple.JSONObject;
 
 public abstract class MapType {
     private boolean is_protected;
+    /**
+     * Is the map type read-only? (i.e. should not be updated by renderer)
+     */
+    private boolean is_readonly;
     protected int tileupdatedelay;
     
     public enum ImageVariant {
@@ -203,6 +207,26 @@ public abstract class MapType {
     public boolean setProtected(boolean p) {
         if(is_protected != p) {
             is_protected = p;
+            return true;
+        }
+        return false;
+    }
+    /**
+     * Is the map type read-only? (i.e. should not be updated by renderer)
+     * @return true if read-only
+     */
+    public boolean isReadOnly() {
+        return is_readonly;
+    }
+
+    /**
+     * Set read-only state of map type
+     * @param r - true if read-only
+     * @return true if state changed
+     */
+    public boolean setReadOnly(boolean r) {
+        if(is_readonly != r) {
+            is_readonly = r;
             return true;
         }
         return false;

--- a/DynmapCore/src/main/java/org/dynmap/hdmap/HDMap.java
+++ b/DynmapCore/src/main/java/org/dynmap/hdmap/HDMap.java
@@ -153,6 +153,7 @@ public class HDMap extends MapType {
         this.append_to_world = configuration.getString("append_to_world", "");
         setProtected(configuration.getBoolean("protected", false));
         setTileUpdateDelay(configuration.getInteger("tileupdatedelay", -1));
+        setReadOnly(configuration.getBoolean("readonly", false));
     }
 
     public ConfigurationNode saveConfiguration() {

--- a/DynmapCore/src/main/java/org/dynmap/hdmap/HDMapManager.java
+++ b/DynmapCore/src/main/java/org/dynmap/hdmap/HDMapManager.java
@@ -131,6 +131,12 @@ public class HDMapManager {
                     /* If limited to one map, and this isn't it, skip */
                     if((mapname != null) && (!hdmap.getName().equals(mapname)))
                         continue;
+
+                    // Maps can be set to read-only, which means they don't get re-rendered
+                    if (map.isReadOnly()) {
+                        continue;
+                    }
+
                     shaders.add(hdmap.getShader().getStateInstance(hdmap, cache, mapiter, scale));
                 }
             }

--- a/DynmapCore/src/main/java/org/dynmap/hdmap/IsoHDPerspective.java
+++ b/DynmapCore/src/main/java/org/dynmap/hdmap/IsoHDPerspective.java
@@ -1268,7 +1268,7 @@ public class IsoHDPerspective implements HDPerspective {
         // Mark the tiles we're going to render as validated
         for (int i = 0; i < numshaders; i++) {
             MapTypeState mts = world.getMapState(shaderstate[i].getMap());
-            if (mts != null) {
+            if (mts != null && mts.type.isReadOnly() == false) {
                 mts.validateTile(tile.tx, tile.ty);
             }
         }

--- a/DynmapCore/src/main/resources/worlds.txt
+++ b/DynmapCore/src/main/resources/worlds.txt
@@ -90,6 +90,8 @@ worlds:
   #      shader: cave
   #      lighting: default
   #      mapzoomin: 3
+  #      # maps can be set to `readonly: false` to prevent updates
+  #      readonly: false 
   #
   # To just label world, and inherit rest from template, just provide name and title
   #- name: world2


### PR DESCRIPTION
This option will prevent the map from being updated by the renderer. It can be used if you want a "natural" map, i.e. you want to generate a map and preserve it without being updated with users buildings.

- I'm not sure if these changes are all needed, or all in the right place. It works appropriately in my testing, but as discussed on Discord the only way to find related code is by manually searching. Possibly this change would be better suited elsewhere
- I have updated the template `worlds.txt` file to include the changes.
- This also affects /fullrender and /radiusrender, i.e. they have no effect on a `readonly` map.