### PR TITLE
Allow addon mods to track when the internal webserver goes online/offline

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -679,6 +679,7 @@ public class DynmapCore implements DynmapCommonAPI {
                 Log.warning("Using external server, but " + JsonFileClientUpdateComponent.class.toString() + " is DISABLED!");
                 webserverCompConfigWarn = true;
             }
+            DynmapWebserverStateListener.stateWebServerDisabled();
         }
         if (webserverCompConfigWarn) {
             Log.warning("If the website is missing files or not loading/updating, this might be why.");
@@ -1075,6 +1076,7 @@ public class DynmapCore implements DynmapCommonAPI {
         try {
             if(webServer != null) {
                 webServer.start();
+                DynmapWebserverStateListener.stateWebserverStarted();
                 Log.info("Web server started on address " + webhostname + ":" + webport);
             }
         } catch (Exception e) {
@@ -1100,6 +1102,7 @@ public class DynmapCore implements DynmapCommonAPI {
                 Log.severe("Failed to stop WebServer!", e);
             }
             webServer = null;
+            DynmapWebserverStateListener.stateWebserverStopped();
         }
 
         if (componentManager != null) {

--- a/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
+++ b/DynmapCore/src/main/java/org/dynmap/DynmapCore.java
@@ -679,7 +679,7 @@ public class DynmapCore implements DynmapCommonAPI {
                 Log.warning("Using external server, but " + JsonFileClientUpdateComponent.class.toString() + " is DISABLED!");
                 webserverCompConfigWarn = true;
             }
-            DynmapWebserverStateListener.stateWebServerDisabled();
+            DynmapWebserverStateListener.stateWebserverDisabled();
         }
         if (webserverCompConfigWarn) {
             Log.warning("If the website is missing files or not loading/updating, this might be why.");

--- a/DynmapCoreAPI/src/main/java/org/dynmap/DynmapWebserverStateListener.java
+++ b/DynmapCoreAPI/src/main/java/org/dynmap/DynmapWebserverStateListener.java
@@ -77,7 +77,7 @@ public abstract class DynmapWebserverStateListener
     }
 
     // Internal call - MODS/PLUGINS MUST NOT USE
-    public static void stateWebServerDisabled()
+    public static void stateWebserverDisabled()
     {
         for (DynmapWebserverStateListener l : listeners)
         {

--- a/DynmapCoreAPI/src/main/java/org/dynmap/DynmapWebserverStateListener.java
+++ b/DynmapCoreAPI/src/main/java/org/dynmap/DynmapWebserverStateListener.java
@@ -1,0 +1,87 @@
+package org.dynmap;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Listener class for the Dynmap integrated web server lifecycle, will only work if the internal webserver is actually being used.
+ */
+public abstract class DynmapWebserverStateListener
+{
+    /**
+     * Status flag indicating if the web server is online or offline.
+     */
+    private static boolean webserverStarted = false;
+
+    private static final CopyOnWriteArrayList<DynmapWebserverStateListener> listeners = new CopyOnWriteArrayList<>();
+
+    /**
+     * Called when API becomes enabled, or during call to register listener if API is already enabled
+     */
+    public abstract void webserverStarted();
+
+    /**
+     * Called when API becomes enabled, or during call to register listener if API is already enabled
+     */
+    public abstract void webserverStopped();
+
+    /**
+     * This method is fired to indicate the listener that the internal web server is not enabled, thus indicating that {@link DynmapWebserverStateListener#webserverStarted()} and {@link DynmapWebserverStateListener#webserverStopped()} will not fire.
+     */
+    public void webserverDisabled() {}
+
+    /**
+     * Register listener instance
+     *
+     * @param listener - listener to register
+     */
+    public static void register(DynmapWebserverStateListener listener)
+    {
+        listeners.add(listener);
+        if (webserverStarted)
+        {
+            listener.webserverStarted();
+        }
+    }
+
+    /**
+     * Unregister listener instance
+     *
+     * @param listener - listener to unregister
+     */
+    public static void unregister(DynmapWebserverStateListener listener) {
+        listeners.remove(listener);
+    }
+
+    // Internal call - MODS/PLUGINS MUST NOT USE
+    public static void stateWebserverStarted()
+    {
+        if (webserverStarted)
+        {
+            stateWebserverStopped();
+        }
+        webserverStarted = true;
+        for (DynmapWebserverStateListener l : listeners)
+        {
+            l.webserverStarted();
+        }
+    }
+
+    // Internal call - MODS/PLUGINS MUST NOT USE
+    public static void stateWebserverStopped()
+    {
+        for (DynmapWebserverStateListener l : listeners)
+        {
+            l.webserverStopped();
+        }
+        webserverStarted = false;
+    }
+
+    // Internal call - MODS/PLUGINS MUST NOT USE
+    public static void stateWebServerDisabled()
+    {
+        for (DynmapWebserverStateListener l : listeners)
+        {
+            l.webserverDisabled();
+        }
+    }
+}


### PR DESCRIPTION
## What is added
A new class to the DynmapCoreAPI, which works similar to the DynmapCommonAPIListener, responsible for tracking listener classes who want to know about state changes in the internal web server.

Features 3 callback methods, when the server is started, stopped, or if the internal webserver was completely disabled through the config.

## Use case
In my addon mod I want to be able to modify the web files to inject (mostly css) to re-style the website itself and markers, rather than relying on people having to manually install new things into the website.

This in itself is already possible, however. The only way possible to track the uptime of the web server is to realisitcally check if the web server files are being created on the filesystem. If the internal webserver is disabled this is never going to happen, leaving my mod into essentially a dead cycle which wouldn't ever complete.
If I can prematurely know if the web server is disabled entirely, I don't have to bother to poll if the index.html exists or not.

Secondly the started/stopped events can help in saying when the server (and thus all it's content) is available, at which point I can safely overwrite any content in the files that I want to add.

## Testing
I verified the code works in the latest Forge, Fabric and Spigot builds to be sure. Though realistically nothing can go wrong unless the callback implementations would throw an exception.