### PR TITLE
Improves Render speed of Zoom tiles by using "free" capacity of the Render Threads.

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/MapManager.java
+++ b/DynmapCore/src/main/java/org/dynmap/MapManager.java
@@ -517,7 +517,7 @@ public class MapManager {
                 }, new MapStorageTileSearchEndCB() {
                     @Override
                     public void searchEnded() {
-                    	
+
                     }
                 });
                 sendMessage(String.format("Scan complete - starting render"));
@@ -938,14 +938,16 @@ public class MapManager {
             scheduleDelayedJob(this, 5000);
         }
     }
-    
+    public int getActivePoolThreadCount(){
+        return render_pool.getActiveCount();
+    }
     private class DoZoomOutProcessing implements Runnable {
         public void run() {
             if (!tpspausezoomout) {
                 Debug.debug("DoZoomOutProcessing started");
                 ArrayList<DynmapWorld> wl = new ArrayList<DynmapWorld>(worlds);
                 for(DynmapWorld w : wl) {
-                    w.freshenZoomOutFiles();
+                    w.freshenZoomOutFiles(parallelrendercnt);
                 }
                 Debug.debug("DoZoomOutProcessing finished");
                 scheduleDelayedJob(this, zoomout_period*1000);


### PR DESCRIPTION
Works by checking the amount of active Threads processing tiles. If the amount of Active Threads is less than parallelrendercnt we can use the "spare" capacity for zoom processing. We are using a seperate ThreadPoolExecutor to achive this. Also adds one more cancellation check to process cancellations for large zoom out renders (when many tiles needs to be processed). Additionally it will report Zoom Rendering progress.

Just some metrics for better perspective.
This change improves Total render time (Start of fullrender until zoom out rendering is completed) by 22-23%
The only drawback is that under high load situations the avg tile render speed can drop.
In Terms of usability Results the Zoom Renderer will complete faster thus providing potentially better user experience. Overall with the improvements from #4011 we are still a bit faster in overall render speed compared to before.
