### PR TITLE
Proper error catching (regarding Quilt)

### DIFF
--- a/fabric-1.20/src/main/java/org/dynmap/fabric_1_20/DynmapMod.java
+++ b/fabric-1.20/src/main/java/org/dynmap/fabric_1_20/DynmapMod.java
@@ -30,7 +30,7 @@ public class DynmapMod implements ModInitializer {
         Path path = MOD_CONTAINER.getRootPath();
         try {
             jarfile = new File(DynmapCore.class.getProtectionDomain().getCodeSource().getLocation().toURI());
-        } catch (URISyntaxException e) {
+        } catch (URISyntaxException | IllegalArgumentException e) {
             Log.severe("Unable to get DynmapCore jar path", e);
         }
 


### PR DESCRIPTION
When the mod is loaded by quilt and you try to get the path using this method an IllegalArgumentException is thrown, I think that quilt is not loading the mod as a file so this is why you are getting this error.

Related to #4016 