### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/hdmap/ChunkVersionHDShader.java
+++ b/DynmapCore/src/main/java/org/dynmap/hdmap/ChunkVersionHDShader.java
@@ -34,7 +34,7 @@ public class ChunkVersionHDShader implements HDShader {
 
     	}
     };
-    // Mapping from https://minecraft.fandom.com/wiki/Data_version
+    // Mapping from https://minecraft.wiki/w/Data_version
     final static DataVersionMap[] versionmap = {
     	new DataVersionMap(0, "unknown", 0x202020),
     	new DataVersionMap(1519, "1.13.0", 0xF9E79F),


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.