### PR TITLE
Improve version helper, use data versions instead of strings

### DIFF
--- a/spigot/build.gradle
+++ b/spigot/build.gradle
@@ -19,7 +19,7 @@ repositories {
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 
 dependencies {
-    implementation('org.bukkit:bukkit:1.10.2-R0.1-SNAPSHOT') { transitive = false }
+    implementation('org.bukkit:bukkit:1.13.2-R0.1-SNAPSHOT') { transitive = false }
     compileOnly('com.nijikokun.bukkit:Permissions:3.1.6')  { transitive = false }
     compileOnly('me.lucko.luckperms:luckperms-api:4.3')  { transitive = false }
     compileOnly('net.luckperms:api:5.0')  { transitive = false }

--- a/spigot/src/main/java/org/dynmap/bukkit/Helper.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/Helper.java
@@ -18,7 +18,16 @@ public class Helper {
 			return null;
 		}
 	}
-    public static final BukkitVersionHelper getHelper() {
+
+    private static int getDataVersion() {
+        try {
+            return Bukkit.getUnsafe().getDataVersion();
+        } catch (NoSuchMethodError e) {
+            return 0;
+        }
+    }
+
+    public static BukkitVersionHelper getHelper() {
         if (BukkitVersionHelper.helper == null) {
         	String v = Bukkit.getServer().getVersion();
             Log.info("version=" + v);
@@ -40,58 +49,68 @@ public class Helper {
                 Log.info("Loading Glowstone support");
                 BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.BukkitVersionHelperGlowstone");
             }
-            else if (v.contains("(MC: 1.20)") || v.contains("(MC: 1.20.1)")) {
-            	BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v120.BukkitVersionHelperSpigot120");
-            }
-            else if (v.contains("(MC: 1.20")) {
-            	BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v120_2.BukkitVersionHelperSpigot120_2");
-            }
-            else if (v.contains("(MC: 1.19)") || v.contains("(MC: 1.19.1)") || v.contains("(MC: 1.19.2)")) {
-            	BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v119.BukkitVersionHelperSpigot119");
-            }
-            else if (v.contains("(MC: 1.19.3)")) {
-            	BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v119_3.BukkitVersionHelperSpigot119_3");
-            }
-            else if (v.contains("(MC: 1.19.")) {
-            	BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v119_4.BukkitVersionHelperSpigot119_4");
-            }
-            else if (v.contains("(MC: 1.18)") || (v.contains("(MC: 1.18.1)"))) {
-            	BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v118.BukkitVersionHelperSpigot118");
-            }
-            else if (v.contains("(MC: 1.18")) {
-            	BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v118_2.BukkitVersionHelperSpigot118_2");
-            }
-            else if (v.contains("(MC: 1.17")) {
-                BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v117.BukkitVersionHelperSpigot117");
-            }
-            else if (v.contains("(MC: 1.16.1")) {
-                BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v116.BukkitVersionHelperSpigot116");
-            }
-            else if (v.contains("(MC: 1.16.2)")) {
-                BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v116_2.BukkitVersionHelperSpigot116_2");
-            }
-            else if (v.contains("(MC: 1.16.3)")) {
-                BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v116_3.BukkitVersionHelperSpigot116_3");
-            }
-            else if (v.contains("(MC: 1.16.")) {
-                BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v116_4.BukkitVersionHelperSpigot116_4");
-            }
-            // Loading last to prevent the 1.16 contains to match all newer versions and load older helper incorrectly.
-            else if (v.contains("(MC: 1.16")) {
-                BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v116.BukkitVersionHelperSpigot116");
-            }
-            else if (v.contains("(MC: 1.15)") || v.contains("(MC: 1.15.")) {
-                BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v115.BukkitVersionHelperSpigot115");
-            }
-            else if (v.contains("(MC: 1.14)") || v.contains("(MC: 1.14.1)") || v.contains("(MC: 1.14.2)") ||
-                v.contains("(MC: 1.14.3)") ||  v.contains("(MC: 1.14.4)")) {
-                BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v114_1.BukkitVersionHelperSpigot114_1");
-            }
-            else if (v.contains("(MC: 1.13.2)")) {
-                BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v113_2.BukkitVersionHelperSpigot113_2");
-            }
-            else {
-            	BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.BukkitVersionHelperCB");
+            switch (getDataVersion()) {
+                case 3578: // 1.20.2
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v120_2.BukkitVersionHelperSpigot120_2");
+                    break;
+                case 3465: // 1.20.1
+                case 3463: // 1.20
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v120.BukkitVersionHelperSpigot120");
+                    break;
+                case 3337: // 1.19.4
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v119_4.BukkitVersionHelperSpigot119_4");
+                    break;
+                case 3218: // 1.19.3
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v119_3.BukkitVersionHelperSpigot119_3");
+                    break;
+                case 3120: // 1.19.2
+                case 3117: // 1.19.1
+                case 3105: // 1.19
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v119.BukkitVersionHelperSpigot119");
+                    break;
+                case 2975: // 1.18.2
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v118_2.BukkitVersionHelperSpigot118_2");
+                    break;
+                case 2865: // 1.18.1
+                case 2860: // 1.18
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v118.BukkitVersionHelperSpigot118");
+                    break;
+                case 2730: // 1.17.1
+                case 2724: // 1.17
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v117.BukkitVersionHelperSpigot117");
+                    break;
+                case 2586: // 1.16.5
+                case 2584: // 1.16.4
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v116_4.BukkitVersionHelperSpigot116_4");
+                    break;
+                case 2580: // 1.16.3
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v116_3.BukkitVersionHelperSpigot116_3");
+                    break;
+                case 2578: // 1.16.2
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v116_2.BukkitVersionHelperSpigot116_2");
+                    break;
+                case 2567: // 1.16.1
+                case 2566: // 1.16
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v116.BukkitVersionHelperSpigot116");
+                    break;
+                case 2230: // 1.15.2
+                case 2227: // 1.15.1
+                case 2225: // 1.15
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v115.BukkitVersionHelperSpigot115");
+                    break;
+                case 1976: // 1.14.4
+                case 1968: // 1.14.3
+                case 1963: // 1.14.2
+                case 1957: // 1.14.1
+                case 1952: // 1.14
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v114_1.BukkitVersionHelperSpigot114_1");
+                    break;
+                case 1631: // 1.13.2
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.v113_2.BukkitVersionHelperSpigot113_2");
+                    break;
+                default: // everything else
+                    BukkitVersionHelper.helper = loadVersionHelper("org.dynmap.bukkit.helper.BukkitVersionHelperCB");
+                    break;
             }
         }
         return BukkitVersionHelper.helper;


### PR DESCRIPTION
Bukkit exposes the magic number `DataVersion` in `Bukkit.getUnsafe().getDataVersion()`. This version is unique to every release and easy to compare.

To minimize errors by parsing the version string I changed the helper method to get the `BukkitVersionHelper` to use this verison. For older versions before 1.13.2 this method is not exposed yet.

The data versions can be found here: https://minecraft.wiki/w/Data_version#List_of_data_versions