### PR TITLE
Enable require-player-login-ip by default

### DIFF
--- a/fabric-1.14.4/src/main/resources/configuration.txt
+++ b/fabric-1.14.4/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/fabric-1.15.2/src/main/resources/configuration.txt
+++ b/fabric-1.15.2/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/fabric-1.16.4/src/main/resources/configuration.txt
+++ b/fabric-1.16.4/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/fabric-1.17.1/src/main/resources/configuration.txt
+++ b/fabric-1.17.1/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/fabric-1.18.2/src/main/resources/configuration.txt
+++ b/fabric-1.18.2/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/fabric-1.19.1/src/main/resources/configuration.txt
+++ b/fabric-1.19.1/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/fabric-1.19.3/src/main/resources/configuration.txt
+++ b/fabric-1.19.3/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/fabric-1.19.4/src/main/resources/configuration.txt
+++ b/fabric-1.19.4/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/fabric-1.19/src/main/resources/configuration.txt
+++ b/fabric-1.19/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/fabric-1.20.2/src/main/resources/configuration.txt
+++ b/fabric-1.20.2/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/fabric-1.20/src/main/resources/configuration.txt
+++ b/fabric-1.20/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/forge-1.12.2/src/main/resources/configuration.txt
+++ b/forge-1.12.2/src/main/resources/configuration.txt
@@ -53,7 +53,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -84,7 +84,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/forge-1.14.4/src/main/resources/configuration.txt
+++ b/forge-1.14.4/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/forge-1.15.2/src/main/resources/configuration.txt
+++ b/forge-1.15.2/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/forge-1.16.5/src/main/resources/configuration.txt
+++ b/forge-1.16.5/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/forge-1.17.1/src/main/resources/configuration.txt
+++ b/forge-1.17.1/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/forge-1.18.2/src/main/resources/configuration.txt
+++ b/forge-1.18.2/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/forge-1.19.2/src/main/resources/configuration.txt
+++ b/forge-1.19.2/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/forge-1.19.3/src/main/resources/configuration.txt
+++ b/forge-1.19.3/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/forge-1.19/src/main/resources/configuration.txt
+++ b/forge-1.19/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/forge-1.20.2/src/main/resources/configuration.txt
+++ b/forge-1.20.2/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/forge-1.20/src/main/resources/configuration.txt
+++ b/forge-1.20/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0

--- a/spigot/src/main/resources/configuration.txt
+++ b/spigot/src/main/resources/configuration.txt
@@ -65,7 +65,7 @@ components:
     # (optional) if true, player login IDs will be used for web chat when their IPs match
     use-player-login-ip: true
     # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
-    require-player-login-ip: false
+    require-player-login-ip: true
     # (optional) block player login IDs that are banned from chatting
     block-banned-player-chat: true
     # Require login for web-to-server chat (requires login-enabled: true)
@@ -96,7 +96,7 @@ components:
   #  includehiddenplayers: false
   #  use-name-colors: false
   #  use-player-login-ip: false
-  #  require-player-login-ip: false
+  #  require-player-login-ip: true
   #  block-banned-player-chat: true
   #  hideifshadow: 0
   #  hideifundercover: 0


### PR DESCRIPTION
This should be on by default to prevent automated bots from spamming chat messages.