### PR TITLE
Allow generic S3 endpoints for alternative services

### DIFF
--- a/DynmapCore/build.gradle
+++ b/DynmapCore/build.gradle
@@ -19,11 +19,11 @@ dependencies {
     implementation 'org.yaml:snakeyaml:1.23'	// DON'T UPDATE - NEWER ONE TRIPS ON WINDOWS ENCODED FILES
     implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20180219.1'
     implementation 'org.postgresql:postgresql:42.2.18'
-    implementation 'io.github.linktosriram:s3-lite-core:0.2.0'
-    implementation 'io.github.linktosriram:s3-lite-api:0.2.0'
-    implementation 'io.github.linktosriram:s3-lite-http-client-url-connection:0.2.0'
-    implementation 'io.github.linktosriram:s3-lite-http-client-spi:0.2.0'
-    implementation 'io.github.linktosriram:s3-lite-util:0.2.0'
+    implementation 'io.github.linktosriram.s3lite:core:0.0.2-SNAPSHOT'
+    implementation 'io.github.linktosriram.s3lite:api:0.0.2-SNAPSHOT'
+    implementation 'io.github.linktosriram.s3lite:http-client-url-connection:0.0.2-SNAPSHOT'
+    implementation 'io.github.linktosriram.s3lite:http-client-spi:0.0.2-SNAPSHOT'
+    implementation 'io.github.linktosriram.s3lite:util:0.0.2-SNAPSHOT'
 }
 
 processResources {
@@ -58,11 +58,11 @@ shadowJar {
         include(dependency('org.eclipse.jetty::'))
         include(dependency('org.eclipse.jetty.orbit:javax.servlet:'))
         include(dependency('org.postgresql:postgresql:'))
-        include(dependency('io.github.linktosriram:s3-lite-core:'))
-        include(dependency('io.github.linktosriram:s3-lite-api:'))
-        include(dependency('io.github.linktosriram:s3-lite-http-client-url-connection:'))
-        include(dependency('io.github.linktosriram:s3-lite-http-client-spi:'))
-	    include(dependency('io.github.linktosriram:s3-lite-util:'))
+        include(dependency('io.github.linktosriram.s3lite:core:'))
+        include(dependency('io.github.linktosriram.s3lite:api:'))
+        include(dependency('io.github.linktosriram.s3lite:http-client-url-connection:'))
+        include(dependency('io.github.linktosriram.s3lite:http-client-spi:'))
+	    include(dependency('io.github.linktosriram.s3lite:util:'))
         include(dependency(':DynmapCoreAPI'))
         exclude("META-INF/maven/**")
         exclude("META-INF/services/**")

--- a/DynmapCore/build.gradle
+++ b/DynmapCore/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     implementation 'io.github.linktosriram.s3lite:http-client-url-connection:0.0.2-SNAPSHOT'
     implementation 'io.github.linktosriram.s3lite:http-client-spi:0.0.2-SNAPSHOT'
     implementation 'io.github.linktosriram.s3lite:util:0.0.2-SNAPSHOT'
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
+    implementation 'com.sun.xml.bind:jaxb-impl:3.0.0'
 }
 
 processResources {
@@ -62,7 +64,9 @@ shadowJar {
         include(dependency('io.github.linktosriram.s3lite:api:'))
         include(dependency('io.github.linktosriram.s3lite:http-client-url-connection:'))
         include(dependency('io.github.linktosriram.s3lite:http-client-spi:'))
-	    include(dependency('io.github.linktosriram.s3lite:util:'))
+        include(dependency('io.github.linktosriram.s3lite:util:'))
+        include(dependency('jakarta.xml.bind::'))
+        include(dependency('com.sun.xml.bind::'))
         include(dependency(':DynmapCoreAPI'))
         exclude("META-INF/maven/**")
         exclude("META-INF/services/**")

--- a/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
@@ -1,6 +1,7 @@
 package org.dynmap.storage.aws_s3;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -221,7 +222,7 @@ public class AWSS3MapStorage extends MapStorage {
     }
     
     private String bucketname;
-    private String region;
+    private Region region;
     private String access_key_id;
     private String secret_access_key;
     private String prefix;
@@ -248,10 +249,20 @@ public class AWSS3MapStorage extends MapStorage {
         }
         // Get our settings
         bucketname = core.configuration.getString("storage/bucketname", "dynmap");
-        region = core.configuration.getString("storage/region", "us-east-1");
         access_key_id = core.configuration.getString("storage/aws_access_key_id", System.getenv("AWS_ACCESS_KEY_ID"));
         secret_access_key = core.configuration.getString("storage/aws_secret_access_key", System.getenv("AWS_SECRET_ACCESS_KEY"));
         prefix = core.configuration.getString("storage/prefix", "");
+
+        // Either use a custom region, or one of the default AWS regions
+        String region_name = core.configuration.getString("storage/region", "us-east-1");
+        String region_endpoint = core.configuration.getString("storage/override_endpoint", "");
+
+        if (region_endpoint.length() > 0) {
+            region = Region.of(region_name, URI.create(region_endpoint));
+        } else {
+            region = Region.fromString(region_name);
+        }
+
         if ((prefix.length() > 0) && (prefix.charAt(prefix.length()-1) != '/')) {
         	prefix += '/';
         }
@@ -763,7 +774,7 @@ public class AWSS3MapStorage extends MapStorage {
                     if (cpoolCount < POOLSIZE) {  // Still more we can have
                         c = new DefaultS3ClientBuilder()
                         	    .credentialsProvider(() -> AwsBasicCredentials.create(access_key_id, secret_access_key))
-                        	    .region(Region.fromString(region))
+                        	    .region(region)
                         	    .httpClient(URLConnectionSdkHttpClient.create())
                         	    .build();
                         if (c == null) {

--- a/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
@@ -139,7 +139,7 @@ public class AWSS3MapStorage extends MapStorage {
         		else {
         			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType(map.getImageFormat().getEncoding().getContentType())
         					.addMetadata("x-dynmap-hash", Long.toHexString(hash)).addMetadata("x-dynmap-ts", Long.toString(timestamp)).build();
-        			s3.putObject(req, RequestBody.fromBytes(encImage.buf, encImage.len));
+        			s3.putObject(req, RequestBody.fromBytes(encImage.buf));
         		}
     			done = true;
             } catch (S3Exception x) {
@@ -518,7 +518,7 @@ public class AWSS3MapStorage extends MapStorage {
     		}
     		else {
     			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType("image/png").build();
-    			s3.putObject(req, RequestBody.fromBytes(encImage.buf, encImage.len));
+    			s3.putObject(req, RequestBody.fromBytes(encImage.buf));
     		}
 			done = true;
         } catch (S3Exception x) {
@@ -571,7 +571,7 @@ public class AWSS3MapStorage extends MapStorage {
     		}
     		else {
        			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType("image/png").build();
-    			s3.putObject(req, RequestBody.fromBytes(encImage.buf, encImage.len));
+    			s3.putObject(req, RequestBody.fromBytes(encImage.buf));
     		}
 			done = true;
         } catch (S3Exception x) {
@@ -734,7 +734,7 @@ public class AWSS3MapStorage extends MapStorage {
     				ct = "application/x-javascript";
     			}
        			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType(ct).build();
-    			s3.putObject(req, RequestBody.fromBytes(content.buf, content.len));
+    			s3.putObject(req, RequestBody.fromBytes(content.buf));
         		standalone_cache.put(fileid, digest);
     		}
 			done = true;

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ allprojects  {
      mavenLocal()
      maven { url 'https://libraries.minecraft.net/' }
      maven { url "https://oss.sonatype.org/content/repositories/releases" }
+     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
      maven { url "https://repo.mikeprimm.com" }
      maven { url "https://repo.maven.apache.org/maven2" }
      maven { url "https://hub.spigotmc.org/nexus/content/repositories/snapshots/" }

--- a/fabric-1.14.4/src/main/resources/configuration.txt
+++ b/fabric-1.14.4/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/fabric-1.15.2/src/main/resources/configuration.txt
+++ b/fabric-1.15.2/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/fabric-1.16.4/src/main/resources/configuration.txt
+++ b/fabric-1.16.4/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/fabric-1.17.1/src/main/resources/configuration.txt
+++ b/fabric-1.17.1/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/fabric-1.18.2/src/main/resources/configuration.txt
+++ b/fabric-1.18.2/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/fabric-1.19.1/src/main/resources/configuration.txt
+++ b/fabric-1.19.1/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/fabric-1.19.3/src/main/resources/configuration.txt
+++ b/fabric-1.19.3/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/fabric-1.19.4/src/main/resources/configuration.txt
+++ b/fabric-1.19.4/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/fabric-1.19/src/main/resources/configuration.txt
+++ b/fabric-1.19/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/fabric-1.20.2/src/main/resources/configuration.txt
+++ b/fabric-1.20.2/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/fabric-1.20/src/main/resources/configuration.txt
+++ b/fabric-1.20/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/forge-1.14.4/src/main/resources/configuration.txt
+++ b/forge-1.14.4/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/forge-1.15.2/src/main/resources/configuration.txt
+++ b/forge-1.15.2/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/forge-1.16.5/src/main/resources/configuration.txt
+++ b/forge-1.16.5/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/forge-1.17.1/src/main/resources/configuration.txt
+++ b/forge-1.17.1/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/forge-1.18.2/src/main/resources/configuration.txt
+++ b/forge-1.18.2/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/forge-1.19.2/src/main/resources/configuration.txt
+++ b/forge-1.19.2/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/forge-1.19.3/src/main/resources/configuration.txt
+++ b/forge-1.19.3/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/forge-1.19/src/main/resources/configuration.txt
+++ b/forge-1.19/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/forge-1.20.2/src/main/resources/configuration.txt
+++ b/forge-1.20.2/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/forge-1.20/src/main/resources/configuration.txt
+++ b/forge-1.20/src/main/resources/configuration.txt
@@ -47,6 +47,7 @@ storage:
   #aws_access_key_id: "<aws-access-key-id>"
   #aws_secret_access_key: "<aws-secret-access-key>"  
   #prefix: ""
+  #override_endpoint: ""
 
 components:
   - class: org.dynmap.ClientConfigurationComponent

--- a/spigot/src/main/resources/configuration.txt
+++ b/spigot/src/main/resources/configuration.txt
@@ -46,7 +46,8 @@ storage:
   #bucketname: "dynmap-bucket-name"
   #region: us-east-1
   #aws_access_key_id: "<aws-access-key-id>"
-  #aws_secret_access_key: "<aws-secret-access-key>"  
+  #aws_secret_access_key: "<aws-secret-access-key>"
+  #override_endpoint: ""
   
 components:
   - class: org.dynmap.ClientConfigurationComponent


### PR DESCRIPTION
# Overview
This is a possible implementation for a previously mentioned feature (#3691, #3973), which is custom S3-compatible endpoints in order to allow the use of non-AWS block storage. 

Many of these services offer significantly cheaper alternatives to AWS (with backblaze being almost 4x cheaper). 

I understand there was some work on this in the s3rework branch, but I was more interested in having something soon to see if my plan to use block storage is feasible, and this is potentially a good stop-gap until someone has the time to fully rework the s3 implementation.

I haven't performed much testing on this release, but it appears to work with Backblaze B2. I had some issues trying to get it to work with Cloudflare R2, but I'm not sure if this is more of a Cloudflare-related issue.

# Changes
The main blocker for implementing this is the lack of custom endpoint support within the s3-lite version dynmap uses. There is a new version, 0.0.2-SNAPSHOT, which does support custom endpoint URLs and is a mostly drop-in replacement. Though it's not an official release, there has been no movement on that repo for about a year, so that's as good as it gets without a rewrite.

Anyway, in order to implement this I updated the s3-lite package to 0.0.2-SNAPSHOT and I have added an override_endpoint option to manually set the S3 endpoint. If override_endpoint is blank (the default), it is assumed AWS S3 is being used, and the endpoint is derived from the region.

I have released jars for this version on [my fork](https://github.com/ChimneySwift/dynmap/releases) for anyone interested in testing. I have only tested spigot on 1.20.2 thus far. 

I have also cloned the wiki onto my fork, and have updated the AWS S3 page to include documentation for third-party providers.  