### PR TITLE
Fix SQLite database size keeps increasing

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/storage/sqllte/SQLiteMapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/sqllte/SQLiteMapStorage.java
@@ -533,6 +533,7 @@ public class SQLiteMapStorage extends MapStorage {
     
     private static Connection configureConnection(Connection conn) throws SQLException {
         final Statement statement = conn.createStatement();
+        statement.execute("PRAGMA auto_vacuum = FULL;");
         statement.execute("PRAGMA journal_mode = WAL;");
         statement.close();
         return conn;


### PR DESCRIPTION
https://www.sqlite.org/pragma.html#pragma_auto_vacuum

I once had a Dyanmp SQLite database that expanded to 140GB after running for several months, but the valid data in it was less than 40GB. After adding `auto_vacuum = FULL`, re-rendering and running for 2 months, the database size has barely increased.

and no performance impact was noticed.