### PR TITLE
Update TopoHDShader.java, allow for -64..319 world height

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/hdmap/TopoHDShader.java
+++ b/DynmapCore/src/main/java/org/dynmap/hdmap/TopoHDShader.java
@@ -30,10 +30,10 @@ public class TopoHDShader implements HDShader {
     public TopoHDShader(DynmapCore core, ConfigurationNode configuration) {
         name = (String) configuration.get("name");
         
-        fillcolor = new Color[256];   /* Color by Y */
+        fillcolor = new Color[384];   /* Color by Y, (-64...319) */
         /* Load defined colors from parameters */
-        for(int i = 0; i < 256; i++) {
-            fillcolor[i] = configuration.getColor("color" + i,  null);
+        for(int i = 0; i < 384; i++) {
+            fillcolor[i] = configuration.getColor("color" + (i-64),  null);
         }
         linecolor = configuration.getColor("linecolor", null);
         watercolor = configuration.getColor("watercolor", null);
@@ -45,11 +45,11 @@ public class TopoHDShader implements HDShader {
         if(fillcolor[0] == null) {
             fillcolor[0] = new Color(0, 0, 0);
         }
-        if(fillcolor[255] == null) {
-            fillcolor[255] = new Color(255, 255, 255);
+        if(fillcolor[383] == null) {
+            fillcolor[383] = new Color(255, 255, 255);
         }
         int starty = 0;
-        for(int i = 1; i < 256; i++) {
+        for(int i = 1; i < 384; i++) {
             if(fillcolor[i] != null) {  /* Found color? */
                 int delta = i - starty;
                 Color c0 = fillcolor[starty];
@@ -146,7 +146,7 @@ public class TopoHDShader implements HDShader {
             /* Compute divider for Y - to map to existing color range */
             int wh = mapiter.getWorldHeight();
             heightshift = 0;
-            while(wh > 256) {
+            while(wh > 384) {
                 heightshift++;
                 wh >>= 1;
             }
@@ -203,7 +203,7 @@ public class TopoHDShader implements HDShader {
                 return false;
             }
             int y = mapiter.getY();
-            if (y < 0) y = 0;	// Clamp at zero for now
+            if (y < -64) y = -64;	// Clamp at -64
             /* See if we're close to an edge */
             int[] xyz = ps.getSubblockCoord();
             // Only color lines when spacing is matched
@@ -231,7 +231,7 @@ public class TopoHDShader implements HDShader {
                     }
                 }
                 else {
-                    c.setColor(fillcolor[y >> heightshift]);
+                    c.setColor(fillcolor[(y+64) >> heightshift]);
                     inWater = false;
                 }
                 break;
@@ -250,7 +250,7 @@ public class TopoHDShader implements HDShader {
                     }
                 }
                 else {
-                    c.setColor(fillcolor[y >> heightshift]);
+                    c.setColor(fillcolor[(y+64) >> heightshift]);
                     inWater = false;
                 }
                 break;


### PR DESCRIPTION
config colors from color-64 to color319 for topo maps, allow for world heights of -64..319

I'm not so sure about the change in lime 149, and the idea behind the 'heightshift', maybe somebody could check.
I would really love to be able to generate topo maps for heights lower than 0 and higher then 255, need it for this map: http://welt.llraphael.com/map/?worldname=world_paul&mapname=topo&zoom=1&x=1784&y=64&z=1886

Maybe the example configuration, shader.txt should also be updated, it still uses hiddenids, where the config for hiding blocks changed to hiddenname.

My config, hiddenname not yet added:
   # Paul Valley Topology Map (Atlas Colors)
  - class: org.dynmap.hdmap.TopoHDShader
    name: topopaul
    color310: "#C7C7C7"
    color270: "#A0A0A0"
    color240: "#737373"
    color210: "#746464"
    color180: "#A16666"
    color150: "#A1736E"
    color120: "#B58C78"
    color90: "#D1B08C"
    color60: "#F0E8AB"
    color25: "#D4DB9E"
    color0: "#8CBA7D"
    color-40: "#8CAB66"
    #linecolor: "#000000"
    watercolor: "#CCF3FF"
    wateralpha: 1.0
    #hiddenids: [ 6, 17, 18, 31, 32, 37, 38, 39, 40, 50, 55, 78, 81, 83, 86, 99, 100, 103, 104, 105, 111, 115 ]
    hiddenids: [6,17,18,20,27,28,31,32,35,37,38,39,40,50,54,55,59,66,68,78,81,83,85,86,95,99,100,101,102,103,104,105,107,111,113,115,130,139,140,141,142,146,157,160,161,162,166,171,175,176,177,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,287,323,330,355,416,425,462,533,532,552,637,641,645,649]
    hiddennames: []

