### PR TITLE
Fix for Breaking S3 Changes

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
@@ -140,7 +140,7 @@ public class AWSS3MapStorage extends MapStorage {
         		else {
         			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType(map.getImageFormat().getEncoding().getContentType())
         					.addMetadata("x-dynmap-hash", Long.toHexString(hash)).addMetadata("x-dynmap-ts", Long.toString(timestamp)).build();
-        			s3.putObject(req, RequestBody.fromBytes(encImage.buf, encImage.len));
+        			s3.putObject(req, RequestBody.fromBytes(Arrays.copyOfRange(encImage.buf, 0, encImage.len)));
         		}
     			done = true;
             } catch (S3Exception x) {
@@ -529,7 +529,7 @@ public class AWSS3MapStorage extends MapStorage {
     		}
     		else {
     			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType("image/png").build();
-    			s3.putObject(req, RequestBody.fromBytes(encImage.buf, encImage.len));
+    			s3.putObject(req, RequestBody.fromBytes(Arrays.copyOfRange(encImage.buf, 0, encImage.len)));
     		}
 			done = true;
         } catch (S3Exception x) {
@@ -582,7 +582,7 @@ public class AWSS3MapStorage extends MapStorage {
     		}
     		else {
        			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType("image/png").build();
-    			s3.putObject(req, RequestBody.fromBytes(encImage.buf, encImage.len));
+    			s3.putObject(req, RequestBody.fromBytes(Arrays.copyOfRange(encImage.buf, 0, encImage.len)));
     		}
 			done = true;
         } catch (S3Exception x) {
@@ -745,7 +745,7 @@ public class AWSS3MapStorage extends MapStorage {
     				ct = "application/x-javascript";
     			}
        			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType(ct).build();
-    			s3.putObject(req, RequestBody.fromBytes(content.buf, content.len));
+    			s3.putObject(req, RequestBody.fromBytes(Arrays.copyOfRange(content.buf, 0, content.len)));
         		standalone_cache.put(fileid, digest);
     		}
 			done = true;

--- a/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
@@ -140,7 +140,7 @@ public class AWSS3MapStorage extends MapStorage {
         		else {
         			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType(map.getImageFormat().getEncoding().getContentType())
         					.addMetadata("x-dynmap-hash", Long.toHexString(hash)).addMetadata("x-dynmap-ts", Long.toString(timestamp)).build();
-        			s3.putObject(req, RequestBody.fromBytes(encImage.buf));
+        			s3.putObject(req, RequestBody.fromBytes(encImage.buf, encImage.len));
         		}
     			done = true;
             } catch (S3Exception x) {
@@ -529,7 +529,7 @@ public class AWSS3MapStorage extends MapStorage {
     		}
     		else {
     			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType("image/png").build();
-    			s3.putObject(req, RequestBody.fromBytes(encImage.buf));
+    			s3.putObject(req, RequestBody.fromBytes(encImage.buf, encImage.len));
     		}
 			done = true;
         } catch (S3Exception x) {
@@ -582,7 +582,7 @@ public class AWSS3MapStorage extends MapStorage {
     		}
     		else {
        			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType("image/png").build();
-    			s3.putObject(req, RequestBody.fromBytes(encImage.buf));
+    			s3.putObject(req, RequestBody.fromBytes(encImage.buf, encImage.len));
     		}
 			done = true;
         } catch (S3Exception x) {
@@ -745,7 +745,7 @@ public class AWSS3MapStorage extends MapStorage {
     				ct = "application/x-javascript";
     			}
        			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType(ct).build();
-    			s3.putObject(req, RequestBody.fromBytes(content.buf));
+    			s3.putObject(req, RequestBody.fromBytes(content.buf, content.len));
         		standalone_cache.put(fileid, digest);
     		}
 			done = true;


### PR DESCRIPTION
Undoing some changes made in #4030 that broke support for S3 (see #4128). These changes will now make sure the appropriate section of the buffer is written to the S3 bucket. Hence resolving #4128.