### PR TITLE
fix (S3): truncate byte buffer when putting object

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
@@ -138,9 +138,9 @@ public class AWSS3MapStorage extends MapStorage {
         			s3.deleteObject(req);
         		}
         		else {
-        			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType(map.getImageFormat().getEncoding().getContentType())
+        		    PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType(map.getImageFormat().getEncoding().getContentType())
         					.addMetadata("x-dynmap-hash", Long.toHexString(hash)).addMetadata("x-dynmap-ts", Long.toString(timestamp)).build();
-        			s3.putObject(req, RequestBody.fromBytes(encImage.buf));
+                    s3.putObject(req, RequestBody.fromBytes(Arrays.copyOf(encImage.buf, encImage.len)));
         		}
     			done = true;
             } catch (S3Exception x) {
@@ -529,7 +529,7 @@ public class AWSS3MapStorage extends MapStorage {
     		}
     		else {
     			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType("image/png").build();
-    			s3.putObject(req, RequestBody.fromBytes(encImage.buf));
+                s3.putObject(req, RequestBody.fromBytes(Arrays.copyOf(encImage.buf, encImage.len)));
     		}
 			done = true;
         } catch (S3Exception x) {
@@ -582,7 +582,7 @@ public class AWSS3MapStorage extends MapStorage {
     		}
     		else {
        			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType("image/png").build();
-    			s3.putObject(req, RequestBody.fromBytes(encImage.buf));
+                s3.putObject(req, RequestBody.fromBytes(Arrays.copyOf(encImage.buf, encImage.len)));
     		}
 			done = true;
         } catch (S3Exception x) {
@@ -611,8 +611,8 @@ public class AWSS3MapStorage extends MapStorage {
 			    s3.deleteObject(delreq);
     		}
     		else {
-       			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType("application/json").build();
-    			s3.putObject(req, RequestBody.fromBytes(content.getBytes(StandardCharsets.UTF_8)));
+                PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType("application/json").build();
+                s3.putObject(req, RequestBody.fromString(content));
     		}
 			done = true;
         } catch (S3Exception x) {
@@ -745,7 +745,7 @@ public class AWSS3MapStorage extends MapStorage {
     				ct = "application/x-javascript";
     			}
        			PutObjectRequest req = PutObjectRequest.builder().bucketName(bucketname).key(baseKey).contentType(ct).build();
-    			s3.putObject(req, RequestBody.fromBytes(content.buf));
+                s3.putObject(req, RequestBody.fromBytes(Arrays.copyOf(content.buf, content.len)));
         		standalone_cache.put(fileid, digest);
     		}
 			done = true;


### PR DESCRIPTION
possible duplicate/necrobump of #4129, resolves #4128

as mentioned in #4129, #4030 introduced a bug that uploads the entire buffer, resulting in null bytes being appended to all files.
this reverts that change, as well as changing to call the overloaded `RequestBody.fromString()`.

before the fix:
![image](https://github.com/user-attachments/assets/304354a6-b822-4d07-8730-f391fadb2b59)

after the fix:
![image](https://github.com/user-attachments/assets/6b97881c-ce77-49bc-b9af-01b8af0d18fa)

access volume looks normal, tested on a fresh world against an initially empty minio bucket:
![image](https://github.com/user-attachments/assets/388c9f70-c126-4d03-8052-bdb0bbbd6e0a)

