### PR TITLE
fix (s3): use correct continuation token

### DIFF
--- a/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
+++ b/DynmapCore/src/main/java/org/dynmap/storage/aws_s3/AWSS3MapStorage.java
@@ -407,7 +407,7 @@ public class AWSS3MapStorage extends MapStorage {
 	    		}
 	    		if (result.isTruncated()) {	// If more, build continuiation request
 	    	    	req = ListObjectsV2Request.builder().bucketName(bucketname)
-	    	    			.prefix(basekey).delimiter("").maxKeys(1000).continuationToken(result.getContinuationToken()).encodingType("url").requestPayer("requester").build();
+	    	    			.prefix(basekey).delimiter("").maxKeys(1000).continuationToken(result.getNextContinuationToken()).encodingType("url").requestPayer("requester").build();
 	    		}
 	    		else {	// Else, we're done
 	    			done = true;
@@ -480,7 +480,7 @@ public class AWSS3MapStorage extends MapStorage {
 	    		}
 	    		if (result.isTruncated()) {	// If more, build continuiation request
 	    	    	req = ListObjectsV2Request.builder().bucketName(bucketname)
-	    	    			.prefix(basekey).delimiter("").maxKeys(1000).continuationToken(result.getContinuationToken()).encodingType("url").requestPayer("requester").build();
+	    	    			.prefix(basekey).delimiter("").maxKeys(1000).continuationToken(result.getNextContinuationToken()).encodingType("url").requestPayer("requester").build();
 	    		}
 	    		else {	// Else, we're done
 	    			done = true;


### PR DESCRIPTION
resolves #4217

as mentioned in #4217 , the use of `getContinuationToken()` rather than `getNextContinuationToken()` causes an infinite loop with S3 requests, and fullrenders won't proceed to the next perspective.

I've tested against the example config in that issue and the problem was resolved.