### PR TITLE
Update DynmapPlugin - SkinsRestorer Update.java

### DIFF
--- a/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
+++ b/spigot/src/main/java/org/dynmap/bukkit/DynmapPlugin.java
@@ -988,7 +988,7 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
         }
 
         /* Skins support via SkinsRestorer */
-        SkinsRestorerSkinUrlProvider skinUrlProvider = null;
+        SkinsRestorerProvider skinUrlProvider = null;
 
         if (core.configuration.getBoolean("skinsrestorer-integration", false)) {
 
@@ -998,7 +998,7 @@ public class DynmapPlugin extends JavaPlugin implements DynmapAPI {
                 Log.warning("SkinsRestorer integration can't be enabled because SkinsRestorer is not installed");
             } else {
                 try {
-                    skinUrlProvider = new SkinsRestorerSkinUrlProvider();
+                    skinUrlProvider = new SkinsRestorerProvider();
                     Log.info("SkinsRestorer API integration enabled");
                 } catch (NoClassDefFoundError e) {
                     skinUrlProvider = null;


### PR DESCRIPTION
dynmap is using an older version of SkinsRestorer's API Class 'SkinsRestorerSkinURLProvider'. 

Update to current Class 'SkinsRestorerProvider' to hopefully fix this issue.