### PR TITLE
feat(neoforge): Add NeoForge 1.21.1 support

### DIFF
--- a/fabric-1.14.4/build.gradle
+++ b/fabric-1.14.4/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6.11'
+	id 'fabric-loom' version '1.8.13'
 }
 
 apply plugin: 'eclipse'

--- a/fabric-1.15.2/build.gradle
+++ b/fabric-1.15.2/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6.11'
+	id 'fabric-loom' version '1.8.13'
 }
 
 archivesBaseName = "Dynmap"

--- a/fabric-1.16.4/build.gradle
+++ b/fabric-1.16.4/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6.11'
+	id 'fabric-loom' version '1.8.13'
 }
 
 archivesBaseName = "Dynmap"

--- a/fabric-1.17.1/build.gradle
+++ b/fabric-1.17.1/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6.11'
+	id 'fabric-loom' version '1.8.13'
 }
 
 archivesBaseName = "Dynmap"

--- a/fabric-1.18.2/build.gradle
+++ b/fabric-1.18.2/build.gradle
@@ -1,6 +1,6 @@
 
 plugins {
-	id 'fabric-loom' version '1.6.11'
+	id 'fabric-loom' version '1.8.13'
 }
 
 archivesBaseName = "Dynmap"

--- a/fabric-1.19.4/build.gradle
+++ b/fabric-1.19.4/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6.11'
+	id 'fabric-loom' version '1.8.13'
 }
 
 archivesBaseName = "Dynmap"

--- a/fabric-1.20.2/build.gradle
+++ b/fabric-1.20.2/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6.11'
+	id 'fabric-loom' version '1.8.13'
 }
 
 archivesBaseName = "Dynmap"

--- a/fabric-1.20.4/build.gradle
+++ b/fabric-1.20.4/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6.11'
+	id 'fabric-loom' version '1.8.13'
 }
 
 archivesBaseName = "Dynmap"

--- a/fabric-1.20.6/build.gradle
+++ b/fabric-1.20.6/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6.11'
+	id 'fabric-loom' version '1.8.13'
 }
 
 archivesBaseName = "Dynmap"

--- a/fabric-1.20/build.gradle
+++ b/fabric-1.20/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6.11'
+	id 'fabric-loom' version '1.8.13'
 }
 
 archivesBaseName = "Dynmap"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge-1.21.1/.gitignore
+++ b/neoforge-1.21.1/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/.gradle/

--- a/neoforge-1.21.1/build.gradle
+++ b/neoforge-1.21.1/build.gradle
@@ -1,0 +1,64 @@
+buildscript {
+    repositories {
+        jcenter()
+        mavenCentral()
+    }
+}
+plugins {
+	id  'eclipse'
+	id  'net.neoforged.gradle.userdev' version '7.1.20'
+}
+
+eclipse {
+    project {
+        name = "Dynmap(NeoForge-1.21.1)"
+    }
+}
+
+sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = JavaLanguageVersion.of(21) // Need this here so eclipse task generates correctly.
+java.toolchain.languageVersion = JavaLanguageVersion.of(21)
+
+println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
+
+ext.buildNumber = System.getenv().BUILD_NUMBER ?: "Dev"
+
+
+project.archivesBaseName = "${project.archivesBaseName}-neoforge-1.21.1"
+
+dependencies {
+    implementation project(path: ":DynmapCore", configuration: "shadow")
+    implementation project(path: ':DynmapCoreAPI')
+    implementation "net.neoforged:neoforge:21.1.219"
+}
+
+processResources
+{
+    filesMatching('META-INF/neoforge.mods.toml') {
+        // replace version and mcversion
+        expand(
+        	version: project.version + '-' + project.ext.buildNumber,
+        	mcversion: "1.21.1"
+    	)
+    }
+}
+
+shadowJar {
+    dependencies {
+        include(dependency(':DynmapCore'))
+        include(dependency("commons-codec:commons-codec:"))
+        exclude("META-INF/maven/**")
+        exclude("META-INF/services/**")
+    }
+	relocate('org.apache.commons.codec', 'org.dynmap.neoforge_1_21_1.commons.codec')
+    
+    archiveBaseName = "Dynmap"
+    archiveClassifier = "neoforge-1.21.1"
+    destinationDirectory = file '../target'
+}
+
+shadowJar.doLast {
+    task ->
+        ant.checksum file: task.archivePath
+}
+
+build.dependsOn(shadowJar)

--- a/neoforge-1.21.1/build.gradle
+++ b/neoforge-1.21.1/build.gradle
@@ -15,15 +15,20 @@ eclipse {
     }
 }
 
-sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = JavaLanguageVersion.of(21) // Need this here so eclipse task generates correctly.
+sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = JavaLanguageVersion.of(21)
 java.toolchain.languageVersion = JavaLanguageVersion.of(21)
 
 println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 
 ext.buildNumber = System.getenv().BUILD_NUMBER ?: "Dev"
 
-
 project.archivesBaseName = "${project.archivesBaseName}-neoforge-1.21.1"
+
+minecraft {
+    accessTransformers {
+        file('src/main/resources/META-INF/accesstransformer.cfg')
+    }
+}
 
 dependencies {
     implementation project(path: ":DynmapCore", configuration: "shadow")
@@ -34,7 +39,6 @@ dependencies {
 processResources
 {
     filesMatching('META-INF/neoforge.mods.toml') {
-        // replace version and mcversion
         expand(
         	version: project.version + '-' + project.ext.buildNumber,
         	mcversion: "1.21.1"

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/ClientProxy.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/ClientProxy.java
@@ -1,0 +1,6 @@
+package org.dynmap.neoforge_1_21_1;
+
+public class ClientProxy extends Proxy {
+	public ClientProxy() {
+	}
+}

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/DynmapMod.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/DynmapMod.java
@@ -1,0 +1,125 @@
+package org.dynmap.neoforge_1_21_1;
+
+import java.io.File;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.dynmap.DynmapCommonAPI;
+import org.dynmap.DynmapCommonAPIListener;
+import org.dynmap.Log;
+import org.dynmap.neoforge_1_21_1.DynmapPlugin.OurLog;
+
+import net.minecraft.server.MinecraftServer;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
+import net.neoforged.neoforge.event.server.ServerStartedEvent;
+import net.neoforged.neoforge.event.server.ServerStartingEvent;
+import net.neoforged.neoforge.event.server.ServerStoppingEvent;
+
+@Mod("dynmap")
+public class DynmapMod
+{
+    // The instance of your mod that Forge uses.
+    public static DynmapMod instance;
+
+    // Says where the client and server 'proxy' code is loaded.
+    public static Proxy proxy = DistExecutor.runForDist(() -> ClientProxy::new, () -> Proxy::new);
+    
+    public static DynmapPlugin plugin;
+    public static File jarfile;
+    public static String ver;
+    public static boolean useforcedchunks;
+
+    public class APICallback extends DynmapCommonAPIListener {
+        @Override
+        public void apiListenerAdded() {
+            if(plugin == null) {
+                plugin = proxy.startServer(server);
+            }
+        }
+        @Override
+        public void apiEnabled(DynmapCommonAPI api) {
+        }
+    } 
+    
+    //TODO
+    //public class LoadingCallback implements net.minecraftforge.common.ForgeChunkManager.LoadingCallback {
+    //    @Override
+    //    public void ticketsLoaded(List<Ticket> tickets, World world) {
+    //        if(tickets.size() > 0) {
+    //            DynmapPlugin.setBusy(world, tickets.get(0));
+    //            for(int i = 1; i < tickets.size(); i++) {
+    //                ForgeChunkManager.releaseTicket(tickets.get(i));
+    //            }
+    //        }
+    //    }
+    //}
+
+    public DynmapMod() {
+    	instance = this;
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::init);
+
+        NeoForge.EVENT_BUS.register(this);
+
+        ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, 
+        		()->new IExtensionPoint.DisplayTest(()->IExtensionPoint.DisplayTest.IGNORESERVERONLY, (remote, isServer)-> true));
+
+        Log.setLogger(new OurLog());      
+        org.dynmap.modsupport.ModSupportImpl.init();
+    }
+    
+    public void setup(final FMLCommonSetupEvent event)
+    {
+    	//TOOO
+        jarfile = ModList.get().getModFileById("dynmap").getFile().getFilePath().toFile();
+
+        ver = ModList.get().getModContainerById("dynmap").get().getModInfo().getVersion().toString();
+
+        //// Load configuration file - use suggested (config/WesterosBlocks.cfg)
+        //Configuration cfg = new Configuration(event.getSuggestedConfigurationFile());
+        //try {
+        //    cfg.load();
+        //    
+        //    useforcedchunks = cfg.get("Settings",  "UseForcedChunks", true).getBoolean(true);
+        //}
+        //finally
+        //{
+        //    cfg.save();
+        //}
+    }
+
+    public void init(FMLLoadCompleteEvent event)
+    {
+        /* Set up for chunk loading notice from chunk manager */
+    	//TODO
+        //if(useforcedchunks) {
+        //    ForgeChunkManager.setForcedChunkLoadingCallback(DynmapMod.instance, new LoadingCallback());
+        //}
+        //else {
+        //    Log.info("[Dynmap] World loading using forced chunks is disabled");
+        //}
+    }
+
+    private MinecraftServer server;
+    
+    @SubscribeEvent
+    public void onServerStarting(ServerAboutToStartEvent event) {
+        server = event.getServer();
+        if(plugin == null)
+            plugin = proxy.startServer(server);
+		plugin.onStarting(server.getCommands().getDispatcher());
+	}
+    
+    @SubscribeEvent
+    public void onServerStarted(ServerStartedEvent event) {
+        DynmapCommonAPIListener.register(new APICallback()); 
+        plugin.serverStarted();
+    }
+
+    @SubscribeEvent
+    public void serverStopping(ServerStoppingEvent event)
+    {
+    	proxy.stopServer(plugin);
+    	plugin = null;
+    }
+}

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/DynmapMod.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/DynmapMod.java
@@ -2,7 +2,6 @@ package org.dynmap.neoforge_1_21_1;
 
 import java.io.File;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.dynmap.DynmapCommonAPI;
 import org.dynmap.DynmapCommonAPIListener;
 import org.dynmap.Log;
@@ -10,20 +9,20 @@ import org.dynmap.neoforge_1_21_1.DynmapPlugin.OurLog;
 
 import net.minecraft.server.MinecraftServer;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
 import net.neoforged.neoforge.event.server.ServerStartedEvent;
-import net.neoforged.neoforge.event.server.ServerStartingEvent;
 import net.neoforged.neoforge.event.server.ServerStoppingEvent;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.IExtensionPoint;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 
 @Mod("dynmap")
 public class DynmapMod
 {
-    // The instance of your mod that Forge uses.
     public static DynmapMod instance;
-
-    // Says where the client and server 'proxy' code is loaded.
-    public static Proxy proxy = DistExecutor.runForDist(() -> ClientProxy::new, () -> Proxy::new);
-    
+    public static Proxy proxy = new Proxy();
     public static DynmapPlugin plugin;
     public static File jarfile;
     public static String ver;
@@ -39,87 +38,39 @@ public class DynmapMod
         @Override
         public void apiEnabled(DynmapCommonAPI api) {
         }
-    } 
+    }
     
-    //TODO
-    //public class LoadingCallback implements net.minecraftforge.common.ForgeChunkManager.LoadingCallback {
-    //    @Override
-    //    public void ticketsLoaded(List<Ticket> tickets, World world) {
-    //        if(tickets.size() > 0) {
-    //            DynmapPlugin.setBusy(world, tickets.get(0));
-    //            for(int i = 1; i < tickets.size(); i++) {
-    //                ForgeChunkManager.releaseTicket(tickets.get(i));
-    //            }
-    //        }
-    //    }
-    //}
-
-    public DynmapMod() {
-    	instance = this;
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::init);
-
-        NeoForge.EVENT_BUS.register(this);
-
-        ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class, 
-        		()->new IExtensionPoint.DisplayTest(()->IExtensionPoint.DisplayTest.IGNORESERVERONLY, (remote, isServer)-> true));
-
-        Log.setLogger(new OurLog());      
+    public DynmapMod(IEventBus modEventBus) {
+        instance = this;
+        modEventBus.addListener(this::setup);
+        NeoForge.EVENT_BUS.addListener(this::onServerStarted);
+        NeoForge.EVENT_BUS.addListener(this::onServerStarting);
+        NeoForge.EVENT_BUS.addListener(this::onServerStopping);
+        Log.setLogger(new OurLog());
         org.dynmap.modsupport.ModSupportImpl.init();
     }
     
-    public void setup(final FMLCommonSetupEvent event)
-    {
-    	//TOOO
+    public void setup(final FMLCommonSetupEvent event) {
         jarfile = ModList.get().getModFileById("dynmap").getFile().getFilePath().toFile();
-
         ver = ModList.get().getModContainerById("dynmap").get().getModInfo().getVersion().toString();
-
-        //// Load configuration file - use suggested (config/WesterosBlocks.cfg)
-        //Configuration cfg = new Configuration(event.getSuggestedConfigurationFile());
-        //try {
-        //    cfg.load();
-        //    
-        //    useforcedchunks = cfg.get("Settings",  "UseForcedChunks", true).getBoolean(true);
-        //}
-        //finally
-        //{
-        //    cfg.save();
-        //}
-    }
-
-    public void init(FMLLoadCompleteEvent event)
-    {
-        /* Set up for chunk loading notice from chunk manager */
-    	//TODO
-        //if(useforcedchunks) {
-        //    ForgeChunkManager.setForcedChunkLoadingCallback(DynmapMod.instance, new LoadingCallback());
-        //}
-        //else {
-        //    Log.info("[Dynmap] World loading using forced chunks is disabled");
-        //}
     }
 
     private MinecraftServer server;
     
-    @SubscribeEvent
     public void onServerStarting(ServerAboutToStartEvent event) {
         server = event.getServer();
         if(plugin == null)
             plugin = proxy.startServer(server);
-		plugin.onStarting(server.getCommands().getDispatcher());
-	}
+        plugin.onStarting(server.getCommands().getDispatcher());
+    }
     
-    @SubscribeEvent
     public void onServerStarted(ServerStartedEvent event) {
-        DynmapCommonAPIListener.register(new APICallback()); 
+        DynmapCommonAPIListener.register(new APICallback());
         plugin.serverStarted();
     }
 
-    @SubscribeEvent
-    public void serverStopping(ServerStoppingEvent event)
-    {
-    	proxy.stopServer(plugin);
-    	plugin = null;
+    public void onServerStopping(ServerStoppingEvent event) {
+        proxy.stopServer(plugin);
+        plugin = null;
     }
 }

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/DynmapPlugin.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/DynmapPlugin.java
@@ -1707,33 +1707,6 @@ public class DynmapPlugin
             }
         }
         
-        private void touchChunk(ForgeWorld fw, ChunkAccess c, String cause) {
-			int ymax = Integer.MIN_VALUE;
-			int ymin = Integer.MAX_VALUE;
-			LevelChunkSection[] sections = c.getSections();
-			// If no sections, assume all
-			if (sections.length == 0) {
-				ymax = (c.getMaxSection()+1) << 4;
-				ymin = c.getMinSection() << 4;
-			}
-			else {
-				for(int i = 0; i < sections.length; i++) {
-					if((sections[i] != null) && (sections[i].hasOnlyAir() == false)) {
-						int sy = c.getSectionYFromSectionIndex(i) << 4;
-						if (sy < ymin) ymin = sy;
-						if ((sy+16) > ymax) ymax = sy + 16;
-					}
-				}
-			}
-			ChunkPos cp = c.getPos();
-			int x = cp.x << 4;
-			int z = cp.z << 4;
-			// If not empty AND not initial scan
-			if (ymax != Integer.MIN_VALUE) {
-				mapManager.touchVolume(fw.getName(), x, ymin, z, x+15, ymax, z+15, "chunkgenerate");
-			}
-        }
-        
         @SubscribeEvent(priority=EventPriority.LOWEST)
     	public void handleChunkLoad(ChunkEvent.Load event) {
 			LevelAccessor w = event.getLevel();
@@ -1755,7 +1728,29 @@ public class DynmapPlugin
 				ChunkPos cp = c.getPos();
 				if (fw != null) {
 					if (!checkIfKnownChunk(fw, cp)) {
-						touchChunk(fw, c, "unload");
+						int ymax = Integer.MIN_VALUE;
+						int ymin = Integer.MAX_VALUE;
+						LevelChunkSection[] sections = c.getSections();
+						// If no sections, assume all
+						if (sections.length == 0) {
+							ymax = (c.getMaxSection()+1) << 4;
+							ymin = c.getMinSection() << 4;
+						}
+						else {
+							for(int i = 0; i < sections.length; i++) {
+								if((sections[i] != null) && (sections[i].hasOnlyAir() == false)) {
+									int sy = c.getSectionYFromSectionIndex(i) << 4;
+									if (sy < ymin) ymin = sy;
+									if ((sy+16) > ymax) ymax = sy + 16;
+								}
+							}
+						}
+						int x = cp.x << 4;
+						int z = cp.z << 4;
+						// If not empty AND not initial scan
+						if (ymax != Integer.MIN_VALUE) {
+							mapManager.touchVolume(fw.getName(), x, ymin, z, x+15, ymax, z+15, "chunkgenerate");
+						}
 					}
 					removeKnownChunk(fw, cp);
 				}
@@ -1770,7 +1765,29 @@ public class DynmapPlugin
 				ForgeWorld fw = getWorld((ServerLevel)w, false);
 				ChunkPos cp = c.getPos();
 				if (fw != null) {
-					touchChunk(fw, c, "datasave");
+					int ymax = Integer.MIN_VALUE;
+				int ymin = Integer.MAX_VALUE;
+				LevelChunkSection[] sections = c.getSections();
+				// If no sections, assume all
+				if (sections.length == 0) {
+					ymax = (c.getMaxSection()+1) << 4;
+					ymin = c.getMinSection() << 4;
+				}
+				else {
+					for(int i = 0; i < sections.length; i++) {
+						if((sections[i] != null) && (sections[i].hasOnlyAir() == false)) {
+							int sy = c.getSectionYFromSectionIndex(i) << 4;
+							if (sy < ymin) ymin = sy;
+							if ((sy+16) > ymax) ymax = sy + 16;
+						}
+					}
+				}
+				int x = cp.x << 4;
+				int z = cp.z << 4;
+				// If not empty AND not initial scan
+				if (ymax != Integer.MIN_VALUE) {
+					mapManager.touchVolume(fw.getName(), x, ymin, z, x+15, ymax, z+15, "chunkgenerate");
+				}
     				// If cooked, add to known
     				if (c.getPersistedStatus() == ChunkStatus.FULL) {
     					addKnownChunk(fw, cp);

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/DynmapPlugin.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/DynmapPlugin.java
@@ -46,7 +46,6 @@ import net.minecraft.server.level.ChunkHolder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
-import net.minecraft.server.players.GameProfileCache;
 import net.minecraft.server.players.UserBanList;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.entity.Pose;
@@ -54,9 +53,7 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.LeavesBlock;
 import net.minecraft.world.level.block.LiquidBlock;
-import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -64,7 +61,7 @@ import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.ServerChatEvent;
-import net.neoforged.neoforge.event.TickEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent.PlayerChangedDimensionEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent.PlayerLoggedInEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent.PlayerLoggedOutEvent;
@@ -73,6 +70,8 @@ import net.neoforged.neoforge.event.level.BlockEvent;
 import net.neoforged.neoforge.event.level.ChunkDataEvent;
 import net.neoforged.neoforge.event.level.ChunkEvent;
 import net.neoforged.neoforge.event.level.LevelEvent;
+import net.neoforged.bus.api.EventPriority;
+import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.loading.LoadingModList;
@@ -123,10 +122,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import net.neoforged.neoforge.eventbus.api.EventPriority;
-import net.neoforged.neoforge.eventbus.api.SubscribeEvent;
-
-import net.minecraft.world.level.EmptyBlockGetter;
 
 public class DynmapPlugin
 { 
@@ -138,7 +133,6 @@ public class DynmapPlugin
     private MapManager mapManager;
     private static net.minecraft.server.MinecraftServer server;
     public static DynmapPlugin plugin;
-    private ChatHandler chathandler;
     private HashMap<String, Integer> sortWeights = new HashMap<String, Integer>(); 
     // Drop world load ticket after 30 seconds
     private long worldIdleTimeoutNS = 30 * 1000000000L;
@@ -251,7 +245,9 @@ public class DynmapPlugin
                 }
                 int lightAtten = 15;
                 try {	// Workaround for mods with broken block state logic...
-                	lightAtten =bs.canOcclude() ? 15 : (bs.isAir() ? 0 : 1);
+                    // [1.21.1] canOcclude()+isAir() replace isSolidRender()+propagatesSkylightDown()
+                    // Avoids modernfix/ferritecore lazy BlockState cache Guava LoadingCache deadlock
+                    lightAtten = bs.canOcclude() ? 15 : (bs.isAir() ? 0 : 1);
                 } catch (Exception x) {
                 	Log.warning(String.format("Exception while checking lighting data for block state: %s[%s]", bn, statename));
                 	Log.verboseinfo("Exception: " + x.toString());
@@ -260,6 +256,7 @@ public class DynmapPlugin
                 // Fill in base attributes
                 bld.setBaseState(basebs).setStateIndex(idx - baseidx).setBlockName(bn).setStateName(statename).setLegacyBlockID(idx).setAttenuatesLight(lightAtten);
                 if (bs.getSoundType() != null) { bld.setMaterial(bs.getSoundType().toString()); }
+				// [1.21.1] canOcclude() replaces isSolid(); avoids same deadlock
 				if (bs.canOcclude()) { bld.setSolid(); }
 				if (bs.isAir()) { bld.setAir(); }
 				if (bs.is(BlockTags.LOGS)) { bld.setLog(); }
@@ -355,18 +352,16 @@ public class DynmapPlugin
     }
     private ConcurrentLinkedQueue<ChatMessage> msgqueue = new ConcurrentLinkedQueue<ChatMessage>();
     
-    public class ChatHandler {
-		@SubscribeEvent
-		public void handleChat(ServerChatEvent event) {
-		    String msg = event.getMessage().getString();
-            if(!msg.startsWith("/")) {
-                ChatMessage cm = new ChatMessage();
-                cm.message = msg;
-                cm.sender = event.getPlayer();
-                msgqueue.add(cm);
-            }
-		}
-    }
+    private boolean handleChatRegistered = false;
+	public void handleChat(final ServerChatEvent event) {
+	    String msg = event.getMessage().getString();
+        if(!msg.startsWith("/")) {
+            ChatMessage cm = new ChatMessage();
+            cm.message = msg;
+            cm.sender = event.getPlayer();
+            msgqueue.add(cm);
+        }
+	}
 
     /** TODO: depends on forge chunk manager
     private static class WorldBusyRecord {
@@ -532,9 +527,8 @@ public class DynmapPlugin
         }
 
         private GameProfile getProfileByName(String player) {
-            GameProfileCache cache = server.getProfileCache();
-            Optional<GameProfile> val = cache.get(player);
-            return val.isPresent() ? val.get() : null;
+        	ServerPlayer p = server.getPlayerList().getPlayerByName(player);
+        	return (p != null) ? p.getGameProfile() : null;
         }
         
         @Override
@@ -647,7 +641,8 @@ public class DynmapPlugin
         public boolean isPlayerBanned(String pid)
         {
             UserBanList bl = server.getPlayerList().getBans();
-            return bl.isBanned(getProfileByName(pid));
+            GameProfile nid = getProfileByName(pid);
+            return (nid != null) ? bl.isBanned(nid) : false;
         }
         
         @Override
@@ -674,7 +669,7 @@ public class DynmapPlugin
                 case WORLD_SPAWN_CHANGE:
                     /*TODO
                     pm.registerEvents(new Listener() {
-                        @EventHandler(priority=EventPriority.MONITOR)
+                        @EventHandler(priority=EventEventPriority.LOWEST)
                         public void onSpawnChange(SpawnChangeEvent evt) {
                             DynmapWorld w = new BukkitWorld(evt.getWorld());
                             core.listenerManager.processWorldEvent(EventType.WORLD_SPAWN_CHANGE, w);
@@ -691,7 +686,7 @@ public class DynmapPlugin
                 case PLAYER_BED_LEAVE:
                     /*TODO
                     pm.registerEvents(new Listener() {
-                        @EventHandler(priority=EventPriority.MONITOR)
+                        @EventHandler(priority=EventEventPriority.LOWEST)
                         public void onPlayerBedLeave(PlayerBedLeaveEvent evt) {
                             DynmapPlayer p = new BukkitPlayer(evt.getPlayer());
                             core.listenerManager.processPlayerEvent(EventType.PLAYER_BED_LEAVE, p);
@@ -701,16 +696,16 @@ public class DynmapPlugin
                     break;
 
                 case PLAYER_CHAT:
-                	if (chathandler == null) {
-                		chathandler = new ChatHandler();
-                		NeoForge.EVENT_BUS.register(chathandler);
+                	if (!handleChatRegistered) {
+                		handleChatRegistered = true;
+                		NeoForge.EVENT_BUS.addListener(DynmapPlugin.this::handleChat);
                 	}
                     break;
 
                 case BLOCK_BREAK:
                     /*TODO
                     pm.registerEvents(new Listener() {
-                        @EventHandler(priority=EventPriority.MONITOR)
+                        @EventHandler(priority=EventEventPriority.LOWEST)
                         public void onBlockBreak(BlockBreakEvent evt) {
                             if(evt.isCancelled()) return;
                             Block b = evt.getBlock();
@@ -726,7 +721,7 @@ public class DynmapPlugin
                 case SIGN_CHANGE:
                     /*TODO
                     pm.registerEvents(new Listener() {
-                        @EventHandler(priority=EventPriority.MONITOR)
+                        @EventHandler(priority=EventEventPriority.LOWEST)
                         public void onSignChange(SignChangeEvent evt) {
                             if(evt.isCancelled()) return;
                             Block b = evt.getBlock();
@@ -811,7 +806,7 @@ public class DynmapPlugin
             if (scm == null) return Collections.emptySet();
             UserBanList bl = scm.getBans();
             if (bl == null) return Collections.emptySet();
-            if(bl.isBanned(getProfileByName(player))) {
+            if (isPlayerBanned(player)) {
                 return Collections.emptySet();
             }
             Set<String> rslt = hasOfflinePermissions(player, perms);
@@ -830,7 +825,7 @@ public class DynmapPlugin
             if (scm == null) return false;
             UserBanList bl = scm.getBans();
             if (bl == null) return false;
-            if(bl.isBanned(getProfileByName(player))) {
+            if (isPlayerBanned(player)) {
                 return false;
             }
             return hasOfflinePermission(player, perm);
@@ -921,7 +916,8 @@ public class DynmapPlugin
         }
 
         @SubscribeEvent
-		public void tickEvent(TickEvent.ServerTickEvent event)  {
+		// [1.21.1] ServerTickEvent.Post replaces TickEvent.ServerTickEvent + Phase check
+		public void tickEvent(ServerTickEvent.Post event)  {
             cur_tick_starttime = System.nanoTime();
             long elapsed = cur_tick_starttime - lasttick;
             lasttick = cur_tick_starttime;
@@ -1062,27 +1058,11 @@ public class DynmapPlugin
         public InputStream openResource(String modid, String rname) {
         	if (modid == null) modid = "minecraft";
 
-        	Optional<? extends ModContainer> mc = ModList.get().getModContainerById(modid);
-            Object mod = (mc.isPresent()) ? mc.get().getMod() : null;
-            if (mod != null) {
-                ClassLoader cl = mod.getClass().getClassLoader();
-                if (cl == null) cl = ClassLoader.getSystemClassLoader();
-                InputStream is = cl.getResourceAsStream(rname);
-                if (is != null) {
-                    return is;
-                }
-            }
-            List<ModInfo> mcl = LoadingModList.get().getMods();
-            for (ModInfo mci : mcl) {
-                mc = ModList.get().getModContainerById(mci.getModId());
-                mod = (mc.isPresent()) ? mc.get().getMod() : null;
-                if (mod == null) continue;
-                ClassLoader cl = mod.getClass().getClassLoader();
-                if (cl == null) cl = ClassLoader.getSystemClassLoader();
-                InputStream is = cl.getResourceAsStream(rname);
-                if (is != null) {
-                    return is;
-                }
+        	ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            if (cl == null) cl = ClassLoader.getSystemClassLoader();
+            InputStream is = cl.getResourceAsStream(rname);
+            if (is != null) {
+                return is;
             }
             return null;
         }
@@ -1193,7 +1173,7 @@ public class DynmapPlugin
                 return null;
             }
             Vec3 v = player.position();
-            return toLoc(player.serverLevel(), v.x, v.y, v.z);
+            return toLoc((ServerLevel) player.level(), v.x, v.y, v.z);
         }
         @Override
         public String getWorld()
@@ -1203,9 +1183,9 @@ public class DynmapPlugin
                 return null;
             }
 
-            if (player.serverLevel() != null)
+            if (player.level() != null)
             {
-                return DynmapPlugin.this.getWorld((ServerLevel)player.serverLevel()).getName();
+                return DynmapPlugin.this.getWorld((ServerLevel)player.level()).getName();
             }
 
             return null;
@@ -1552,7 +1532,7 @@ public class DynmapPlugin
         
         /* Register tick handler */
         if(!tickregistered) {
-            NeoForge.EVENT_BUS.register(fserver);
+        	NeoForge.EVENT_BUS.addListener(fserver::tickEvent);
             tickregistered = true;
         }
 
@@ -1727,49 +1707,55 @@ public class DynmapPlugin
             }
         }
         
+        private void touchChunk(ForgeWorld fw, ChunkAccess c, String cause) {
+			int ymax = Integer.MIN_VALUE;
+			int ymin = Integer.MAX_VALUE;
+			LevelChunkSection[] sections = c.getSections();
+			// If no sections, assume all
+			if (sections.length == 0) {
+				ymax = (c.getMaxSection()+1) << 4;
+				ymin = c.getMinSection() << 4;
+			}
+			else {
+				for(int i = 0; i < sections.length; i++) {
+					if((sections[i] != null) && (sections[i].hasOnlyAir() == false)) {
+						int sy = c.getSectionYFromSectionIndex(i) << 4;
+						if (sy < ymin) ymin = sy;
+						if ((sy+16) > ymax) ymax = sy + 16;
+					}
+				}
+			}
+			ChunkPos cp = c.getPos();
+			int x = cp.x << 4;
+			int z = cp.z << 4;
+			// If not empty AND not initial scan
+			if (ymax != Integer.MIN_VALUE) {
+				mapManager.touchVolume(fw.getName(), x, ymin, z, x+15, ymax, z+15, "chunkgenerate");
+			}
+        }
+        
         @SubscribeEvent(priority=EventPriority.LOWEST)
     	public void handleChunkLoad(ChunkEvent.Load event) {
-			if(!onchunkgenerate) return;
-
 			LevelAccessor w = event.getLevel();
-            if(!(w instanceof ServerLevel)) return;
+            if (!(w instanceof ServerLevel)) return;
 			ChunkAccess c = event.getChunk();
-			if ((c != null) && (c.getPersistedStatus() == ChunkStatus.FULL) && (c instanceof LevelChunk)) {
+			if ((c != null) && (c.getPersistedStatus() == ChunkStatus.FULL)) {
 				ForgeWorld fw = getWorld((ServerLevel)w, false);
 				if (fw != null) {
 					addKnownChunk(fw, c.getPos());
 				}
 			}
     	}
-        @SubscribeEvent(priority=EventPriority.LOWEST)
     	public void handleChunkUnload(ChunkEvent.Unload event) {
-			if(!onchunkgenerate) return;
-
 			LevelAccessor w = event.getLevel();
-            if(!(w instanceof ServerLevel)) return;
+            if (!(w instanceof ServerLevel)) return;
 			ChunkAccess c = event.getChunk();
 			if (c != null) {
 				ForgeWorld fw = getWorld((ServerLevel)w, false);
 				ChunkPos cp = c.getPos();
 				if (fw != null) {
 					if (!checkIfKnownChunk(fw, cp)) {
-        				int ymax = Integer.MIN_VALUE;
-        				int ymin = Integer.MAX_VALUE;
-        				LevelChunkSection[] sections = c.getSections();
-        				for(int i = 0; i < sections.length; i++) {
-        					if((sections[i] != null) && (sections[i].hasOnlyAir() == false)) {
-        						int sy = c.getSectionYFromSectionIndex(i);
-        						if (sy < ymin) ymin = sy;
-        						if ((sy+16) > ymax) ymax = sy + 16;
-        					}
-        				}
-        				int x = cp.x << 4;
-        				int z = cp.z << 4;
-        				// If not empty AND not initial scan
-        				if (ymax != Integer.MIN_VALUE) {
-        					//Log.info(String.format("chunkkeyerate(unload)(%s,%d,%d,%d,%d,%d,%s)", fw.getName(), x, ymin, z, x+15, ymax, z+15));
-        					mapManager.touchVolume(fw.getName(), x, ymin, z, x+15, ymax, z+15, "chunkgenerate");
-        				}
+						touchChunk(fw, c, "unload");
 					}
 					removeKnownChunk(fw, cp);
 				}
@@ -1777,45 +1763,47 @@ public class DynmapPlugin
     	}
         @SubscribeEvent(priority=EventPriority.LOWEST)
     	public void handleChunkDataSave(ChunkDataEvent.Save event) {
-			if(!onchunkgenerate) return;
-
 			LevelAccessor w = event.getLevel();
-            if(!(w instanceof ServerLevel)) return;
+            if (!(w instanceof ServerLevel)) return;
 			ChunkAccess c = event.getChunk();
 			if (c != null) {
 				ForgeWorld fw = getWorld((ServerLevel)w, false);
 				ChunkPos cp = c.getPos();
 				if (fw != null) {
-					if (!checkIfKnownChunk(fw, cp)) {
-        				int ymax = Integer.MIN_VALUE;
-        				int ymin = Integer.MAX_VALUE;
-        				LevelChunkSection[] sections = c.getSections();
-        				for(int i = 0; i < sections.length; i++) {
-        					if((sections[i] != null) && (sections[i].hasOnlyAir() == false)) {
-        						int sy = c.getSectionYFromSectionIndex(i);
-        						if (sy < ymin) ymin = sy;
-        						if ((sy+16) > ymax) ymax = sy + 16;
-        					}
-        				}
-        				int x = cp.x << 4;
-        				int z = cp.z << 4;
-        				// If not empty AND not initial scan
-        				if (ymax != Integer.MIN_VALUE) {
-        					//Log.info(String.format("chunkkeyerate(save)(%s,%d,%d,%d,%d,%d,%s)", fw.getName(), x, ymin, z, x+15, ymax, z+15));
-        					mapManager.touchVolume(fw.getName(), x, ymin, z, x+15, ymax, z+15, "chunkgenerate");
-        				}
-        				// If cooked, add to known
-        				if ((c.getPersistedStatus() == ChunkStatus.FULL) && (c instanceof LevelChunk)) {
-        					addKnownChunk(fw, cp);
-        				}
-					}
+					touchChunk(fw, c, "datasave");
+    				// If cooked, add to known
+    				if (c.getPersistedStatus() == ChunkStatus.FULL) {
+    					addKnownChunk(fw, cp);
+    				}
 				}
 			}
     	}
         @SubscribeEvent(priority=EventPriority.LOWEST)
-        public void handleBlockEvent(BlockEvent event) {
+        public void handleBlockToolModificationEvent(BlockEvent.BlockToolModificationEvent event) {
+        	handleBlockEvent(event);
+        }
+        @SubscribeEvent(priority=EventPriority.LOWEST)
+        public void handleBreakEvent(BlockEvent.BreakEvent event) {
+        	handleBlockEvent(event);
+        }
+        @SubscribeEvent(priority=EventPriority.LOWEST)
+        public void handleEntityPlaceEvent(BlockEvent.EntityPlaceEvent event) {
+        	handleBlockEvent(event);
+        }
+        @SubscribeEvent(priority=EventPriority.LOWEST)
+        public void handleFluidPlaceBlockEvent(BlockEvent.FluidPlaceBlockEvent event) {
+        	handleBlockEvent(event);
+        }
+        @SubscribeEvent(priority=EventPriority.LOWEST)
+        public void handleNeighborNotifyEvent(BlockEvent.NeighborNotifyEvent event) {
+        	handleBlockEvent(event);
+        }
+        @SubscribeEvent(priority=EventPriority.LOWEST)
+        public void handlePortalSpawnEvent(BlockEvent.PortalSpawnEvent event) {
+        	handleBlockEvent(event);
+        }
+        private void handleBlockEvent(BlockEvent event) {
         	if(!core_enabled) return;
-        	if(!onblockchange) return;
         	BlockUpdateRec r = new BlockUpdateRec();
         	r.w = event.getLevel();
             if(!(r.w instanceof ServerLevel)) return;  // band-aid to prevent errors in unsupported 'running in client' scenario
@@ -1846,23 +1834,33 @@ public class DynmapPlugin
         	onblockchange = true;
     	if ((worldTracker == null) && (onblockchange || onchunkpopulate || onchunkgenerate)) {
     		worldTracker = new WorldTracker();
-    		NeoForge.EVENT_BUS.register(worldTracker);
+    		NeoForge.EVENT_BUS.addListener(worldTracker::handleWorldLoad);
+    		NeoForge.EVENT_BUS.addListener(worldTracker::handleWorldUnload);
+    		if (onchunkgenerate) {
+    			NeoForge.EVENT_BUS.addListener(worldTracker::handleChunkLoad);
+    			NeoForge.EVENT_BUS.addListener(worldTracker::handleChunkDataSave);
+    		}
+    		if (onblockchange) {
+    			NeoForge.EVENT_BUS.addListener(worldTracker::handleBlockToolModificationEvent);
+    			NeoForge.EVENT_BUS.addListener(worldTracker::handleBreakEvent);
+    			NeoForge.EVENT_BUS.addListener(worldTracker::handleEntityPlaceEvent);
+    			NeoForge.EVENT_BUS.addListener(worldTracker::handleFluidPlaceBlockEvent);
+    			NeoForge.EVENT_BUS.addListener(worldTracker::handleNeighborNotifyEvent);
+    			NeoForge.EVENT_BUS.addListener(worldTracker::handlePortalSpawnEvent);
+    		}
     	}        
     	// Prime the known full chunks
         if (onchunkgenerate && (server.getAllLevels() != null)) { 
             for (ServerLevel world : server.getAllLevels()) {
             	ForgeWorld fw = getWorld(world);
             	if (fw == null) continue;
-            	Long2ObjectLinkedOpenHashMap<ChunkHolder> chunks = world.getChunkSource().chunkMap.visibleChunkMap;
-            	for (Entry<Long, ChunkHolder> k : chunks.long2ObjectEntrySet()) {
-            		long key = k.getKey().longValue();
-            		ChunkHolder ch = k.getValue();
+            	for (ChunkHolder ch : world.getChunkSource().chunkMap.visibleChunkMap.values()) {
             		ChunkAccess c = null;
             		try {
-            			c = ch.getLatestChunk();
+            			c = ch.getLatestChunk();  // [1.21.1] replaces getLastAvailable()
             		} catch (Exception x) { }
             		if (c == null) continue;
-            		ChunkStatus cs = c.getPersistedStatus();
+            		ChunkStatus cs = c.getPersistedStatus();  // [1.21.1] replaces getStatus()
             		ChunkPos pos = ch.getPos();
             		if (cs == ChunkStatus.FULL) {	// Cooked?
     					// Add it as known

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/DynmapPlugin.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/DynmapPlugin.java
@@ -1,0 +1,2038 @@
+package org.dynmap.neoforge_1_21_1;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.regex.Pattern;
+
+import net.minecraft.commands.CommandSource;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.IdMapper;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.Connection;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundSetSubtitleTextPacket;
+import net.minecraft.network.protocol.game.ClientboundSetTitleTextPacket;
+import net.minecraft.network.protocol.game.ClientboundSetTitlesAnimationPacket;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ChunkHolder;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.server.players.GameProfileCache;
+import net.minecraft.server.players.UserBanList;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.entity.Pose;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.LeavesBlock;
+import net.minecraft.world.level.block.LiquidBlock;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.LevelChunkSection;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.ServerChatEvent;
+import net.neoforged.neoforge.event.TickEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent.PlayerChangedDimensionEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent.PlayerLoggedInEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent.PlayerLoggedOutEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent.PlayerRespawnEvent;
+import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.ChunkDataEvent;
+import net.neoforged.neoforge.event.level.ChunkEvent;
+import net.neoforged.neoforge.event.level.LevelEvent;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.loading.LoadingModList;
+import net.neoforged.fml.loading.moddiscovery.ModFileInfo;
+import net.neoforged.fml.loading.moddiscovery.ModInfo;
+import net.minecraft.world.level.chunk.status.ChunkStatus;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.dynmap.ConfigurationNode;
+import org.dynmap.DynmapChunk;
+import org.dynmap.DynmapCommonAPIListener;
+import org.dynmap.DynmapCore;
+import org.dynmap.DynmapLocation;
+import org.dynmap.DynmapWorld;
+import org.dynmap.Log;
+import org.dynmap.MapManager;
+import org.dynmap.PlayerList;
+import org.dynmap.common.BiomeMap;
+import org.dynmap.common.DynmapCommandSender;
+import org.dynmap.common.DynmapPlayer;
+import org.dynmap.common.DynmapServerInterface;
+import org.dynmap.common.DynmapListenerManager.EventType;
+import org.dynmap.common.chunk.GenericChunkCache;
+import org.dynmap.neoforge_1_21_1.DmapCommand;
+import org.dynmap.neoforge_1_21_1.DmarkerCommand;
+import org.dynmap.neoforge_1_21_1.DynmapCommand;
+import org.dynmap.neoforge_1_21_1.permissions.FilePermissions;
+import org.dynmap.neoforge_1_21_1.permissions.OpPermissions;
+import org.dynmap.neoforge_1_21_1.permissions.PermissionProvider;
+import org.dynmap.permissions.PermissionsHandler;
+import org.dynmap.renderer.DynmapBlockState;
+import org.dynmap.utils.DynmapLogger;
+import org.dynmap.utils.MapChunkCache;
+import org.dynmap.utils.VisibilityLimit;
+
+import com.google.common.collect.Iterables;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import net.neoforged.neoforge.eventbus.api.EventPriority;
+import net.neoforged.neoforge.eventbus.api.SubscribeEvent;
+
+import net.minecraft.world.level.EmptyBlockGetter;
+
+public class DynmapPlugin
+{ 
+    private DynmapCore core;
+    private PermissionProvider permissions;
+    private boolean core_enabled;
+    public GenericChunkCache sscache;
+    public PlayerList playerList;
+    private MapManager mapManager;
+    private static net.minecraft.server.MinecraftServer server;
+    public static DynmapPlugin plugin;
+    private ChatHandler chathandler;
+    private HashMap<String, Integer> sortWeights = new HashMap<String, Integer>(); 
+    // Drop world load ticket after 30 seconds
+    private long worldIdleTimeoutNS = 30 * 1000000000L;
+    private HashMap<String, ForgeWorld> worlds = new HashMap<String, ForgeWorld>();
+    private LevelAccessor last_world;
+    private ForgeWorld last_fworld;
+    private Map<String, ForgePlayer> players = new HashMap<String, ForgePlayer>();
+    //TODO private ForgeMetrics metrics;
+    private HashSet<String> modsused = new HashSet<String>();
+    private ForgeServer fserver = new ForgeServer();
+    private boolean tickregistered = false;
+    // TPS calculator
+    private double tps;
+    private long lasttick;
+    private long avgticklen;
+    // Per tick limit, in nsec
+    private long perTickLimit = (50000000); // 50 ms
+    private boolean useSaveFolder = true;
+
+    private static final String[] TRIGGER_DEFAULTS = { "blockupdate", "chunkpopulate", "chunkgenerate" };
+
+    private static final Pattern patternControlCode = Pattern.compile("(?i)\\u00A7[0-9A-FK-OR]");
+
+    public static class BlockUpdateRec {
+    	LevelAccessor w;
+    	String wid;
+    	int x, y, z;
+    }
+    ConcurrentLinkedQueue<BlockUpdateRec> blockupdatequeue = new ConcurrentLinkedQueue<BlockUpdateRec>();
+
+    public static DynmapBlockState[] stateByID;
+
+    private Map<String, LongOpenHashSet> knownloadedchunks = new HashMap<String, LongOpenHashSet>();
+    private boolean didInitialKnownChunks = false;
+    private void addKnownChunk(ForgeWorld fw, ChunkPos pos) {
+    	LongOpenHashSet cset = knownloadedchunks.get(fw.getName());
+    	if (cset == null) {
+    		cset = new LongOpenHashSet();
+    		knownloadedchunks.put(fw.getName(), cset);
+    	}                    	
+    	cset.add(pos.toLong());
+    }
+    private void removeKnownChunk(ForgeWorld fw, ChunkPos pos) {
+    	LongOpenHashSet cset = knownloadedchunks.get(fw.getName());
+    	if (cset != null) {
+        	cset.remove(pos.toLong());     		
+    	}
+    }
+    private boolean checkIfKnownChunk(ForgeWorld fw, ChunkPos pos) {
+    	LongOpenHashSet cset = knownloadedchunks.get(fw.getName());
+    	if (cset != null) {
+    		return cset.contains(pos.toLong());     		
+    	}
+    	return false;
+    }
+
+    private static Registry<Biome> reg = null;
+
+    private static Registry<Biome> getBiomeReg() {
+    	if (reg == null) {
+    		reg = server.registryAccess().registryOrThrow(Registries.BIOME);
+    	}
+    	return reg;
+    }
+
+    /**
+     * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
+     */
+    public void initializeBlockStates() {
+    	stateByID = new DynmapBlockState[512*32];	// Simple map - scale as needed
+    	Arrays.fill(stateByID, DynmapBlockState.AIR); // Default to air
+
+    	IdMapper<BlockState> bsids = Block.BLOCK_STATE_REGISTRY;
+
+        DynmapBlockState basebs = null;
+        Block baseb = null;
+        int baseidx = 0;
+    	
+    	Iterator<BlockState> iter = bsids.iterator();
+    	DynmapBlockState.Builder bld = new DynmapBlockState.Builder();
+		while (iter.hasNext()) {
+			BlockState bs = iter.next();
+			int idx = bsids.getId(bs);
+    		if (idx >= stateByID.length) {
+    			int plen = stateByID.length;
+    			stateByID = Arrays.copyOf(stateByID, idx*11/10); // grow array by 10%
+    			Arrays.fill(stateByID, plen, stateByID.length, DynmapBlockState.AIR);
+    		}
+            Block b = bs.getBlock();
+    		// If this is new block vs last, it's the base block state
+    		if (b != baseb) {
+    			basebs = null;
+                baseidx = idx;
+                baseb = b;
+    		}
+            ResourceLocation ui = BuiltInRegistries.BLOCK.getKey(b);
+
+            if (ui == null) {
+            	continue;
+            }
+            String bn = ui.getNamespace() + ":" + ui.getPath();
+            // Only do defined names, and not "air"
+            if (!bn.equals(DynmapBlockState.AIR_BLOCK)) {
+                String statename = "";
+                for (net.minecraft.world.level.block.state.properties.Property<?> p : bs.getProperties()) {
+                	if (statename.length() > 0) {
+                		statename += ",";
+                	}
+                	statename += p.getName() + "=" + bs.getValue(p).toString();
+                }
+                int lightAtten = 15;
+                try {	// Workaround for mods with broken block state logic...
+                	lightAtten =bs.canOcclude() ? 15 : (bs.isAir() ? 0 : 1);
+                } catch (Exception x) {
+                	Log.warning(String.format("Exception while checking lighting data for block state: %s[%s]", bn, statename));
+                	Log.verboseinfo("Exception: " + x.toString());
+                }
+                //Log.info("statename=" + bn + "[" + statename + "], lightAtten=" + lightAtten);
+                // Fill in base attributes
+                bld.setBaseState(basebs).setStateIndex(idx - baseidx).setBlockName(bn).setStateName(statename).setLegacyBlockID(idx).setAttenuatesLight(lightAtten);
+                if (bs.getSoundType() != null) { bld.setMaterial(bs.getSoundType().toString()); }
+				if (bs.canOcclude()) { bld.setSolid(); }
+				if (bs.isAir()) { bld.setAir(); }
+				if (bs.is(BlockTags.LOGS)) { bld.setLog(); }
+				if (bs.is(BlockTags.LEAVES)) { bld.setLeaves(); }
+				if ((!bs.getFluidState().isEmpty()) && !(bs.getBlock() instanceof LiquidBlock)) {
+					bld.setWaterlogged();
+				}
+                DynmapBlockState dbs = bld.build(); // Build state
+                stateByID[idx] = dbs;
+                if (basebs == null) { basebs = dbs; }
+            }
+    	}
+        for (int gidx = 0; gidx < DynmapBlockState.getGlobalIndexMax(); gidx++) {
+        	DynmapBlockState bs = DynmapBlockState.getStateByGlobalIndex(gidx);
+        	//Log.info(gidx + ":" + bs.toString() + ", gidx=" + bs.globalStateIndex + ", sidx=" + bs.stateIndex);
+        }
+    }
+
+    //public static final Item getItemByID(int id) {
+    //    return Item.getItemById(id);
+    //}
+    
+    private static Biome[] biomelist = null;
+    
+    public static final Biome[] getBiomeList() {
+        if (biomelist == null) {
+        	biomelist = new Biome[256];
+        	Iterator<Biome> iter = getBiomeReg().iterator();
+        	while (iter.hasNext()) {
+                Biome b = iter.next();
+                int bidx = getBiomeReg().getId(b);
+        		if (bidx >= biomelist.length) {
+        			biomelist = Arrays.copyOf(biomelist, bidx + biomelist.length);
+        		}
+        		biomelist[bidx] = b;
+        	}
+        }
+        return biomelist;
+    }
+    //public static final NetworkManager getNetworkManager(ServerPlayNetHandler nh) {
+    //    return nh.netManager;
+    //}
+    
+    private ForgePlayer getOrAddPlayer(ServerPlayer p) {
+        String name = p.getName().getString();
+    	ForgePlayer fp = players.get(name);
+    	if(fp != null) {
+    		fp.player = p;
+    	}
+    	else {
+    		fp = new ForgePlayer(p);
+    		players.put(name, fp);
+    	}
+    	return fp;
+    }
+    
+    private static class TaskRecord implements Comparable<Object>
+    {
+        private long ticktorun;
+        private long id;
+        private FutureTask<?> future;
+        @Override
+        public int compareTo(Object o)
+        {
+            TaskRecord tr = (TaskRecord)o;
+
+            if (this.ticktorun < tr.ticktorun)
+            {
+                return -1;
+            }
+            else if (this.ticktorun > tr.ticktorun)
+            {
+                return 1;
+            }
+            else if (this.id < tr.id)
+            {
+                return -1;
+            }
+            else if (this.id > tr.id)
+            {
+                return 1;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+    }
+
+    private class ChatMessage {
+    	String message;
+    	ServerPlayer sender;
+    }
+    private ConcurrentLinkedQueue<ChatMessage> msgqueue = new ConcurrentLinkedQueue<ChatMessage>();
+    
+    public class ChatHandler {
+		@SubscribeEvent
+		public void handleChat(ServerChatEvent event) {
+		    String msg = event.getMessage().getString();
+            if(!msg.startsWith("/")) {
+                ChatMessage cm = new ChatMessage();
+                cm.message = msg;
+                cm.sender = event.getPlayer();
+                msgqueue.add(cm);
+            }
+		}
+    }
+
+    /** TODO: depends on forge chunk manager
+    private static class WorldBusyRecord {
+        long last_ts;
+        Ticket ticket;
+    }
+    private static HashMap<Integer, WorldBusyRecord> busy_worlds = new HashMap<Integer, WorldBusyRecord>();
+    
+    private void setBusy(World w) {
+        setBusy(w, null);
+    }
+    static void setBusy(World w, Ticket t) {
+        if(w == null) return;
+        if (!DynmapMod.useforcedchunks) return;
+        WorldBusyRecord wbr = busy_worlds.get(w.provider.getDimension());
+        if(wbr == null) {   // Not busy, make ticket and keep spawn loaded
+            Debug.debug("World " + w.getWorldInfo().getWorldName() + "/"+ w.provider.getDimensionType().getName() + " is busy");
+            wbr = new WorldBusyRecord();
+            if(t != null)
+                wbr.ticket = t;
+            else
+                wbr.ticket = ForgeChunkManager.requestTicket(DynmapMod.instance, w, ForgeChunkManager.Type.NORMAL);
+            if(wbr.ticket != null) {
+                BlockPos cc = w.getSpawnPoint();
+                ChunkPos ccip = new ChunkPos(cc.getX() >> 4, cc.getZ() >> 4);
+                ForgeChunkManager.forceChunk(wbr.ticket, ccip);
+                busy_worlds.put(w.provider.getDimension(), wbr);  // Add to busy list
+            }
+        }
+        wbr.last_ts = System.nanoTime();
+    }
+    
+    private void doIdleOutOfWorlds() {
+        if (!DynmapMod.useforcedchunks) return;
+        long ts = System.nanoTime() - worldIdleTimeoutNS;
+        for(Iterator<WorldBusyRecord> itr = busy_worlds.values().iterator(); itr.hasNext();) {
+            WorldBusyRecord wbr = itr.next();
+            if(wbr.last_ts < ts) {
+                World w = wbr.ticket.world;
+                Debug.debug("World " + w.getWorldInfo().getWorldName() + "/" + wbr.ticket.world.provider.getDimensionType().getName() + " is idle");
+                if (wbr.ticket != null)
+                    ForgeChunkManager.releaseTicket(wbr.ticket);    // Release hold on world 
+                itr.remove();
+            }
+        }
+    }
+    */
+    
+    public static class OurLog implements DynmapLogger {
+        Logger log;
+        public static final String DM = "[Dynmap] ";
+        OurLog() {
+            log = LogManager.getLogger("Dynmap");
+        }
+        @Override
+        public void info(String s) {
+            log.info(DM + s);
+        }
+
+        @Override
+        public void severe(Throwable t) {
+            log.fatal(t);
+        }
+
+        @Override
+        public void severe(String s) {
+            log.fatal(DM + s);
+        }
+
+        @Override
+        public void severe(String s, Throwable t) {
+            log.fatal(DM + s, t);
+        }
+
+        @Override
+        public void verboseinfo(String s) {
+            log.info(DM + s);
+        }
+
+        @Override
+        public void warning(String s) {
+            log.warn(DM + s);
+        }
+
+        @Override
+        public void warning(String s, Throwable t) {
+            log.warn(DM + s, t);
+        }
+    }
+    
+    public DynmapPlugin(MinecraftServer srv)
+    {
+        plugin = this;
+        this.server = srv;
+    }
+
+    public boolean isOp(String player) {
+    	String[] ops = server.getPlayerList().getOps().getUserList();
+    	for (String op : ops) {
+    		if (op.equalsIgnoreCase(player)) {
+    			return true;
+    		}
+    	}
+    	return (server.isSingleplayer() && player.equalsIgnoreCase(server.getSingleplayerProfile().getName()));
+    }
+    
+    private boolean hasPerm(ServerPlayer psender, String permission) {  
+        PermissionsHandler ph = PermissionsHandler.getHandler();
+        if ((psender != null) && (ph != null) && ph.hasPermission(psender.getName().getString(), permission)) {
+            return true;
+        }
+        return permissions.has(psender, permission);
+    }
+    
+    private boolean hasPermNode(ServerPlayer psender, String permission) {
+        PermissionsHandler ph = PermissionsHandler.getHandler();
+        if ((psender != null) && (ph != null) && ph.hasPermissionNode(psender.getName().getString(), permission)) {
+            return true;
+        }
+        return permissions.hasPermissionNode(psender, permission);
+    } 
+
+    private Set<String> hasOfflinePermissions(String player, Set<String> perms) {
+        Set<String> rslt = null;
+        PermissionsHandler ph = PermissionsHandler.getHandler();
+        if(ph != null) {
+            rslt = ph.hasOfflinePermissions(player, perms);
+        }
+        Set<String> rslt2 = hasOfflinePermissions(player, perms);
+        if((rslt != null) && (rslt2 != null)) {
+            Set<String> newrslt = new HashSet<String>(rslt);
+            newrslt.addAll(rslt2);
+            rslt = newrslt;
+        }
+        else if(rslt2 != null) {
+            rslt = rslt2;
+        }
+        return rslt;
+    }
+    private boolean hasOfflinePermission(String player, String perm) {
+        PermissionsHandler ph = PermissionsHandler.getHandler();
+        if(ph != null) {
+            if(ph.hasOfflinePermission(player, perm)) {
+                return true;
+            }
+        }
+        return permissions.hasOfflinePermission(player, perm);
+    }
+
+    /**
+     * Server access abstraction class
+     */
+    public class ForgeServer extends DynmapServerInterface
+    {
+        /* Server thread scheduler */
+        private Object schedlock = new Object();
+        private long cur_tick;
+        private long next_id;
+        private long cur_tick_starttime;
+        private PriorityQueue<TaskRecord> runqueue = new PriorityQueue<TaskRecord>();
+
+        public ForgeServer() {
+        }
+
+        private GameProfile getProfileByName(String player) {
+            GameProfileCache cache = server.getProfileCache();
+            Optional<GameProfile> val = cache.get(player);
+            return val.isPresent() ? val.get() : null;
+        }
+        
+        @Override
+        public int getBlockIDAt(String wname, int x, int y, int z) {
+            return -1;
+        }
+		
+        @Override
+        public int isSignAt(String wname, int x, int y, int z) {
+            return -1;
+        }
+
+        @Override
+        public void scheduleServerTask(Runnable run, long delay)
+        {
+            TaskRecord tr = new TaskRecord();
+            tr.future = new FutureTask<Object>(run, null);
+
+            /* Add task record to queue */
+            synchronized (schedlock)
+            {
+                tr.id = next_id++;
+                tr.ticktorun = cur_tick + delay;
+                runqueue.add(tr);
+            }
+        }
+        @Override
+        public DynmapPlayer[] getOnlinePlayers()
+        {
+            if(server.getPlayerList() == null)
+                return new DynmapPlayer[0];
+            List<ServerPlayer> playlist = server.getPlayerList().getPlayers();
+            int pcnt = playlist.size();
+            DynmapPlayer[] dplay = new DynmapPlayer[pcnt];
+
+            for (int i = 0; i < pcnt; i++)
+            {
+                ServerPlayer p = playlist.get(i);
+                dplay[i] = getOrAddPlayer(p);
+            }
+
+            return dplay;
+        }
+        @Override
+        public void reload()
+        {
+            plugin.onDisable();
+            plugin.onEnable();
+            plugin.onStart();
+        }
+        @Override
+        public DynmapPlayer getPlayer(String name)
+        {
+            List<ServerPlayer> players = server.getPlayerList().getPlayers();
+
+            for (ServerPlayer p : players)
+            {
+                if (p.getName().getString().equalsIgnoreCase(name))
+                {
+                    return getOrAddPlayer(p);
+                }
+            }
+
+            return null;
+        }
+        @Override
+        public Set<String> getIPBans()
+        {
+            UserBanList bl = server.getPlayerList().getBans();
+            Set<String> ips = new HashSet<String>();
+
+            for (String s : bl.getUserList()) {
+                ips.add(s);
+            }
+            
+            return ips;
+        }
+        @Override
+        public <T> Future<T> callSyncMethod(Callable<T> task) {
+        	return callSyncMethod(task, 0);
+        }
+        public <T> Future<T> callSyncMethod(Callable<T> task, long delay)
+        {
+            TaskRecord tr = new TaskRecord();
+            FutureTask<T> ft = new FutureTask<T>(task);
+            tr.future = ft;
+
+            /* Add task record to queue */
+            synchronized (schedlock)
+            {
+                tr.id = next_id++;
+                tr.ticktorun = cur_tick + delay;
+                runqueue.add(tr);
+            }
+
+            return ft;
+        }
+        @Override
+        public String getServerName()
+        {
+            String sn;
+            if (server.isSingleplayer())
+                sn = "Integrated";
+            else
+                sn = server.getLocalIp();
+        	if(sn == null) sn = "Unknown Server";
+        	return sn;
+        }
+        @Override
+        public boolean isPlayerBanned(String pid)
+        {
+            UserBanList bl = server.getPlayerList().getBans();
+            return bl.isBanned(getProfileByName(pid));
+        }
+        
+        @Override
+        public String stripChatColor(String s)
+        {
+            return patternControlCode.matcher(s).replaceAll("");
+        }
+        private Set<EventType> registered = new HashSet<EventType>();
+        @Override
+        public boolean requestEventNotification(EventType type)
+        {
+            if (registered.contains(type))
+            {
+                return true;
+            }
+
+            switch (type)
+            {
+                case WORLD_LOAD:
+                case WORLD_UNLOAD:
+                    /* Already called for normal world activation/deactivation */
+                    break;
+
+                case WORLD_SPAWN_CHANGE:
+                    /*TODO
+                    pm.registerEvents(new Listener() {
+                        @EventHandler(priority=EventPriority.MONITOR)
+                        public void onSpawnChange(SpawnChangeEvent evt) {
+                            DynmapWorld w = new BukkitWorld(evt.getWorld());
+                            core.listenerManager.processWorldEvent(EventType.WORLD_SPAWN_CHANGE, w);
+                        }
+                    }, DynmapPlugin.this);
+                    */
+                    break;
+
+                case PLAYER_JOIN:
+                case PLAYER_QUIT:
+                    /* Already handled */
+                    break;
+
+                case PLAYER_BED_LEAVE:
+                    /*TODO
+                    pm.registerEvents(new Listener() {
+                        @EventHandler(priority=EventPriority.MONITOR)
+                        public void onPlayerBedLeave(PlayerBedLeaveEvent evt) {
+                            DynmapPlayer p = new BukkitPlayer(evt.getPlayer());
+                            core.listenerManager.processPlayerEvent(EventType.PLAYER_BED_LEAVE, p);
+                        }
+                    }, DynmapPlugin.this);
+                    */
+                    break;
+
+                case PLAYER_CHAT:
+                	if (chathandler == null) {
+                		chathandler = new ChatHandler();
+                		NeoForge.EVENT_BUS.register(chathandler);
+                	}
+                    break;
+
+                case BLOCK_BREAK:
+                    /*TODO
+                    pm.registerEvents(new Listener() {
+                        @EventHandler(priority=EventPriority.MONITOR)
+                        public void onBlockBreak(BlockBreakEvent evt) {
+                            if(evt.isCancelled()) return;
+                            Block b = evt.getBlock();
+                            if(b == null) return;
+                            Location l = b.getLocation();
+                            core.listenerManager.processBlockEvent(EventType.BLOCK_BREAK, b.getType().getId(),
+                                    BukkitWorld.normalizeWorldName(l.getWorld().getName()), l.getBlockX(), l.getBlockY(), l.getBlockZ());
+                        }
+                    }, DynmapPlugin.this);
+                    */
+                    break;
+
+                case SIGN_CHANGE:
+                    /*TODO
+                    pm.registerEvents(new Listener() {
+                        @EventHandler(priority=EventPriority.MONITOR)
+                        public void onSignChange(SignChangeEvent evt) {
+                            if(evt.isCancelled()) return;
+                            Block b = evt.getBlock();
+                            Location l = b.getLocation();
+                            String[] lines = evt.getLines();
+                            DynmapPlayer dp = null;
+                            Player p = evt.getPlayer();
+                            if(p != null) dp = new BukkitPlayer(p);
+                            core.listenerManager.processSignChangeEvent(EventType.SIGN_CHANGE, b.getType().getId(),
+                                    BukkitWorld.normalizeWorldName(l.getWorld().getName()), l.getBlockX(), l.getBlockY(), l.getBlockZ(), lines, dp);
+                        }
+                    }, DynmapPlugin.this);
+                    */
+                    break;
+
+                default:
+                    Log.severe("Unhandled event type: " + type);
+                    return false;
+            }
+
+            registered.add(type);
+            return true;
+        }
+        @Override
+        public boolean sendWebChatEvent(String source, String name, String msg)
+        {
+            return DynmapCommonAPIListener.fireWebChatEvent(source, name, msg);
+        }
+        @Override
+        public void broadcastMessage(String msg)
+        {
+            Component component = Component.literal(msg);
+            server.getPlayerList().broadcastSystemMessage(component, false);
+            Log.info(stripChatColor(msg));
+        }
+        @Override
+        public String[] getBiomeIDs()
+        {
+            BiomeMap[] b = BiomeMap.values();
+            String[] bname = new String[b.length];
+
+            for (int i = 0; i < bname.length; i++)
+            {
+                bname[i] = b[i].toString();
+            }
+
+            return bname;
+        }
+        @Override
+        public double getCacheHitRate()
+        {
+            if(sscache != null)
+                return sscache.getHitRate();
+            return 0.0;
+        }
+        @Override
+        public void resetCacheStats()
+        {
+            if(sscache != null)
+                sscache.resetStats();
+        }
+        @Override
+        public DynmapWorld getWorldByName(String wname)
+        {
+        	return DynmapPlugin.this.getWorldByName(wname);
+        }
+        @Override
+        public DynmapPlayer getOfflinePlayer(String name)
+        {
+            /*
+            OfflinePlayer op = getServer().getOfflinePlayer(name);
+            if(op != null) {
+                return new BukkitPlayer(op);
+            }
+            */
+            return null;
+        }
+        @Override
+        public Set<String> checkPlayerPermissions(String player, Set<String> perms)
+        {
+            net.minecraft.server.players.PlayerList scm = server.getPlayerList();
+            if (scm == null) return Collections.emptySet();
+            UserBanList bl = scm.getBans();
+            if (bl == null) return Collections.emptySet();
+            if(bl.isBanned(getProfileByName(player))) {
+                return Collections.emptySet();
+            }
+            Set<String> rslt = hasOfflinePermissions(player, perms);
+            if (rslt == null) {
+                rslt = new HashSet<String>();
+                if(plugin.isOp(player)) {
+                    rslt.addAll(perms);
+                }
+            }
+            return rslt;
+        }
+        @Override
+        public boolean checkPlayerPermission(String player, String perm)
+        {
+            net.minecraft.server.players.PlayerList scm = server.getPlayerList();
+            if (scm == null) return false;
+            UserBanList bl = scm.getBans();
+            if (bl == null) return false;
+            if(bl.isBanned(getProfileByName(player))) {
+                return false;
+            }
+            return hasOfflinePermission(player, perm);
+        }
+        /**
+         * Render processor helper - used by code running on render threads to request chunk snapshot cache from server/sync thread
+         */
+        @Override
+        public MapChunkCache createMapChunkCache(DynmapWorld w, List<DynmapChunk> chunks,
+                boolean blockdata, boolean highesty, boolean biome, boolean rawbiome)
+        {
+            ForgeMapChunkCache c = (ForgeMapChunkCache) w.getChunkCache(chunks);
+            if(c == null) {
+            	return null;
+            }
+            if (w.visibility_limits != null)
+            {
+                for (VisibilityLimit limit: w.visibility_limits)
+                {
+                    c.setVisibleRange(limit);
+                }
+
+                c.setHiddenFillStyle(w.hiddenchunkstyle);
+            }
+
+            if (w.hidden_limits != null)
+            {
+                for (VisibilityLimit limit: w.hidden_limits)
+                {
+                    c.setHiddenRange(limit);
+                }
+
+                c.setHiddenFillStyle(w.hiddenchunkstyle);
+            }
+
+            if (chunks.size() == 0)     /* No chunks to get? */
+            {
+                c.loadChunks(0);
+                return c;
+            }
+            
+            //Now handle any chunks in server thread that are already loaded (on server thread)
+            final ForgeMapChunkCache cc = c;
+            Future<Boolean> f = this.callSyncMethod(new Callable<Boolean>() {
+                public Boolean call() throws Exception {
+                    // Update busy state on world
+                    ForgeWorld fw = (ForgeWorld)cc.getWorld();
+                    //TODO
+                    //setBusy(fw.getWorld());
+                    cc.getLoadedChunks();
+                    return true;
+                }
+            }, 0);
+            try {
+                f.get();
+            }
+            catch (CancellationException cx) {
+                return null;
+            }
+            catch (InterruptedException cx) {
+                return null;
+            }
+            catch (ExecutionException xx) {
+                Log.severe("Exception while loading chunks", xx.getCause());
+                return null;
+            }
+            catch (Exception ix) {
+                Log.severe(ix);
+                return null;
+            }
+            if(w.isLoaded() == false) {
+            	return null;
+            }
+            // Now, do rest of chunk reading from calling thread
+            c.readChunks(chunks.size());
+            
+            return c;
+        }
+        @Override
+        public int getMaxPlayers()
+        {
+            return server.getMaxPlayers();
+        }
+        @Override
+        public int getCurrentPlayers()
+        {
+            return server.getPlayerList().getPlayerCount();
+        }
+
+        @SubscribeEvent
+		public void tickEvent(TickEvent.ServerTickEvent event)  {
+            cur_tick_starttime = System.nanoTime();
+            long elapsed = cur_tick_starttime - lasttick;
+            lasttick = cur_tick_starttime;
+            avgticklen = ((avgticklen * 99) / 100) + (elapsed / 100);
+            tps = (double)1E9 / (double)avgticklen;
+            // Tick core
+            if (core != null) {
+                core.serverTick(tps);
+            }
+
+            boolean done = false;
+            TaskRecord tr = null;
+
+            while(!blockupdatequeue.isEmpty()) {
+                BlockUpdateRec r = blockupdatequeue.remove();
+                BlockState bs = r.w.getBlockState(new BlockPos(r.x, r.y, r.z));
+                int idx = Block.BLOCK_STATE_REGISTRY.getId(bs);
+                if((idx >= 0) && (!org.dynmap.hdmap.HDBlockModels.isChangeIgnoredBlock(stateByID[idx]))) {
+                    if(onblockchange_with_id)
+                        mapManager.touch(r.wid, r.x, r.y, r.z, "blockchange[" + idx + "]");
+                    else
+                        mapManager.touch(r.wid, r.x, r.y, r.z, "blockchange");
+                }
+            }
+
+            long now;
+
+            synchronized(schedlock) {
+                cur_tick++;
+                now = System.nanoTime();
+                tr = runqueue.peek();
+                /* Nothing due to run */
+                if((tr == null) || (tr.ticktorun > cur_tick) || ((now - cur_tick_starttime) > perTickLimit)) {
+                    done = true;
+                }
+                else {
+                    tr = runqueue.poll();
+                }
+            }
+            while (!done) {
+                tr.future.run();
+
+                synchronized(schedlock) {
+                    tr = runqueue.peek();
+                    now = System.nanoTime();
+                    /* Nothing due to run */
+                    if((tr == null) || (tr.ticktorun > cur_tick) || ((now - cur_tick_starttime) > perTickLimit)) {
+                        done = true;
+                    }
+                    else {
+                        tr = runqueue.poll();
+                    }
+                }
+            }
+            while(!msgqueue.isEmpty()) {
+                ChatMessage cm = msgqueue.poll();
+                DynmapPlayer dp = null;
+                if(cm.sender != null)
+                    dp = getOrAddPlayer(cm.sender);
+                else
+                    dp = new ForgePlayer(null);
+
+                core.listenerManager.processChatEvent(EventType.PLAYER_CHAT, dp, cm.message);
+            }
+            // Check for generated chunks
+            if((cur_tick % 20) == 0) {
+            }
+		}
+
+		@Override
+		public boolean isModLoaded(String name) {
+			boolean loaded = ModList.get().isLoaded(name);
+			if (loaded) {
+                modsused.add(name);
+			}
+			return loaded;
+		}
+		@Override
+		public String getModVersion(String name) {
+		    Optional<? extends ModContainer> mod = ModList.get().getModContainerById(name);    // Try case sensitive lookup
+		    if (mod.isPresent()) {
+		    	ArtifactVersion vi = mod.get().getModInfo().getVersion();
+		    	return vi.getMajorVersion() + "." + vi.getMinorVersion() + "." + vi.getIncrementalVersion();
+		    }
+		    return null;
+		}
+        @Override
+        public double getServerTPS() {
+            return tps;
+        }
+        
+        @Override
+        public String getServerIP() {
+            if (server.isSingleplayer())
+                return "0.0.0.0";
+            else
+                return server.getLocalIp();
+        }
+        @Override
+        public File getModContainerFile(String name) {
+            ModFileInfo mfi = LoadingModList.get().getModFileById(name);    // Try case sensitive lookup
+            if (mfi != null) {
+                try {
+                    File f = mfi.getFile().getFilePath().toFile();
+                    return f;
+                }
+                catch (UnsupportedOperationException ex) {
+                    //TODO Implement proper jar in jar method for fetching data
+/*
+                    Log.info("Searching for: " + name);
+                    for (IModInfo e: ModList.get().getMods()) {
+                        Log.info("in: " + e.getModId().toString());
+                        Log.info("resource: "+ ModList.get().getModFileById(e.getModId()).getFile().findResource(String.valueOf(mfi.getFile().getFilePath())));
+                    }
+*/
+                    Log.warning("jar in jar method found, skipping: " + ex.getMessage());
+                }
+            }
+            return null;
+        }
+        @Override
+        public List<String> getModList() {
+        	List<ModInfo> mil = LoadingModList.get().getMods();
+        	List<String> lst = new ArrayList<String>();
+        	for (ModInfo mi : mil) {
+        		lst.add(mi.getModId());
+        	}
+        	return lst;
+        }
+
+        @Override
+        public Map<Integer, String> getBlockIDMap() {
+            Map<Integer, String> map = new HashMap<Integer, String>();
+            return map;
+        }
+
+        @Override
+        public InputStream openResource(String modid, String rname) {
+        	if (modid == null) modid = "minecraft";
+
+        	Optional<? extends ModContainer> mc = ModList.get().getModContainerById(modid);
+            Object mod = (mc.isPresent()) ? mc.get().getMod() : null;
+            if (mod != null) {
+                ClassLoader cl = mod.getClass().getClassLoader();
+                if (cl == null) cl = ClassLoader.getSystemClassLoader();
+                InputStream is = cl.getResourceAsStream(rname);
+                if (is != null) {
+                    return is;
+                }
+            }
+            List<ModInfo> mcl = LoadingModList.get().getMods();
+            for (ModInfo mci : mcl) {
+                mc = ModList.get().getModContainerById(mci.getModId());
+                mod = (mc.isPresent()) ? mc.get().getMod() : null;
+                if (mod == null) continue;
+                ClassLoader cl = mod.getClass().getClassLoader();
+                if (cl == null) cl = ClassLoader.getSystemClassLoader();
+                InputStream is = cl.getResourceAsStream(rname);
+                if (is != null) {
+                    return is;
+                }
+            }
+            return null;
+        }
+        /**
+         * Get block unique ID map (module:blockid)
+         */
+        @Override
+        public Map<String, Integer> getBlockUniqueIDMap() {
+            HashMap<String, Integer> map = new HashMap<String, Integer>();
+            return map;
+        }
+        /**
+         * Get item unique ID map (module:itemid)
+         */
+        @Override
+        public Map<String, Integer> getItemUniqueIDMap() {
+            HashMap<String, Integer> map = new HashMap<String, Integer>();
+            return map;
+        }
+
+    }
+    private static final Gson gson = new GsonBuilder().create();
+
+    public class TexturesPayload {
+        public long timestamp;
+        public String profileId;
+        public String profileName;
+        public boolean isPublic;
+        public Map<String, ProfileTexture> textures;
+
+    }
+    public class ProfileTexture {
+        public String url;
+    }
+    
+    /**
+     * Player access abstraction class
+     */
+    public class ForgePlayer extends ForgeCommandSender implements DynmapPlayer
+    {
+        private ServerPlayer player;
+        private final String skinurl;
+        private final UUID uuid;
+
+
+        public ForgePlayer(ServerPlayer p)
+        {
+            player = p;
+            String url = null;
+        	if (player != null) {
+        		uuid = player.getUUID();
+        		GameProfile prof = player.getGameProfile();
+        		if (prof != null) {
+        	        Property textureProperty = Iterables.getFirst(prof.getProperties().get("textures"), null);
+
+        	        if (textureProperty != null) {
+        	        	TexturesPayload result = null;
+        	        	try {
+                            String json = new String(Base64.getDecoder().decode(textureProperty.value()), StandardCharsets.UTF_8);
+        	        		result = gson.fromJson(json, TexturesPayload.class);
+        	        	} catch (JsonParseException e) {
+        	        	}
+        	        	if ((result != null) && (result.textures != null) && (result.textures.containsKey("SKIN"))) {
+        	        		url = result.textures.get("SKIN").url;
+        	        	}
+        			}
+        		}
+        	}
+        	else {
+        		uuid = null;
+        	}
+        	skinurl = url;
+        }
+        @Override
+        public boolean isConnected()
+        {
+            return true;
+        }
+        @Override
+        public String getName()
+        {
+        	if(player != null) {
+        		String n = player.getName().getString();;
+        		return n;
+        	}
+        	else
+        		return "[Server]";
+        }
+        @Override
+        public String getDisplayName()
+        {
+        	if(player != null) {
+        		String n = player.getDisplayName().getString();
+        		return n;
+        	}
+        	else
+        		return "[Server]";
+        }
+        @Override
+        public boolean isOnline()
+        {
+            return true;
+        }
+        @Override
+        public DynmapLocation getLocation()
+        {
+            if (player == null) {
+                return null;
+            }
+            Vec3 v = player.position();
+            return toLoc(player.serverLevel(), v.x, v.y, v.z);
+        }
+        @Override
+        public String getWorld()
+        {
+            if (player == null)
+            {
+                return null;
+            }
+
+            if (player.serverLevel() != null)
+            {
+                return DynmapPlugin.this.getWorld((ServerLevel)player.serverLevel()).getName();
+            }
+
+            return null;
+        }
+        public static final Connection getNetworkManager(ServerGamePacketListenerImpl nh) {
+            return nh.getConnection();
+        }
+
+        @Override
+        public InetSocketAddress getAddress()
+        {
+            if((player != null) && (player instanceof ServerPlayer)) {
+            	ServerGamePacketListenerImpl nsh = ((ServerPlayer)player).connection;
+            	if((nsh != null) && (getNetworkManager(nsh) != null)) {
+            		SocketAddress sa = getNetworkManager(nsh).getRemoteAddress();
+            		if(sa instanceof InetSocketAddress) {
+            			return (InetSocketAddress)sa;
+            		}
+            	}
+            }
+            return null;
+        }
+        @Override
+        public boolean isSneaking()
+        {
+            if (player != null)
+            {
+                return player.getPose() == Pose.CROUCHING;
+            }
+
+            return false;
+        }
+        @Override
+        public double getHealth()
+        {
+            if (player != null)
+            {
+                double h = player.getHealth();
+                if(h > 20) h = 20;
+                return h;  // Scale to 20 range
+            }
+            else
+            {
+                return 0;
+            }
+        }
+        @Override
+        public int getArmorPoints()
+        {
+            if (player != null)
+            {
+                return player.getArmorValue();
+            }
+            else
+            {
+                return 0;
+            }
+        }
+        @Override
+        public DynmapLocation getBedSpawnLocation()
+        {
+            return null;
+        }
+        @Override
+        public long getLastLoginTime()
+        {
+            return 0;
+        }
+        @Override
+        public long getFirstLoginTime()
+        {
+            return 0;
+        }
+        @Override
+        public boolean hasPrivilege(String privid)
+        {
+            if(player != null)
+                return hasPerm(player, privid);
+            return false;
+        }
+        @Override
+        public boolean isOp()
+        {
+        	return DynmapPlugin.this.isOp(player.getName().getString());
+    	}
+        @Override
+        public void sendMessage(String msg)
+        {
+            Component ichatcomponent = Component.literal(msg);
+            player.sendSystemMessage(ichatcomponent);
+        }
+        @Override
+        public boolean isInvisible() {
+        	if(player != null) {
+        		return player.isInvisible();
+        	}
+        	return false;
+        }
+        @Override
+        public boolean isSpectator() {
+            if(player != null) {
+                return player.isSpectator();
+            }
+            return false;
+        }
+        @Override
+        public int getSortWeight() {
+            Integer wt = sortWeights.get(getName());
+            if (wt != null)
+                return wt;
+            return 0;
+        }
+        @Override
+        public void setSortWeight(int wt) {
+            if (wt == 0) {
+                sortWeights.remove(getName());
+            }
+            else {
+                sortWeights.put(getName(), wt);
+            }
+        }
+        @Override
+        public boolean hasPermissionNode(String node) {
+            if(player != null)
+                return hasPermNode(player, node);
+            return false;
+        }
+        @Override
+        public String getSkinURL() {
+        	return skinurl;
+        }
+        @Override
+        public UUID getUUID() {
+        	return uuid;
+        }
+        /**
+         * Send title and subtitle text (called from server thread)
+         */
+        @Override
+        public void sendTitleText(String title, String subtitle, int fadeInTicks, int stayTicks, int fadeOutTicks) {
+        	if (player instanceof ServerPlayer) {
+        		ServerPlayer mp = (ServerPlayer) player;
+        		ClientboundSetTitlesAnimationPacket times = new ClientboundSetTitlesAnimationPacket(fadeInTicks, stayTicks, fadeOutTicks);
+        		mp.connection.send(times);
+                if (title != null) {
+                	ClientboundSetTitleTextPacket titlepkt = new ClientboundSetTitleTextPacket(Component.literal(title));
+            		mp.connection.send(titlepkt);
+                }
+
+                if (subtitle != null) {
+                	ClientboundSetSubtitleTextPacket subtitlepkt = new ClientboundSetSubtitleTextPacket(Component.literal(subtitle));
+            		mp.connection.send(subtitlepkt);
+                }
+        	}
+    	}
+    }
+    /* Handler for generic console command sender */
+    public class ForgeCommandSender implements DynmapCommandSender
+    {
+        private CommandSourceStack sender;
+
+        protected ForgeCommandSender() {
+        	sender = null;
+        }
+
+        public ForgeCommandSender(CommandSourceStack send)
+        {
+            sender = send;
+        }
+
+        @Override
+        public boolean hasPrivilege(String privid)
+        {
+        	return true;
+        }
+
+        @Override
+        public void sendMessage(String msg)
+        {
+        	if(sender != null) {
+                Component ichatcomponent = Component.literal(msg);
+                sender.sendSuccess(() -> ichatcomponent, true);
+        	}
+        }
+
+        @Override
+        public boolean isConnected()
+        {
+            return false;
+        }
+        @Override
+        public boolean isOp()
+        {
+            return true;
+        }
+        @Override
+        public boolean hasPermissionNode(String node) {
+            return true;
+        } 
+    }
+
+    public void loadExtraBiomes(String mcver) {
+    	int cnt = 0;
+        BiomeMap.loadWellKnownByVersion(mcver);
+
+    	Biome[] list = getBiomeList();
+    	
+        for (int i = 0; i < list.length; i++) {
+            Biome bb = list[i];
+            if (bb != null) {
+            	ResourceLocation regid = getBiomeReg().getKey(bb);
+                String id = regid.getPath();
+                String rl = regid.toString();
+                float tmp = bb.getBaseTemperature(), hum = bb.getModifiedClimateSettings().downfall();
+                int watermult = bb.getWaterColor();
+                Log.verboseinfo("biome[" + i + "]: hum=" + hum + ", tmp=" + tmp + ", mult=" + Integer.toHexString(watermult));
+
+                BiomeMap bmap = BiomeMap.NULL;
+                if (rl != null) {	// If resource location, lookup by this
+                	bmap = BiomeMap.byBiomeResourceLocation(rl);
+                }
+                else {
+                	bmap = BiomeMap.byBiomeID(i);
+                }
+                if (bmap.isDefault() || (bmap == BiomeMap.NULL)) {
+                    bmap = new BiomeMap((rl != null) ? BiomeMap.NO_INDEX : i, id, tmp, hum, rl);
+                    Log.verboseinfo("Add custom biome [" + bmap.toString() + "] (" + i + ")");
+                    cnt++;
+                }
+                else {
+                    bmap.setTemperature(tmp);
+                    bmap.setRainfall(hum);
+                }
+                if (watermult != -1) {
+                    bmap.setWaterColorMultiplier(watermult);
+                	Log.verboseinfo("Set watercolormult for " + bmap.toString() + " (" + i + ") to " + Integer.toHexString(watermult));
+                }
+                bmap.setBiomeObject(bb);
+            }
+        }
+        if(cnt > 0)
+        	Log.info("Added " + cnt + " custom biome mappings");
+    }
+
+    private String[] getBiomeNames() {
+        Biome[] list = getBiomeList();
+        String[] lst = new String[list.length];
+        for(int i = 0; i < list.length; i++) {
+            Biome bb = list[i];
+            if (bb != null) {
+                lst[i] = bb.toString();
+            }
+        }
+        return lst;
+    }
+
+    public void onEnable()
+    {
+        /* Get MC version */
+        String mcver = server.getServerVersion();
+        /* Load extra biomes */
+        loadExtraBiomes(mcver);
+        /* Set up player login/quit event handler */
+        registerPlayerLoginListener();
+        
+        /* Initialize permissions handler */
+        permissions = FilePermissions.create();
+        if(permissions == null) {
+            permissions = new OpPermissions(new String[] { "webchat", "marker.icons", "marker.list", "webregister", "stats", "hide.self", "show.self" });
+        }
+        /* Get and initialize data folder */
+        File dataDirectory = new File("dynmap");
+
+        if (dataDirectory.exists() == false)
+        {
+            dataDirectory.mkdirs();
+        }
+
+        /* Instantiate core */
+        if (core == null)
+        {
+            core = new DynmapCore();
+        }
+
+        /* Inject dependencies */
+        core.setPluginJarFile(DynmapMod.jarfile);
+        core.setPluginVersion(DynmapMod.ver);
+        core.setMinecraftVersion(mcver);
+        core.setDataFolder(dataDirectory);
+        core.setServer(fserver);
+        core.setTriggerDefault(TRIGGER_DEFAULTS);
+        core.setBiomeNames(getBiomeNames());
+
+        if(!core.initConfiguration(null))
+        {
+        	return;
+        }
+        // Extract default permission example, if needed
+        File filepermexample = new File(core.getDataFolder(), "permissions.yml.example");
+        core.createDefaultFileFromResource("/permissions.yml.example", filepermexample);
+
+        DynmapCommonAPIListener.apiInitialized(core);
+    }
+    
+    private static int test(CommandSource source) throws CommandSyntaxException
+	{
+    	Log.warning(source.toString());
+		return 1;
+    }
+    
+    private DynmapCommand dynmapCmd;
+    private DmapCommand dmapCmd;
+    private DmarkerCommand dmarkerCmd;
+    private DynmapExpCommand dynmapexpCmd;
+
+    public void onStarting(CommandDispatcher<CommandSourceStack> cd) {
+        /* Register command hander */
+        dynmapCmd = new DynmapCommand(this);
+        dmapCmd = new DmapCommand(this);
+        dmarkerCmd = new DmarkerCommand(this);
+        dynmapexpCmd = new DynmapExpCommand(this);
+        dynmapCmd.register(cd);
+        dmapCmd.register(cd);
+        dmarkerCmd.register(cd);
+        dynmapexpCmd.register(cd);
+
+        Log.info("Register commands");
+    }
+    
+    public void onStart() {
+    	initializeBlockStates();
+        /* Enable core */
+        if (!core.enableCore(null))
+        {
+            return;
+        }
+        core_enabled = true;
+        VersionCheck.runCheck(core);
+        // Get per tick time limit
+        perTickLimit = core.getMaxTickUseMS() * 1000000;
+        // Prep TPS
+        lasttick = System.nanoTime();
+        tps = 20.0;
+        
+        /* Register tick handler */
+        if(!tickregistered) {
+            NeoForge.EVENT_BUS.register(fserver);
+            tickregistered = true;
+        }
+
+        playerList = core.playerList;
+        sscache = new GenericChunkCache(core.getSnapShotCacheSize(), core.useSoftRefInSnapShotCache());
+        /* Get map manager from core */
+        mapManager = core.getMapManager();
+
+        /* Load saved world definitions */
+        loadWorlds();
+        
+        /* Initialized the currently loaded worlds */
+        for (ServerLevel world : server.getAllLevels()) {
+            ForgeWorld w = this.getWorld(world);
+        }
+        for(ForgeWorld w : worlds.values()) {
+            if (core.processWorldLoad(w)) {   /* Have core process load first - fire event listeners if good load after */
+                if(w.isLoaded()) {
+                    core.listenerManager.processWorldEvent(EventType.WORLD_LOAD, w);
+                }
+            }
+        }
+        core.updateConfigHashcode();
+
+        /* Register our update trigger events */
+        registerEvents();
+        Log.info("Register events");
+        
+        //DynmapCommonAPIListener.apiInitialized(core);
+
+        Log.info("Enabled");
+    }
+
+    public void onDisable()
+    {
+        DynmapCommonAPIListener.apiTerminated();
+
+    	//if (metrics != null) {
+    	//	metrics.stop();
+    	//	metrics = null;
+    	//}
+    	/* Save worlds */
+        saveWorlds();
+
+        /* Purge tick queue */
+        fserver.runqueue.clear();
+        
+        /* Disable core */
+        core.disableCore();
+        core_enabled = false;
+
+        if (sscache != null)
+        {
+            sscache.cleanup();
+            sscache = null;
+        }
+        
+        Log.info("Disabled");
+    }
+
+    void onCommand(CommandSourceStack commandSourceStack, String cmd, String[] args)
+    {
+        DynmapCommandSender dsender;
+        ServerPlayer psender;
+        try {
+            psender = commandSourceStack.getPlayerOrException();
+        } catch (com.mojang.brigadier.exceptions.CommandSyntaxException x) {
+            psender = null;
+        }
+
+        if (psender != null)
+        {
+            dsender = new ForgePlayer(psender);
+        }
+        else
+        {
+            dsender = new ForgeCommandSender(commandSourceStack);
+        }
+        try {
+        	core.processCommand(dsender, cmd, cmd, args);
+        } catch (Exception x) {
+            dsender.sendMessage("Command internal error: " + x.getMessage());
+        	Log.severe("Error with command: " + cmd + Arrays.deepToString(args), x);
+        }
+    }
+
+    private DynmapLocation toLoc(ServerLevel level, double x, double y, double z)
+    {
+        return new DynmapLocation(DynmapPlugin.this.getWorld(level).getName(), x, y, z);
+    }
+
+    public class PlayerTracker {
+		@SubscribeEvent
+		public void onPlayerLogin(PlayerLoggedInEvent event) {			
+			if(!core_enabled) return;
+            final DynmapPlayer dp = getOrAddPlayer((ServerPlayer)event.getEntity());
+            /* This event can be called from off server thread, so push processing there */
+            core.getServer().scheduleServerTask(new Runnable() {
+                public void run() {
+                    core.listenerManager.processPlayerEvent(EventType.PLAYER_JOIN, dp);
+                }
+            }, 2);
+		}
+        @SubscribeEvent
+		public void onPlayerLogout(PlayerLoggedOutEvent event) {
+			if(!core_enabled) return;
+            final DynmapPlayer dp = getOrAddPlayer((ServerPlayer)event.getEntity());
+            final String name = event.getEntity().getName().getString();
+            /* This event can be called from off server thread, so push processing there */
+            core.getServer().scheduleServerTask(new Runnable() {
+                public void run() {
+                    core.listenerManager.processPlayerEvent(EventType.PLAYER_QUIT, dp);
+                    players.remove(name);
+                }
+            }, 0);
+		}
+        @SubscribeEvent
+		public void onPlayerChangedDimension(PlayerChangedDimensionEvent event) {
+            if(!core_enabled) return;
+            getOrAddPlayer((ServerPlayer)event.getEntity());	// Freshen player object reference
+		}
+        @SubscribeEvent
+		public void onPlayerRespawn(PlayerRespawnEvent event) {
+            if(!core_enabled) return;
+            getOrAddPlayer((ServerPlayer)event.getEntity());	// Freshen player object reference
+		}
+    }
+    private PlayerTracker playerTracker = null;
+    
+    private void registerPlayerLoginListener()
+    {
+    	if (playerTracker == null) {
+    		playerTracker = new PlayerTracker();
+    		NeoForge.EVENT_BUS.register(playerTracker);
+    	}
+    }
+
+    public class WorldTracker {
+        @SubscribeEvent(priority=EventPriority.LOWEST)
+    	public void handleWorldLoad(LevelEvent.Load event) {
+			if(!core_enabled) return;
+			LevelAccessor w = event.getLevel();
+			if(!(w instanceof ServerLevel)) return;
+            final ForgeWorld fw = getWorld((ServerLevel)w);
+            // This event can be called from off server thread, so push processing there
+            core.getServer().scheduleServerTask(new Runnable() {
+            	public void run() {
+            		if(core.processWorldLoad(fw))    // Have core process load first - fire event listeners if good load after
+            			core.listenerManager.processWorldEvent(EventType.WORLD_LOAD, fw);
+            	}
+            }, 0);
+    	}
+        @SubscribeEvent(priority=EventPriority.LOWEST)
+    	public void handleWorldUnload(LevelEvent.Unload event) {
+			if(!core_enabled) return;
+			LevelAccessor w = event.getLevel();
+            if(!(w instanceof ServerLevel)) return;
+            final ForgeWorld fw = getWorld((ServerLevel)w);
+            if(fw != null) {
+                // This event can be called from off server thread, so push processing there
+                core.getServer().scheduleServerTask(new Runnable() {
+                	public void run() {
+                		core.listenerManager.processWorldEvent(EventType.WORLD_UNLOAD, fw);
+                		core.processWorldUnload(fw);
+                	}
+                }, 0);
+                // Set world unloaded (needs to be immediate, since it may be invalid after event)
+                fw.setWorldUnloaded();
+                // Clean up tracker
+                //WorldUpdateTracker wut = updateTrackers.remove(fw.getName());
+                //if(wut != null) wut.world = null;
+            }
+        }
+        
+        @SubscribeEvent(priority=EventPriority.LOWEST)
+    	public void handleChunkLoad(ChunkEvent.Load event) {
+			if(!onchunkgenerate) return;
+
+			LevelAccessor w = event.getLevel();
+            if(!(w instanceof ServerLevel)) return;
+			ChunkAccess c = event.getChunk();
+			if ((c != null) && (c.getPersistedStatus() == ChunkStatus.FULL) && (c instanceof LevelChunk)) {
+				ForgeWorld fw = getWorld((ServerLevel)w, false);
+				if (fw != null) {
+					addKnownChunk(fw, c.getPos());
+				}
+			}
+    	}
+        @SubscribeEvent(priority=EventPriority.LOWEST)
+    	public void handleChunkUnload(ChunkEvent.Unload event) {
+			if(!onchunkgenerate) return;
+
+			LevelAccessor w = event.getLevel();
+            if(!(w instanceof ServerLevel)) return;
+			ChunkAccess c = event.getChunk();
+			if (c != null) {
+				ForgeWorld fw = getWorld((ServerLevel)w, false);
+				ChunkPos cp = c.getPos();
+				if (fw != null) {
+					if (!checkIfKnownChunk(fw, cp)) {
+        				int ymax = Integer.MIN_VALUE;
+        				int ymin = Integer.MAX_VALUE;
+        				LevelChunkSection[] sections = c.getSections();
+        				for(int i = 0; i < sections.length; i++) {
+        					if((sections[i] != null) && (sections[i].hasOnlyAir() == false)) {
+        						int sy = c.getSectionYFromSectionIndex(i);
+        						if (sy < ymin) ymin = sy;
+        						if ((sy+16) > ymax) ymax = sy + 16;
+        					}
+        				}
+        				int x = cp.x << 4;
+        				int z = cp.z << 4;
+        				// If not empty AND not initial scan
+        				if (ymax != Integer.MIN_VALUE) {
+        					//Log.info(String.format("chunkkeyerate(unload)(%s,%d,%d,%d,%d,%d,%s)", fw.getName(), x, ymin, z, x+15, ymax, z+15));
+        					mapManager.touchVolume(fw.getName(), x, ymin, z, x+15, ymax, z+15, "chunkgenerate");
+        				}
+					}
+					removeKnownChunk(fw, cp);
+				}
+			}
+    	}
+        @SubscribeEvent(priority=EventPriority.LOWEST)
+    	public void handleChunkDataSave(ChunkDataEvent.Save event) {
+			if(!onchunkgenerate) return;
+
+			LevelAccessor w = event.getLevel();
+            if(!(w instanceof ServerLevel)) return;
+			ChunkAccess c = event.getChunk();
+			if (c != null) {
+				ForgeWorld fw = getWorld((ServerLevel)w, false);
+				ChunkPos cp = c.getPos();
+				if (fw != null) {
+					if (!checkIfKnownChunk(fw, cp)) {
+        				int ymax = Integer.MIN_VALUE;
+        				int ymin = Integer.MAX_VALUE;
+        				LevelChunkSection[] sections = c.getSections();
+        				for(int i = 0; i < sections.length; i++) {
+        					if((sections[i] != null) && (sections[i].hasOnlyAir() == false)) {
+        						int sy = c.getSectionYFromSectionIndex(i);
+        						if (sy < ymin) ymin = sy;
+        						if ((sy+16) > ymax) ymax = sy + 16;
+        					}
+        				}
+        				int x = cp.x << 4;
+        				int z = cp.z << 4;
+        				// If not empty AND not initial scan
+        				if (ymax != Integer.MIN_VALUE) {
+        					//Log.info(String.format("chunkkeyerate(save)(%s,%d,%d,%d,%d,%d,%s)", fw.getName(), x, ymin, z, x+15, ymax, z+15));
+        					mapManager.touchVolume(fw.getName(), x, ymin, z, x+15, ymax, z+15, "chunkgenerate");
+        				}
+        				// If cooked, add to known
+        				if ((c.getPersistedStatus() == ChunkStatus.FULL) && (c instanceof LevelChunk)) {
+        					addKnownChunk(fw, cp);
+        				}
+					}
+				}
+			}
+    	}
+        @SubscribeEvent(priority=EventPriority.LOWEST)
+        public void handleBlockEvent(BlockEvent event) {
+        	if(!core_enabled) return;
+        	if(!onblockchange) return;
+        	BlockUpdateRec r = new BlockUpdateRec();
+        	r.w = event.getLevel();
+            if(!(r.w instanceof ServerLevel)) return;  // band-aid to prevent errors in unsupported 'running in client' scenario
+			ForgeWorld fw = getWorld((ServerLevel)r.w, false);
+			if (fw == null) return;
+			r.wid = fw.getName();
+			BlockPos p = event.getPos();
+			r.x = p.getX();
+			r.y = p.getY();
+			r.z = p.getZ();
+			blockupdatequeue.add(r);        	
+        }
+    }
+    private WorldTracker worldTracker = null;
+    private boolean onblockchange = false;
+    private boolean onchunkpopulate = false;
+    private boolean onchunkgenerate = false;
+    private boolean onblockchange_with_id = false;
+    
+    private void registerEvents()
+    {
+        // To trigger rendering.
+        onblockchange = core.isTrigger("blockupdate");
+        onchunkpopulate = core.isTrigger("chunkpopulate");
+        onchunkgenerate = core.isTrigger("chunkgenerate");
+        onblockchange_with_id = core.isTrigger("blockupdate-with-id");
+        if(onblockchange_with_id)
+        	onblockchange = true;
+    	if ((worldTracker == null) && (onblockchange || onchunkpopulate || onchunkgenerate)) {
+    		worldTracker = new WorldTracker();
+    		NeoForge.EVENT_BUS.register(worldTracker);
+    	}        
+    	// Prime the known full chunks
+        if (onchunkgenerate && (server.getAllLevels() != null)) { 
+            for (ServerLevel world : server.getAllLevels()) {
+            	ForgeWorld fw = getWorld(world);
+            	if (fw == null) continue;
+            	Long2ObjectLinkedOpenHashMap<ChunkHolder> chunks = world.getChunkSource().chunkMap.visibleChunkMap;
+            	for (Entry<Long, ChunkHolder> k : chunks.long2ObjectEntrySet()) {
+            		long key = k.getKey().longValue();
+            		ChunkHolder ch = k.getValue();
+            		ChunkAccess c = null;
+            		try {
+            			c = ch.getLatestChunk();
+            		} catch (Exception x) { }
+            		if (c == null) continue;
+            		ChunkStatus cs = c.getPersistedStatus();
+            		ChunkPos pos = ch.getPos();
+            		if (cs == ChunkStatus.FULL) {	// Cooked?
+    					// Add it as known
+        				addKnownChunk(fw, pos);
+            		}
+            	}
+            }
+        }
+    }
+
+    private ForgeWorld getWorldByName(String name) {
+    	return worlds.get(name);
+    }
+    
+    private ForgeWorld getWorld(ServerLevel w) {
+    	return getWorld(w, true);
+    }
+    
+    private ForgeWorld getWorld(ServerLevel w, boolean add_if_not_found) {
+    	if(last_world == w) {
+    		return last_fworld;
+    	}
+    	String wname = ForgeWorld.getWorldName(w);
+    	
+    	for(ForgeWorld fw : worlds.values()) {
+			if(fw.getRawName().equals(wname)) {
+				last_world = w;
+	           	last_fworld = fw;
+           		if(fw.isLoaded() == false) {
+       				fw.setWorldLoaded(w);
+           		}
+           		fw.updateWorld(w);
+    			return fw;
+    		}
+    	}
+    	ForgeWorld fw = null;
+    	if(add_if_not_found) {
+    		/* Add to list if not found */
+    		fw = new ForgeWorld(w);
+    		worlds.put(fw.getName(), fw);
+    	}
+		last_world = w;
+		last_fworld = fw;
+    	return fw;
+    }
+
+    private void saveWorlds() {
+        File f = new File(core.getDataFolder(), "forgeworlds.yml");
+        ConfigurationNode cn = new ConfigurationNode(f);
+        ArrayList<HashMap<String,Object>> lst = new ArrayList<HashMap<String,Object>>();
+        for(DynmapWorld fw : core.mapManager.getWorlds()) {
+            HashMap<String, Object> vals = new HashMap<String, Object>();
+            vals.put("name", fw.getRawName());
+            vals.put("height",  fw.worldheight);
+            vals.put("miny",  fw.minY);
+            vals.put("sealevel", fw.sealevel);
+            vals.put("nether",  fw.isNether());
+            vals.put("the_end",  ((ForgeWorld)fw).isTheEnd());
+            vals.put("title", fw.getTitle());
+            lst.add(vals);
+        }
+        cn.put("worlds", lst);
+        cn.put("useSaveFolderAsName", useSaveFolder);
+        cn.put("maxWorldHeight", ForgeWorld.getMaxWorldHeight());
+
+        cn.save();
+    }
+    private void loadWorlds() {
+        File f = new File(core.getDataFolder(), "forgeworlds.yml");
+        if(f.canRead() == false) {
+            useSaveFolder = true;
+            return;
+        }
+        ConfigurationNode cn = new ConfigurationNode(f);
+        cn.load();
+        // If defined, use maxWorldHeight
+        ForgeWorld.setMaxWorldHeight(cn.getInteger("maxWorldHeight", 256));
+        
+        // If setting defined, use it 
+        if (cn.containsKey("useSaveFolderAsName")) {
+            useSaveFolder = cn.getBoolean("useSaveFolderAsName", useSaveFolder);
+        }
+        List<Map<String,Object>> lst = cn.getMapList("worlds");
+        if(lst == null) {
+            Log.warning("Discarding bad forgeworlds.yml");
+            return;
+        }
+        
+        for(Map<String,Object> world : lst) {
+            try {
+                String name = (String)world.get("name");
+                int height = (Integer)world.get("height");
+                Integer miny = (Integer) world.get("miny");
+                int sealevel = (Integer)world.get("sealevel");
+                boolean nether = (Boolean)world.get("nether");
+                boolean theend = (Boolean)world.get("the_end");
+                String title = (String)world.get("title");
+                if(name != null) {
+                    ForgeWorld fw = new ForgeWorld(name, height, sealevel, nether, theend, title, (miny != null) ? miny : 0);
+                    fw.setWorldUnloaded();
+                    core.processWorldLoad(fw);
+                    worlds.put(fw.getName(), fw);
+                }
+            } catch (Exception x) {
+                Log.warning("Unable to load saved worlds from forgeworlds.yml");
+                return;
+            }
+        }
+    }
+    public void serverStarted() {
+        this.onStart();
+        if (core != null) {
+            core.serverStarted();
+        }
+    }
+    public MinecraftServer getMCServer() {
+        return server;
+    }
+}
+
+class DynmapCommandHandler
+{
+    private String cmd;
+    private DynmapPlugin plugin;
+
+    public DynmapCommandHandler(String cmd, DynmapPlugin p)
+    {
+        this.cmd = cmd;
+        this.plugin = p;
+    }
+
+    public void register(CommandDispatcher<CommandSourceStack> cd) {
+        cd.register(Commands.literal(cmd).
+            then(RequiredArgumentBuilder.<CommandSourceStack, String> argument("args", StringArgumentType.greedyString()).
+            executes((ctx) -> this.execute(plugin.getMCServer(), ctx.getSource(), ctx.getInput()))).
+            executes((ctx) -> this.execute(plugin.getMCServer(), ctx.getSource(), ctx.getInput())));
+    }
+
+//    @Override
+    public int execute(MinecraftServer server, CommandSourceStack commandSourceStack,
+        String cmdline) {
+        String[] args = cmdline.split("\\s+");
+        plugin.onCommand(commandSourceStack, cmd, Arrays.copyOfRange(args, 1, args.length));
+        return 1;
+    }
+
+//    @Override
+    public String getUsage(CommandSource arg0) {
+        return "Run /" + cmd + " help for details on using command";
+    }
+}
+
+class DynmapCommand extends DynmapCommandHandler {
+    DynmapCommand(DynmapPlugin p) {
+        super("dynmap", p);
+    }
+}
+class DmapCommand extends DynmapCommandHandler {
+    DmapCommand(DynmapPlugin p) {
+        super("dmap", p);
+    }
+}
+class DmarkerCommand extends DynmapCommandHandler {
+    DmarkerCommand(DynmapPlugin p) {
+        super("dmarker", p);
+    }
+}
+class DynmapExpCommand extends DynmapCommandHandler {
+    DynmapExpCommand(DynmapPlugin p) {
+        super("dynmapexp", p);
+    }
+}
+

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/ForgeMapChunkCache.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/ForgeMapChunkCache.java
@@ -17,8 +17,8 @@ import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.chunk.storage.ChunkSerializer;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
+import net.minecraft.world.level.chunk.storage.ChunkSerializer;
 
 /**
  * Container for managing chunks - dependent upon using chunk snapshots, since
@@ -39,7 +39,7 @@ public class ForgeMapChunkCache extends GenericMapChunkCache {
 		GenericChunk gc = null;
 		ChunkAccess ch = cps.getChunk(chunk.x, chunk.z, ChunkStatus.FULL, false);
 		if (ch != null) {
-			CompoundTag nbt = ChunkSerializer.write(w, ch);
+            CompoundTag nbt = ChunkSerializer.write(w, ch);
 			if (nbt != null) {
 				gc = parseChunkFromNBT(new NBT.NBTCompound(nbt));
 			}
@@ -75,7 +75,7 @@ public class ForgeMapChunkCache extends GenericMapChunkCache {
 					lev = lev.getCompound("Level");
 				}
 				// Don't load uncooked chunks
-				String stat = lev.getString("Status");
+				String stat = lev.contains("Status") ? lev.getString("Status") : null;
 				ChunkStatus cs = ChunkStatus.byName(stat);
 				if ((stat == null) ||
 				// Needs to be at least lighted
@@ -95,8 +95,8 @@ public class ForgeMapChunkCache extends GenericMapChunkCache {
 	}
 	@Override
 	public int getFoliageColor(BiomeMap bm, int[] colormap, int x, int z) {
-		return bm.<Biome>getBiomeObject().map(Biome::getSpecialEffects)
-				.flatMap(BiomeSpecialEffects::getFoliageColorOverride)
+		return bm.<Biome>getBiomeObject().map(Biome::getSpecialEffects).
+				flatMap(BiomeSpecialEffects::getFoliageColorOverride)
 				.orElse(colormap[bm.biomeLookup()]);
 	}
 

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/ForgeMapChunkCache.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/ForgeMapChunkCache.java
@@ -1,0 +1,109 @@
+package org.dynmap.neoforge_1_21_1;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeSpecialEffects;
+import org.dynmap.DynmapChunk;
+import org.dynmap.Log;
+import org.dynmap.common.BiomeMap;
+import org.dynmap.common.chunk.GenericChunk;
+import org.dynmap.common.chunk.GenericChunkCache;
+import org.dynmap.common.chunk.GenericMapChunkCache;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerChunkCache;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.storage.ChunkSerializer;
+import net.minecraft.world.level.chunk.status.ChunkStatus;
+
+/**
+ * Container for managing chunks - dependent upon using chunk snapshots, since
+ * rendering is off server thread
+ */
+public class ForgeMapChunkCache extends GenericMapChunkCache {
+	private ServerLevel w;
+	private ServerChunkCache cps;
+	/**
+	 * Construct empty cache
+	 */
+	public ForgeMapChunkCache(GenericChunkCache cc) {
+		super(cc);
+	}
+
+	// Load generic chunk from existing and already loaded chunk
+	protected GenericChunk getLoadedChunk(DynmapChunk chunk) {
+		GenericChunk gc = null;
+		ChunkAccess ch = cps.getChunk(chunk.x, chunk.z, ChunkStatus.FULL, false);
+		if (ch != null) {
+			CompoundTag nbt = ChunkSerializer.write(w, ch);
+			if (nbt != null) {
+				gc = parseChunkFromNBT(new NBT.NBTCompound(nbt));
+			}
+		}
+		return gc;
+	}
+	// Load generic chunk from unloaded chunk
+	protected GenericChunk loadChunk(DynmapChunk chunk) {
+		GenericChunk gc = null;
+		CompoundTag nbt = readChunk(chunk.x, chunk.z);
+		// If read was good
+		if (nbt != null) {
+			gc = parseChunkFromNBT(new NBT.NBTCompound(nbt));
+		}
+		return gc;
+	}
+
+	public void setChunks(ForgeWorld dw, List<DynmapChunk> chunks) {
+		this.w = dw.getWorld();
+		if (dw.isLoaded()) {
+			/* Check if world's provider is ServerChunkProvider */
+			cps = this.w.getChunkSource();
+		}
+		super.setChunks(dw, chunks);
+	}
+
+	private CompoundTag readChunk(int x, int z) {
+		try {
+			CompoundTag rslt = cps.chunkMap.read(new ChunkPos(x, z)).join().get();
+			if (rslt != null) {
+				CompoundTag lev = rslt;
+				if (lev.contains("Level")) {
+					lev = lev.getCompound("Level");
+				}
+				// Don't load uncooked chunks
+				String stat = lev.getString("Status");
+				ChunkStatus cs = ChunkStatus.byName(stat);
+				if ((stat == null) ||
+				// Needs to be at least lighted
+						(!cs.isOrAfter(ChunkStatus.LIGHT))) {
+					rslt = null;
+				}
+			}
+			// Log.info(String.format("loadChunk(%d,%d)=%s", x, z, (rslt != null) ?
+			// rslt.toString() : "null"));
+			return rslt;
+		} catch (NoSuchElementException nsex) {
+			return null;
+		} catch (Exception exc) {
+			Log.severe(String.format("Error reading chunk: %s,%d,%d", dw.getName(), x, z), exc);
+			return null;
+		}
+	}
+	@Override
+	public int getFoliageColor(BiomeMap bm, int[] colormap, int x, int z) {
+		return bm.<Biome>getBiomeObject().map(Biome::getSpecialEffects)
+				.flatMap(BiomeSpecialEffects::getFoliageColorOverride)
+				.orElse(colormap[bm.biomeLookup()]);
+	}
+
+	@Override
+	public int getGrassColor(BiomeMap bm, int[] colormap, int x, int z) {
+		BiomeSpecialEffects effects = bm.<Biome>getBiomeObject().map(Biome::getSpecialEffects).orElse(null);
+		if (effects == null) return colormap[bm.biomeLookup()];
+		return effects.getGrassColorModifier().modifyColor(x, z, effects.getGrassColorOverride().orElse(colormap[bm.biomeLookup()]));
+	}
+}

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/ForgeMapChunkCache.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/ForgeMapChunkCache.java
@@ -39,7 +39,7 @@ public class ForgeMapChunkCache extends GenericMapChunkCache {
 		GenericChunk gc = null;
 		ChunkAccess ch = cps.getChunk(chunk.x, chunk.z, ChunkStatus.FULL, false);
 		if (ch != null) {
-            CompoundTag nbt = ChunkSerializer.write(w, ch);
+			CompoundTag nbt = ChunkSerializer.write(w, ch);
 			if (nbt != null) {
 				gc = parseChunkFromNBT(new NBT.NBTCompound(nbt));
 			}
@@ -95,8 +95,8 @@ public class ForgeMapChunkCache extends GenericMapChunkCache {
 	}
 	@Override
 	public int getFoliageColor(BiomeMap bm, int[] colormap, int x, int z) {
-		return bm.<Biome>getBiomeObject().map(Biome::getSpecialEffects).
-				flatMap(BiomeSpecialEffects::getFoliageColorOverride)
+		return bm.<Biome>getBiomeObject().map(Biome::getSpecialEffects)
+				.flatMap(BiomeSpecialEffects::getFoliageColorOverride)
 				.orElse(colormap[bm.biomeLookup()]);
 	}
 

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/ForgeWorld.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/ForgeWorld.java
@@ -1,0 +1,249 @@
+package org.dynmap.neoforge_1_21_1;
+/**
+ * Forge specific implementation of DynmapWorld
+ */
+import java.util.List;
+
+import net.minecraft.world.level.ServerLevelAccessor;
+import net.minecraft.world.level.border.WorldBorder;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LightLayer;
+
+import org.dynmap.DynmapChunk;
+import org.dynmap.DynmapLocation;
+import org.dynmap.DynmapWorld;
+import org.dynmap.utils.MapChunkCache;
+import org.dynmap.utils.Polygon;
+
+public class ForgeWorld extends DynmapWorld
+{
+    private ServerLevelAccessor world;
+    private final boolean skylight;
+    private final boolean isnether;
+    private final boolean istheend;
+    private final String env;
+    private DynmapLocation spawnloc = new DynmapLocation();
+    private static int maxWorldHeight = 320;    // Maximum allows world height
+    
+    public static int getMaxWorldHeight() {
+        return maxWorldHeight;
+    }
+    public static void setMaxWorldHeight(int h) {
+        maxWorldHeight = h;
+    }
+
+    public static String getWorldName(ServerLevelAccessor w) {
+        ResourceKey<Level> rk = w.getLevel().dimension();
+    	String id = rk.location().getNamespace() + "_" + rk.location().getPath();
+    	if (id.equals("minecraft_overworld")) {	// Overworld?
+            return w.getLevel().serverLevelData.getLevelName();
+    	}
+    	else if (id.equals("minecraft_the_end")) {
+    		return "DIM1";
+    	}
+    	else if (id.equals("minecraft_the_nether")) {
+    		return "DIM-1";
+    	}
+    	else {
+    		return id;
+    	}
+    }
+
+    public void updateWorld(ServerLevelAccessor w) {
+    	this.updateWorldHeights(w.getLevel().getHeight(), w.getLevel().dimensionType().minY(), w.getLevel().getSeaLevel());
+    }
+
+    public ForgeWorld(ServerLevelAccessor w)
+    {
+        this(getWorldName(w), 
+        	w.getLevel().getHeight(), 
+    		w.getLevel().getSeaLevel(), 
+    		w.getLevel().dimension() == Level.NETHER,
+    		w.getLevel().dimension() == Level.END,
+			getWorldName(w),
+			w.getLevel().dimensionType().minY());
+        setWorldLoaded(w);
+    }
+    public ForgeWorld(String name, int height, int sealevel, boolean nether, boolean the_end, String deftitle, int miny)
+    {
+        super(name, (height > maxWorldHeight)?maxWorldHeight:height, sealevel, miny);
+        world = null;
+        setTitle(deftitle);
+        isnether = nether;
+        istheend = the_end;
+        skylight = !(isnether || istheend);
+
+        if (isnether)
+        {
+            env = "nether";
+        }
+        else if (istheend)
+        {
+            env = "the_end";
+        }
+        else
+        {
+            env = "normal";
+        }
+        //Log.info(getName() + ": skylight=" + skylight + ", height=" + this.worldheight + ", isnether=" + isnether + ", istheend=" + istheend);
+    }
+    /* Test if world is nether */
+    @Override
+    public boolean isNether()
+    {
+        return isnether;
+    }
+    public boolean isTheEnd()
+    {
+        return istheend;
+    }
+    /* Get world spawn location */
+    @Override
+    public DynmapLocation getSpawnLocation()
+    {
+    	if(world != null) {
+    		BlockPos p = world.getLevel().getSharedSpawnPos();
+    		spawnloc.x = p.getX();
+    		spawnloc.y = p.getY();
+    		spawnloc.z = p.getZ();
+    		spawnloc.world = this.getName();
+    	}
+        return spawnloc;
+    }
+    /* Get world time */
+    @Override
+    public long getTime()
+    {
+    	if(world != null)
+    		return world.getLevel().getDayTime();
+    	else
+    		return -1;
+    }
+    /* World is storming */
+    @Override
+    public boolean hasStorm()
+    {
+    	if(world != null)
+    		return world.getLevel().isRaining();
+    	else
+    		return false;
+    }
+    /* World is thundering */
+    @Override
+    public boolean isThundering()
+    {
+    	if(world != null)
+    		return world.getLevel().isThundering();
+    	else
+    		return false;
+    }
+    /* World is loaded */
+    @Override
+    public boolean isLoaded()
+    {
+        return (world != null);
+    }
+    /* Set world to unloaded */
+    @Override
+    public void setWorldUnloaded() 
+    {
+    	getSpawnLocation();
+    	world = null;
+    }
+    /* Set world to loaded */
+    public void setWorldLoaded(ServerLevelAccessor w) {
+    	world = w;
+    	this.sealevel = w.getLevel().getSeaLevel();   // Read actual current sealevel from world
+    	// Update lighting table
+    	for (int i = 0; i < 16; i++) {
+            // Algorithm based on LightmapTextureManager.getBrightness()
+            // We can't call that method because it's client-only.
+            // This means the code below can stop being correct if Mojang ever
+            // updates the curve; in that case we should reflect the changes.
+            float value = (float) i / 15.0f;
+            float brightness = value / (4.0f - 3.0f * value);
+            this.setBrightnessTableEntry(i, brightness);
+    	    //Log.info(getName() + ": light " + i + " = " + light);
+    	}
+    }
+    /* Get light level of block */
+    @Override
+    public int getLightLevel(int x, int y, int z)
+    {
+    	if(world != null)
+    		return world.getLevel().getLightEngine().getRawBrightness(new BlockPos(x,  y,  z), 0);
+    	else
+    		return -1;
+    }
+    /* Get highest Y coord of given location */
+    @Override
+    public int getHighestBlockYAt(int x, int z)
+    {
+    	if(world != null) {
+            return world.getLevel().getChunk(x >> 4, z >> 4).getHeight(Heightmap.Types.MOTION_BLOCKING, x & 15, z & 15);
+    	}
+    	else
+    		return -1;
+    }
+    /* Test if sky light level is requestable */
+    @Override
+    public boolean canGetSkyLightLevel()
+    {
+        return skylight;
+    }
+    /* Return sky light level */
+    @Override
+    public int getSkyLightLevel(int x, int y, int z)
+    {
+    	if(world != null) {
+    		return world.getLevel().getBrightness(LightLayer.SKY, new BlockPos(x, y, z));
+    	}
+    	else
+    		return -1;
+    }
+    /**
+     * Get world environment ID (lower case - normal, the_end, nether)
+     */
+    @Override
+    public String getEnvironment()
+    {
+        return env;
+    }
+    /**
+     * Get map chunk cache for world
+     */
+    @Override
+    public MapChunkCache getChunkCache(List<DynmapChunk> chunks)
+    {
+    	if (world != null) {
+    		ForgeMapChunkCache c = new ForgeMapChunkCache(DynmapPlugin.plugin.sscache);
+    		c.setChunks(this, chunks);
+    		return c;
+    	}
+    	return null;
+    }
+
+    public ServerLevel getWorld()
+    {
+        return world.getLevel();
+    }
+    @Override
+    public Polygon getWorldBorder() {
+        if (world != null) {
+            WorldBorder wb = world.getWorldBorder();
+            if ((wb != null) && (wb.getSize() < 5.9E7)) {
+                Polygon p = new Polygon();
+                p.addVertex(wb.getMinX(), wb.getMinZ());
+                p.addVertex(wb.getMinX(), wb.getMaxZ());
+                p.addVertex(wb.getMaxX(), wb.getMaxZ());
+                p.addVertex(wb.getMaxX(), wb.getMinZ());
+                return p;
+            }
+        }
+        return null;
+    }
+}

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/NBT.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/NBT.java
@@ -1,0 +1,139 @@
+package org.dynmap.neoforge_1_21_1;
+
+import org.dynmap.common.chunk.GenericBitStorage;
+import org.dynmap.common.chunk.GenericNBTCompound;
+import org.dynmap.common.chunk.GenericNBTList;
+
+import java.util.Set;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.util.SimpleBitStorage;
+
+public class NBT {
+
+	public static class NBTCompound implements GenericNBTCompound {
+		private final CompoundTag obj;
+		public NBTCompound(CompoundTag t) {
+			this.obj = t;
+		}
+		@Override
+		public Set<String> getAllKeys() {
+			return obj.keySet();
+		}
+		@Override
+		public boolean contains(String s) {
+			return obj.contains(s);
+		}
+		@Override
+		public boolean contains(String s, int i) {
+			// API changed in 1.21.1 - contains(String, int) behavior changed, reimplemented manually
+			Tag base = obj.get(s);
+			if (base == null)
+				return false;
+			byte type = base.getId();
+			if (type == (byte) i)
+				return true;
+			else if (i != TAG_ANY_NUMERIC)
+				return false;
+			return type == TAG_BYTE || type == TAG_SHORT || type == TAG_INT || type == TAG_LONG || type == TAG_FLOAT
+				|| type == TAG_DOUBLE;
+		}
+		@Override
+		public byte getByte(String s) {
+			return obj.getByteOr(s, (byte)0);
+		}
+		@Override
+		public short getShort(String s) {
+			return obj.getShortOr(s, (short)0);
+		}
+		@Override
+		public int getInt(String s) {
+			return obj.getIntOr(s, (int)0);
+		}
+		@Override
+		public long getLong(String s) {
+			return obj.getLongOr(s, (long)0);
+		}
+		@Override
+		public float getFloat(String s) {
+			return obj.getFloatOr(s, (float)0);
+		}
+		@Override
+		public double getDouble(String s) {
+			return obj.getDoubleOr(s, (double)0);
+		}
+		@Override
+		public String getString(String s) {
+			return obj.getStringOr(s, "");
+		}
+		@Override
+		public byte[] getByteArray(String s) {
+			return obj.getByteArray(s).orElseGet(() -> new byte[0]);
+		}
+		@Override
+		public int[] getIntArray(String s) {
+			return obj.getIntArray(s).orElseGet(() -> new int[0]);
+		}
+		@Override
+		public long[] getLongArray(String s) {
+			return obj.getLongArray(s).orElseGet(() -> new long[0]);
+		}
+		@Override
+		public GenericNBTCompound getCompound(String s) {
+			return new NBTCompound(obj.getCompoundOrEmpty(s));
+		}
+		@Override
+		public GenericNBTList getList(String s, int i) {
+			return new NBTList(obj.getListOrEmpty(s));
+		}
+		@Override
+		public boolean getBoolean(String s) {
+			return obj.getBooleanOr(s, false);
+		}
+		@Override
+		public String getAsString(String s) {
+			Tag tag = obj.get(s);
+			if (tag == null) return "";
+			return tag.asString().orElse("");
+		}
+		@Override
+		public GenericBitStorage makeBitStorage(int bits, int count, long[] data) {
+			return new OurBitStorage(bits, count, data);
+		}		
+		public String toString() {
+			return obj.toString();
+		}
+	}
+	public static class NBTList implements GenericNBTList {
+		private final ListTag obj;
+		public NBTList(ListTag t) {
+			obj = t;
+		}
+		@Override
+		public int size() {
+			return obj.size();
+		}
+		@Override
+		public String getString(int idx) {
+			return obj.getStringOr(idx, "");
+		}
+		@Override
+		public GenericNBTCompound getCompound(int idx) {
+			return new NBTCompound(obj.getCompoundOrEmpty(idx));
+		}
+		public String toString() {
+			return obj.toString();
+		}
+	}
+	public static class OurBitStorage implements GenericBitStorage {
+		private final SimpleBitStorage bs;
+		public OurBitStorage(int bits, int count, long[] data) {
+			bs = new SimpleBitStorage(bits, count, data);
+		}
+		@Override
+		public int get(int idx) {
+			return bs.get(idx);
+		}
+	}
+}

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/NBT.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/NBT.java
@@ -19,7 +19,7 @@ public class NBT {
 		}
 		@Override
 		public Set<String> getAllKeys() {
-			return obj.keySet();
+			return obj.getAllKeys();
 		}
 		@Override
 		public boolean contains(String s) {
@@ -27,7 +27,7 @@ public class NBT {
 		}
 		@Override
 		public boolean contains(String s, int i) {
-			// API changed in 1.21.1 - contains(String, int) behavior changed, reimplemented manually
+			// [1.21.1] Reimplemented type checking - 1.21 changed contains(s,i) behavior
 			Tag base = obj.get(s);
 			if (base == null)
 				return false;
@@ -41,61 +41,61 @@ public class NBT {
 		}
 		@Override
 		public byte getByte(String s) {
-			return obj.getByteOr(s, (byte)0);
+			return obj.getByte(s);
 		}
 		@Override
 		public short getShort(String s) {
-			return obj.getShortOr(s, (short)0);
+			return obj.getShort(s);
 		}
 		@Override
 		public int getInt(String s) {
-			return obj.getIntOr(s, (int)0);
+			return obj.getInt(s);
 		}
 		@Override
 		public long getLong(String s) {
-			return obj.getLongOr(s, (long)0);
+			return obj.getLong(s);
 		}
 		@Override
 		public float getFloat(String s) {
-			return obj.getFloatOr(s, (float)0);
+			return obj.getFloat(s);
 		}
 		@Override
 		public double getDouble(String s) {
-			return obj.getDoubleOr(s, (double)0);
+			return obj.getDouble(s);
 		}
 		@Override
 		public String getString(String s) {
-			return obj.getStringOr(s, "");
+			return obj.getString(s);
 		}
 		@Override
 		public byte[] getByteArray(String s) {
-			return obj.getByteArray(s).orElseGet(() -> new byte[0]);
+			return obj.getByteArray(s);
 		}
 		@Override
 		public int[] getIntArray(String s) {
-			return obj.getIntArray(s).orElseGet(() -> new int[0]);
+			return obj.getIntArray(s);
 		}
 		@Override
 		public long[] getLongArray(String s) {
-			return obj.getLongArray(s).orElseGet(() -> new long[0]);
+			return obj.getLongArray(s);
 		}
 		@Override
 		public GenericNBTCompound getCompound(String s) {
-			return new NBTCompound(obj.getCompoundOrEmpty(s));
+			return new NBTCompound(obj.getCompound(s));
 		}
 		@Override
 		public GenericNBTList getList(String s, int i) {
-			return new NBTList(obj.getListOrEmpty(s));
+			return new NBTList(obj.getList(s, i));
 		}
 		@Override
 		public boolean getBoolean(String s) {
-			return obj.getBooleanOr(s, false);
+			return obj.getBoolean(s);
 		}
 		@Override
 		public String getAsString(String s) {
-			Tag tag = obj.get(s);
-			if (tag == null) return "";
-			return tag.asString().orElse("");
+			// [1.21.1] Added null safety - getAsString behavior changed
+			Tag t = obj.get(s);
+			return t != null ? t.getAsString() : "";
 		}
 		@Override
 		public GenericBitStorage makeBitStorage(int bits, int count, long[] data) {
@@ -116,11 +116,11 @@ public class NBT {
 		}
 		@Override
 		public String getString(int idx) {
-			return obj.getStringOr(idx, "");
+			return obj.getString(idx);
 		}
 		@Override
 		public GenericNBTCompound getCompound(int idx) {
-			return new NBTCompound(obj.getCompoundOrEmpty(idx));
+			return new NBTCompound(obj.getCompound(idx));
 		}
 		public String toString() {
 			return obj.toString();

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/Proxy.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/Proxy.java
@@ -1,0 +1,24 @@
+package org.dynmap.neoforge_1_21_1;
+
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * Server side proxy - methods for creating and cleaning up plugin
+ */
+public class Proxy
+{
+    public Proxy()
+    {
+    }
+	public DynmapPlugin startServer(MinecraftServer srv) {
+	    DynmapPlugin plugin = DynmapPlugin.plugin; 
+	    if (plugin == null) {
+	        plugin = new DynmapPlugin(srv);
+	        plugin.onEnable();
+	    }
+		return plugin;
+	}
+	public void stopServer(DynmapPlugin plugin) {
+		plugin.onDisable();
+	}
+}

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/VersionCheck.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/VersionCheck.java
@@ -1,0 +1,97 @@
+package org.dynmap.neoforge_1_21_1;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.dynmap.DynmapCore;
+import org.dynmap.Log;
+
+public class VersionCheck {
+    private static final String VERSION_URL = "http://mikeprimm.com/dynmap/releases.php";
+    public static void runCheck(final DynmapCore core) {
+        new Thread(new Runnable() {
+            public void run() {
+                doCheck(core);
+            }
+        }).start();
+    }
+    
+    private static int getReleaseVersion(String s) {
+        int index = s.lastIndexOf('-');
+        if(index < 0)
+            index = s.lastIndexOf('.');
+        if(index >= 0)
+            s = s.substring(0, index);
+        String[] split = s.split("\\.");
+        int v = 0;
+        try {
+            for(int i = 0; (i < split.length) && (i < 3); i++) {
+                v += Integer.parseInt(split[i]) << (8 * (2 - i)); 
+            }
+        } catch (NumberFormatException nfx) {}
+        return v;
+    }
+    
+    private static int getBuildNumber(String s) {
+        int index = s.lastIndexOf('-');
+        if(index < 0)
+            index = s.lastIndexOf('.');
+        if(index >= 0)
+            s = s.substring(index+1);
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException nfx) {
+            return 99999999;
+        }
+    }
+    
+    private static void doCheck(DynmapCore core) {
+        String pluginver = core.getDynmapPluginVersion();
+        String platform = core.getDynmapPluginPlatform();
+        String platver = core.getDynmapPluginPlatformVersion();
+        if((pluginver == null) || (platform == null) || (platver == null))
+            return;
+        HttpURLConnection conn = null;
+        String loc = VERSION_URL;
+        int cur_ver = getReleaseVersion(pluginver);
+        int cur_bn = getBuildNumber(pluginver);
+        try {
+            while((loc != null) && (!loc.isEmpty())) {
+                URL url = new URL(loc);
+                conn = (HttpURLConnection) url.openConnection();
+                conn.setRequestProperty("User-Agent", "Dynmap (" + platform + "/" + platver + "/" + pluginver);
+                conn.connect();
+                loc = conn.getHeaderField("Location");
+            }
+            BufferedReader rdr = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String line = null;
+            while((line = rdr.readLine()) != null) {
+                String[] split = line.split(":");
+                if(split.length < 4) continue;
+                /* If our platform and version, or wildcard platform version */
+                if(split[0].equals(platform) && (split[1].equals("*") || split[1].equals(platver))) {
+                    int recommended_ver = getReleaseVersion(split[2]);
+                    int recommended_bn = getBuildNumber(split[2]);
+                    if((recommended_ver > cur_ver) || ((recommended_ver == cur_ver) && (recommended_bn > cur_bn)))  { /* Newer recommended build */
+                        Log.info("Version obsolete: new recommended version " + split[2] + " is available.");
+                    }
+                    else if(cur_ver > recommended_ver) {    /* Running dev or prerelease? */
+                        int prerel_ver = getReleaseVersion(split[3]);
+                        int prerel_bn = getBuildNumber(split[3]);
+                        if((prerel_ver > cur_ver) || ((prerel_ver == cur_ver) && (prerel_bn > cur_bn))) {
+                            Log.info("Version obsolete: new prerelease version " + split[3] + " is available.");
+                        }
+                    }
+                }
+            }
+        } catch (Exception x) {
+            Log.info("Error checking for latest version");
+        } finally {
+            if(conn != null) {
+                conn.disconnect();
+            }
+        }
+    }
+}

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/permissions/FilePermissions.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/permissions/FilePermissions.java
@@ -1,0 +1,103 @@
+package org.dynmap.neoforge_1_21_1.permissions;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.dynmap.ConfigurationNode;
+import org.dynmap.Log;
+import org.dynmap.neoforge_1_21_1.DynmapPlugin;
+
+import net.minecraft.server.level.ServerPlayer;
+
+public class FilePermissions implements PermissionProvider {
+    private HashMap<String, Set<String>> perms;
+    private Set<String> defperms;
+    
+    public static FilePermissions create() {
+        File f = new File("dynmap/permissions.yml");
+        if(!f.exists())
+            return null;
+        ConfigurationNode cfg = new ConfigurationNode(f);
+        cfg.load();
+        
+        Log.info("Using permissions.yml for access control");
+        
+        return new FilePermissions(cfg);
+    }
+    
+    private FilePermissions(ConfigurationNode cfg) {
+        perms = new HashMap<String,Set<String>>();
+        for(String k : cfg.keySet()) {
+            List<String> p = cfg.getStrings(k, null);
+            if(p != null) {
+                k = k.toLowerCase();
+                HashSet<String> pset = new HashSet<String>();
+                for(String perm : p) {
+                    pset.add(perm.toLowerCase());
+                }
+                perms.put(k,  pset);
+                if(k.equals("defaultuser")) {
+                    defperms = pset;
+                }
+            }
+        }
+    }
+
+    private boolean hasPerm(String player, String perm) {
+        Set<String> ps = perms.get(player);
+        if((ps != null) && (ps.contains(perm))) {
+            return true;
+        }
+        if(defperms.contains(perm)) {
+            return true;
+        }
+        return false;
+    }
+    @Override
+    public Set<String> hasOfflinePermissions(String player, Set<String> perms) {
+        player = player.toLowerCase();
+        HashSet<String> rslt = new HashSet<String>();
+        if(DynmapPlugin.plugin.isOp(player)) {
+            rslt.addAll(perms);
+        }
+        else {
+            for(String p : perms) {
+                if(hasPerm(player, p)) {
+                    rslt.add(p);
+                }
+            }
+        }
+        return rslt;
+    }
+    @Override
+    public boolean hasOfflinePermission(String player, String perm) {
+        player = player.toLowerCase();
+        if(DynmapPlugin.plugin.isOp(player)) {
+            return true;
+        }
+        else {
+            return hasPerm(player, perm);
+        }
+    }
+
+    @Override
+    public boolean has(ServerPlayer psender, String permission) {
+        if(psender != null) {
+        	String n = psender.getName().getString().toLowerCase();
+            return hasPerm(n, permission);
+        }
+        return true;
+    }
+    @Override
+    public boolean hasPermissionNode(ServerPlayer psender, String permission) {
+        if(psender != null) {
+            String player = psender.getName().getString().toLowerCase();
+            return DynmapPlugin.plugin.isOp(player);
+        }
+        return false;
+    } 
+
+}

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/permissions/OpPermissions.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/permissions/OpPermissions.java
@@ -1,0 +1,51 @@
+package org.dynmap.neoforge_1_21_1.permissions;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.dynmap.Log;
+import org.dynmap.neoforge_1_21_1.DynmapPlugin;
+
+import net.minecraft.server.level.ServerPlayer;
+
+public class OpPermissions implements PermissionProvider {
+    public HashSet<String> usrCommands = new HashSet<String>();
+
+    public OpPermissions(String[] usrCommands) {
+        for (String usrCommand : usrCommands) {
+            this.usrCommands.add(usrCommand);
+        }
+        Log.info("Using ops.txt for access control");
+    }
+
+    @Override
+    public Set<String> hasOfflinePermissions(String player, Set<String> perms) {
+        HashSet<String> rslt = new HashSet<String>();
+        if(DynmapPlugin.plugin.isOp(player)) {
+            rslt.addAll(perms);
+        }
+        return rslt;
+    }
+    @Override
+    public boolean hasOfflinePermission(String player, String perm) {
+        return DynmapPlugin.plugin.isOp(player);
+    }
+
+    @Override
+    public boolean has(ServerPlayer psender, String permission) {
+        if(psender != null) {
+            if(usrCommands.contains(permission)) {
+                return true;
+            }
+            return DynmapPlugin.plugin.isOp(psender.getName().getString());
+        }
+        return true;
+    }
+    @Override
+    public boolean hasPermissionNode(ServerPlayer psender, String permission) {
+        if(psender != null) {
+            return DynmapPlugin.plugin.isOp(psender.getName().getString());
+        }
+        return true;
+    } 
+}

--- a/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/permissions/PermissionProvider.java
+++ b/neoforge-1.21.1/src/main/java/org/dynmap/neoforge_1_21_1/permissions/PermissionProvider.java
@@ -1,0 +1,15 @@
+package org.dynmap.neoforge_1_21_1.permissions;
+
+import java.util.Set;
+
+import net.minecraft.server.level.ServerPlayer;
+
+public interface PermissionProvider {
+    boolean has(ServerPlayer sender, String permission);
+    boolean hasPermissionNode(ServerPlayer sender, String permission); 
+    
+    Set<String> hasOfflinePermissions(String player, Set<String> perms);
+
+    boolean hasOfflinePermission(String player, String perm);
+
+}

--- a/neoforge-1.21.1/src/main/resources/META-INF/accesstransformer.cfg
+++ b/neoforge-1.21.1/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,4 @@
+public net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48006_ # waterColor
+public net.minecraft.server.level.ServerLevel f_8549_ # serverLevelData
+public net.minecraft.server.level.ChunkMap f_140130_ # visibleChunkMap
+public net.minecraft.server.level.ChunkMap m_214963_(Lnet/minecraft/world/level/ChunkPos;)Ljava/util/concurrent/CompletableFuture; # readChunk(

--- a/neoforge-1.21.1/src/main/resources/META-INF/accesstransformer.cfg
+++ b/neoforge-1.21.1/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,4 +1,6 @@
-public net.minecraft.world.level.biome.BiomeSpecialEffects$Builder f_48006_ # waterColor
-public net.minecraft.server.level.ServerLevel f_8549_ # serverLevelData
-public net.minecraft.server.level.ChunkMap f_140130_ # visibleChunkMap
-public net.minecraft.server.level.ChunkMap m_214963_(Lnet/minecraft/world/level/ChunkPos;)Ljava/util/concurrent/CompletableFuture; # readChunk(
+# Dynmap NeoForge 1.21.1 Access Transformers
+# Using official MCP/Mojang mappings (NeoForge default)
+public net.minecraft.world.level.biome.BiomeSpecialEffects$Builder waterColor # waterColor field
+public net.minecraft.server.level.ServerLevel serverLevelData # serverLevelData field  
+public net.minecraft.server.level.ChunkMap visibleChunkMap # visibleChunkMap field
+public net.minecraft.server.level.ChunkMap read(Lnet/minecraft/world/level/ChunkPos;)Ljava/util/concurrent/CompletableFuture; # read method

--- a/neoforge-1.21.1/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge-1.21.1/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,0 +1,27 @@
+modLoader="javafml"
+loaderVersion="[4,)"
+issueTrackerURL="https://github.com/webbukkit/dynmap/issues"
+license="Apache Public License v2"
+[[mods]]
+modId="dynmap"
+version="${version}"
+displayName="Dynmap"
+authors="mikeprimm"
+description='''
+Dynamic, Google-maps style rendered maps for your Minecraft server
+'''
+[[accessTransformers]]
+file="META-INF/accesstransformer.cfg"
+[[dependencies.dynmap]]
+    modId="neoforge"
+    mandatory=true
+    versionRange="[21.1,)"
+    ordering="NONE"
+    # Side this dependency is applied on - BOTH, CLIENT or SERVER
+    side="SERVER"
+[[dependencies.dynmap]]
+    modId="minecraft"
+    mandatory=true
+    versionRange="[1.21.1,1.22)"
+    ordering="NONE"
+    side="SERVER"

--- a/neoforge-1.21.1/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge-1.21.1/src/main/resources/META-INF/neoforge.mods.toml
@@ -17,7 +17,6 @@ file="META-INF/accesstransformer.cfg"
     mandatory=true
     versionRange="[21.1,)"
     ordering="NONE"
-    # Side this dependency is applied on - BOTH, CLIENT or SERVER
     side="SERVER"
 [[dependencies.dynmap]]
     modId="minecraft"

--- a/neoforge-1.21.1/src/main/resources/configuration.txt
+++ b/neoforge-1.21.1/src/main/resources/configuration.txt
@@ -1,0 +1,504 @@
+# All paths in this configuration file are relative to Dynmap's data-folder: minecraft_server/dynmap/
+
+# All map templates are defined in the templates directory
+# To use the HDMap very-low-res (2 ppb) map templates as world defaults, set value to vlowres
+#   The definitions of these templates are in normal-vlowres.txt, nether-vlowres.txt, and the_end-vlowres.txt
+# To use the HDMap low-res (4 ppb) map templates as world defaults, set value to lowres
+#   The definitions of these templates are in normal-lowres.txt, nether-lowres.txt, and the_end-lowres.txt
+# To use the HDMap hi-res (16 ppb) map templates (these can take a VERY long time for initial fullrender), set value to hires
+#   The definitions of these templates are in normal-hires.txt, nether-hires.txt, and the_end-hires.txt
+# To use the HDMap low-res (4 ppb) map templates, with support for boosting resolution selectively to hi-res (16 ppb), set value to low_boost_hi
+#   The definitions of these templates are in normal-low_boost_hi.txt, nether-low_boost_hi.txt, and the_end-low_boost_hi.txt
+# To use the HDMap hi-res (16 ppb) map templates, with support for boosting resolution selectively to vhi-res (32 ppb), set value to hi_boost_vhi
+#   The definitions of these templates are in normal-hi_boost_vhi.txt, nether-hi_boost_vhi.txt, and the_end-hi_boost_vhi.txt
+# To use the HDMap hi-res (16 ppb) map templates, with support for boosting resolution selectively to xhi-res (64 ppb), set value to hi_boost_xhi
+#   The definitions of these templates are in normal-hi_boost_xhi.txt, nether-hi_boost_xhi.txt, and the_end-hi_boost_xhi.txt
+deftemplatesuffix: hires
+
+# Set default tile scale (0 = 128px x 128x, 1 = 256px x 256px, 2 = 512px x 512px, 3 = 1024px x 1024px, 4 = 2048px x 2048px) - 0 is default
+# Note: changing this value will result in all maps that use the default value being required to be fully rendered
+#defaulttilescale: 0
+
+# Map storage scheme: only uncommoent one 'type' value
+#  filetree: classic and default scheme: tree of files, with all map data under the directory indicated by 'tilespath' setting
+#  sqlite: single SQLite database file (this can get VERY BIG), located at 'dbfile' setting (default is file dynmap.db in data directory)
+#  mysql: MySQL database, at hostname:port in database, accessed via userid with password
+#  mariadb: MariaDB database, at hostname:port in database, accessed via userid with password
+#  postgres: PostgreSQL database, at hostname:port in database, accessed via userid with password
+storage:
+  # Filetree storage (standard tree of image files for maps)
+  type: filetree
+  # SQLite db for map storage (uses dbfile as storage location)
+  #type: sqlite
+  #dbfile: dynmap.db
+  # MySQL DB for map storage (at 'hostname':'port' in database 'database' using user 'userid' password 'password' and table prefix 'prefix'
+  #type: mysql
+  #hostname: localhost
+  #port: 3306
+  #database: dynmap
+  #userid: dynmap
+  #password: dynmap
+  #prefix: ""
+  #
+  # AWS S3 backet web site
+  #type: aws_s3
+  #bucketname: "dynmap-bucket-name"
+  #region: us-east-1
+  #aws_access_key_id: "<aws-access-key-id>"
+  #aws_secret_access_key: "<aws-secret-access-key>"  
+  #prefix: ""
+  #override_endpoint: ""
+
+components:
+  - class: org.dynmap.ClientConfigurationComponent
+  
+  # Remember to change the following class to org.dynmap.JsonFileClientUpdateComponent when using an external web server.
+  - class: org.dynmap.InternalClientUpdateComponent
+    sendhealth: true
+    sendposition: true
+    allowwebchat: true
+    webchat-interval: 5
+    hidewebchatip: false
+    trustclientname: false
+    includehiddenplayers: false
+    # (optional) if true, color codes in player display names are used
+    use-name-colors: false
+    # (optional) if true, player login IDs will be used for web chat when their IPs match
+    use-player-login-ip: true
+    # (optional) if use-player-login-ip is true, setting this to true will cause chat messages not matching a known player IP to be ignored
+    require-player-login-ip: false
+    # (optional) block player login IDs that are banned from chatting
+    block-banned-player-chat: true
+    # Require login for web-to-server chat (requires login-enabled: true)
+    webchat-requires-login: false
+    # If set to true, users must have dynmap.webchat permission in order to chat
+    webchat-permissions: false
+    # Limit length of single chat messages
+    chatlengthlimit: 256
+  #  # Optional - make players hidden when they are inside/underground/in shadows (#=light level: 0=full shadow,15=sky)
+  #  hideifshadow: 4
+  #  # Optional - make player hidden when they are under cover (#=sky light level,0=underground,15=open to sky)
+  #  hideifundercover: 14
+  #  # (Optional) if true, players that are crouching/sneaking will be hidden 
+    hideifsneaking: false
+    # optional, if true, players that are in spectator mode will be hidden
+    hideifspectator: false
+    # If true, player positions/status is protected (login with ID with dynmap.playermarkers.seeall permission required for info other than self)
+    protected-player-info: false
+    # If true, hide players with invisibility potion effects active
+    hide-if-invisiblity-potion: true
+    # If true, player names are not shown on map, chat, list
+    hidenames: false
+  #- class: org.dynmap.JsonFileClientUpdateComponent
+  #  writeinterval: 1
+  #  sendhealth: true
+  #  sendposition: true
+  #  allowwebchat: true
+  #  webchat-interval: 5
+  #  hidewebchatip: false
+  #  includehiddenplayers: false
+  #  use-name-colors: false
+  #  use-player-login-ip: false
+  #  require-player-login-ip: false
+  #  block-banned-player-chat: true
+  #  hideifshadow: 0
+  #  hideifundercover: 0
+  #  hideifsneaking: false
+  #  # Require login for web-to-server chat (requires login-enabled: true)
+  #  webchat-requires-login: false
+  #  # If set to true, users must have dynmap.webchat permission in order to chat
+  #  webchat-permissions: false
+  #  # Limit length of single chat messages
+  #  chatlengthlimit: 256
+  #  hide-if-invisiblity-potion: true
+  #  hidenames: false
+   
+  - class: org.dynmap.SimpleWebChatComponent
+    allowchat: true
+    # If true, web UI users can supply name for chat using 'playername' URL parameter.  'trustclientname' must also be set true.
+    allowurlname: false
+  
+  # Note: this component is needed for the dmarker commands, and for the Marker API to be available to other plugins
+  - class: org.dynmap.MarkersComponent
+    type: markers
+    showlabel: false
+    enablesigns: false
+    # Default marker set for sign markers
+    default-sign-set: markers
+    # (optional) add spawn point markers to standard marker layer
+    showspawn: true
+    spawnicon: world
+    spawnlabel: "Spawn"
+    # (optional) layer for showing offline player's positions (for 'maxofflinetime' minutes after logoff)
+    showofflineplayers: false
+    offlinelabel: "Offline"
+    offlineicon: offlineuser
+    offlinehidebydefault: true
+    offlineminzoom: 0
+    maxofflinetime: 30
+    # (optional) layer for showing player's spawn beds
+    showspawnbeds: false
+    spawnbedlabel: "Spawn Beds"
+    spawnbedicon: bed
+    spawnbedhidebydefault: true
+    spawnbedminzoom: 0
+    spawnbedformat: "%name%'s bed"
+    spawnbedremoveonplayerleave: true
+    # (optional) Show world border (vanilla 1.8+)
+    showworldborder: true
+    worldborderlabel: "Border"
+    
+  - class: org.dynmap.ClientComponent
+    type: chat
+    allowurlname: false
+  - class: org.dynmap.ClientComponent
+    type: chatballoon
+    focuschatballoons: false
+  - class: org.dynmap.ClientComponent
+    type: chatbox
+    showplayerfaces: true
+    messagettl: 5
+    # Optional: set number of lines in scrollable message history: if set, messagettl is not used to age out messages
+    #scrollback: 100
+    # Optional: set maximum number of lines visible for chatbox
+    #visiblelines: 10
+    # Optional: send push button
+    sendbutton: false
+  - class: org.dynmap.ClientComponent
+    type: playermarkers
+    showplayerfaces: true
+    showplayerhealth: true
+    # If true, show player body too (only valid if showplayerfaces=true)
+    showplayerbody: false
+    # Option to make player faces small - don't use with showplayerhealth or largeplayerfaces
+    smallplayerfaces: false
+    # Option to make player faces larger - don't use with showplayerhealth or smallplayerfaces
+    largeplayerfaces: false
+    # Optional - make player faces layer hidden by default
+    hidebydefault: false
+    # Optional - ordering priority in layer menu (low goes before high - default is 0)
+    layerprio: 0
+    # Optional - label for player marker layer (default is 'Players')
+    label: "Players"
+    
+  #- class: org.dynmap.ClientComponent
+  #  type: digitalclock
+  - class: org.dynmap.ClientComponent
+    type: link
+    
+  - class: org.dynmap.ClientComponent
+    type: timeofdayclock
+    showdigitalclock: true
+    #showweather: true
+  # Mouse pointer world coordinate display
+  - class: org.dynmap.ClientComponent
+    type: coord
+    label: "Location"
+    hidey: false
+    show-mcr: false
+    show-chunk: false
+    
+  # Note: more than one logo component can be defined
+  #- class: org.dynmap.ClientComponent
+  #  type: logo
+  #  text: "Dynmap"
+  #  #logourl: "images/block_surface.png"
+  #  linkurl: "http://forums.bukkit.org/threads/dynmap.489/"
+  #  # Valid positions: top-left, top-right, bottom-left, bottom-right
+  #  position: bottom-right
+
+  #- class: org.dynmap.ClientComponent
+  #  type: inactive
+  #  timeout: 1800 # in seconds (1800 seconds = 30 minutes)
+  #  redirecturl: inactive.html
+  #  #showmessage: 'You were inactive for too long.'
+  
+  #- class: org.dynmap.TestComponent
+  #  stuff: "This is some configuration-value"
+
+# Treat hiddenplayers.txt as a whitelist for players to be shown on the map? (Default false)
+display-whitelist: false
+
+# How often a tile gets rendered (in seconds).
+renderinterval: 1
+
+# How many tiles on update queue before accelerate render interval
+renderacceleratethreshold: 60
+
+# How often to render tiles when backlog is above renderacceleratethreshold
+renderaccelerateinterval: 0.2
+
+# How many update tiles to work on at once (if not defined, default is 1/2 the number of cores)
+tiles-rendered-at-once: 2
+
+# If true, use normal priority threads for rendering (versus low priority) - this can keep rendering
+# from starving on busy Windows boxes (Linux JVMs pretty much ignore thread priority), but may result
+# in more competition for CPU resources with other processes
+usenormalthreadpriority: true
+
+# Save and restore pending tile renders - prevents their loss on server shutdown or /reload
+saverestorepending: true
+
+# Save period for pending jobs (in seconds): periodic saving for crash recovery of jobs
+save-pending-period: 900
+
+# Zoom-out tile update period - how often to scan for and process tile updates into zoom-out tiles (in seconds)
+zoomoutperiod: 30
+
+# Control whether zoom out tiles are validated on startup (can be needed if zoomout processing is interrupted, but can be expensive on large maps)
+initial-zoomout-validate: true
+
+# Default delay on processing of updated tiles, in seconds.  This can reduce potentially expensive re-rendering
+# of frequently updated tiles (such as due to machines, pistons, quarries or other automation).  Values can
+# also be set on individual worlds and individual maps.
+tileupdatedelay: 30
+
+# Tile hashing is used to minimize tile file updates when no changes have occurred - set to false to disable
+enabletilehash: true
+
+# Optional - hide ores: render as normal stone (so that they aren't revealed by maps)
+#hideores: true
+
+# Optional - enabled BetterGrass style rendering of grass and snow block sides
+#better-grass: true
+
+# Optional - enable smooth lighting by default on all maps supporting it (can be set per map as lighting option)
+smooth-lighting: true
+
+# Optional - use world provider lighting table (good for custom worlds with custom lighting curves, like nether)
+#   false=classic Dynmap lighting curve
+use-brightness-table: true
+
+# Optional - render specific block names using the textures and models of another block name: can be used to hide/disguise specific
+#  blocks (e.g. make ores look like stone, hide chests) or to provide simple support for rendering unsupported custom blocks
+block-alias:
+#    "minecraft:quartz_ore": "stone"
+#    "diamond_ore": "coal_ore"
+
+# Default image format for HDMaps (png, jpg, jpg-q75, jpg-q80, jpg-q85, jpg-q90, jpg-q95, jpg-q100, webp, webp-q75, webp-q80, webp-q85, webp-q90, webp-q95, webp-q100),
+# Note: any webp format requires the presence of the 'webp command line tools' (cwebp, dwebp) (https://developers.google.com/speed/webp/download)
+#
+# Has no effect on maps with explicit format settings
+image-format: jpg-q90
+
+# If cwebp or dwebp are not on the PATH, use these settings to provide their full path.  Do not use these settings if the tools are on the PATH
+# For Windows, include .exe
+#
+#cwebpPath: /usr/bin/cwebp
+#dwebpPath: /usr/bin/dwebp
+
+#  use-generated-textures: if true, use generated textures (same as client); false is static water/lava textures
+#  correct-water-lighting: if true, use corrected water lighting (same as client); false is legacy water (darker)
+#  transparent-leaves: if true, leaves are transparent (lighting-wise): false is needed for some Spout versions that break lighting on leaf blocks
+use-generated-textures: true
+correct-water-lighting: true
+transparent-leaves: true
+
+# ctm-support: if true, Connected Texture Mod (CTM) in texture packs is enabled (default)
+ctm-support: true
+# custom-colors-support: if true, Custom Colors in texture packs is enabled (default)
+custom-colors-support: true
+
+# Control loading of player faces (if set to false, skins are never fetched)
+#fetchskins: false
+
+# Control updating of player faces, once loaded (if faces are being managed by other apps or manually)
+#refreshskins: false
+
+# Customize URL used for fetching player skins (%player% is macro for name, %uuid% for UUID)
+skin-url: "http://skins.minecraft.net/MinecraftSkins/%player%.png"
+
+# Control behavior for new (1.0+) compass orientation (sunrise moved 90 degrees: east is now what used to be south)
+#   default is 'newrose' (preserve pre-1.0 maps, rotate rose)
+#   'newnorth' is used to rotate maps and rose (requires fullrender of any HDMap map - same as 'newrose' for FlatMap or KzedMap)
+compass-mode: newnorth
+
+# Triggers for automatic updates : blockupdate-with-id is debug for breaking down updates by ID:meta
+# To disable, set just 'none' and comment/delete the rest
+render-triggers:
+  - blockupdate
+  #- blockupdate-with-id
+  #- lightingupdate
+  - chunkpopulate
+  - chunkgenerate
+  #- none
+
+# Title for the web page - if not specified, defaults to the server's name (unless it is the default of 'Unknown Server')
+#webpage-title: "My Awesome Server Map"
+
+# The path where the tile-files are placed.
+tilespath: web/tiles
+
+# The path where the web-files are located.
+webpath: web
+
+# If set to false, disable extraction of webpath content (good if using custom web UI or 3rd party web UI)
+# Note: web interface is unsupported in this configuration - you're on your own
+update-webpath-files: true
+
+# The path were the /dynmapexp command exports OBJ ZIP files
+exportpath: export
+
+# The path where files can be imported for /dmarker commands
+importpath: import
+
+# The network-interface the webserver will bind to (0.0.0.0 for all interfaces, 127.0.0.1 for only local access).
+# If not set, uses same setting as server in server.properties (or 0.0.0.0 if not specified)
+#webserver-bindaddress: 0.0.0.0
+
+# The TCP-port the webserver will listen on.
+webserver-port: 8123
+
+# Maximum concurrent session on internal web server - limits resources used in Bukkit server
+max-sessions: 30
+
+# Disables Webserver portion of Dynmap (Advanced users only)
+disable-webserver: false
+
+# Enable/disable having the web server allow symbolic links (true=compatible with existing code, false=more secure (default))
+allow-symlinks: true
+
+# Enable login support
+login-enabled: false
+# Require login to access website (requires login-enabled: true)
+login-required: false
+
+# Period between tile renders for fullrender, in seconds (non-zero to pace fullrenders, lessen CPU load)
+timesliceinterval: 0.0
+
+# Maximum chunk loads per server tick (1/20th of a second) - reducing this below 90 will impact render performance, but also will reduce server thread load
+maxchunkspertick: 200
+
+# Progress report interval for fullrender/radiusrender, in tiles.  Must be 100 or greater
+progressloginterval: 100
+
+# Parallel fullrender: if defined, number of concurrent threads used for fullrender or radiusrender
+#   Note: setting this will result in much more intensive CPU use, some additional memory use.  Caution should be used when
+#  setting this to equal or exceed the number of physical cores on the system.
+#parallelrendercnt: 4
+
+# Interval the browser should poll for updates.
+updaterate: 2000
+
+# If nonzero, server will pause fullrender/radiusrender processing when 'fullrenderplayerlimit' or more users are logged in
+fullrenderplayerlimit: 0
+# If nonzero, server will pause update render processing when 'updateplayerlimit' or more users are logged in
+updateplayerlimit: 0
+# Target limit on server thread use - msec per tick
+per-tick-time-limit: 50
+# If TPS of server is below this setting, update renders processing is paused
+update-min-tps: 18.0
+# If TPS of server is below this setting, full/radius renders processing is paused
+fullrender-min-tps: 18.0
+# If TPS of server is below this setting, zoom out processing is paused
+zoomout-min-tps: 18.0
+
+showplayerfacesinmenu: true
+
+# Control whether players that are hidden or not on current map are grayed out (true=yes)
+grayplayerswhenhidden: true
+
+# Set sidebaropened: 'true' to pin menu sidebar opened permanently, 'pinned' to default the sidebar to pinned, but allow it to unpin
+#sidebaropened: true
+
+# Customized HTTP response headers - add 'id: value' pairs to all HTTP response headers (internal web server only)
+#http-response-headers:
+#    Access-Control-Allow-Origin: "my-domain.com"
+#    X-Custom-Header-Of-Mine: "MyHeaderValue"
+
+# Trusted proxies for web server - which proxy addresses are trusted to supply valid X-Forwarded-For fields
+#   This now supports both IP address, and subnet ranges (e.g. 192.168.1.0/24 or 202.24.0.0/14 )
+trusted-proxies:
+  - "127.0.0.1"
+  - "0:0:0:0:0:0:0:1"
+  
+joinmessage: "%playername% joined"
+quitmessage: "%playername% quit"
+spammessage: "You may only chat once every %interval% seconds."
+# format for messages from web: %playername% substitutes sender ID (typically IP), %message% includes text
+webmsgformat: "&color;2[WEB] %playername%: &color;f%message%"
+
+# Control whether layer control is presented on the UI (default is true)
+showlayercontrol: true
+
+# Enable checking for banned IPs via banned-ips.txt (internal web server only)
+check-banned-ips: true
+
+# Default selection when map page is loaded
+defaultzoom: 0
+defaultworld: world
+defaultmap: flat
+# (optional) Zoom level and map to switch to when following a player, if possible
+#followzoom: 3
+#followmap: surface
+
+# If true, make persistent record of IP addresses used by player logins, to support web IP to player matching
+persist-ids-by-ip: true
+
+# If true, map text to cyrillic
+cyrillic-support: false
+
+# Messages to customize
+msg:
+    maptypes: "Map Types"
+    players: "Players"
+    chatrequireslogin: "Chat Requires Login"
+    chatnotallowed: "You are not permitted to send chat messages"
+    hiddennamejoin: "Player joined"
+    hiddennamequit: "Player quit"
+
+# URL for client configuration (only need to be tailored for proxies or other non-standard configurations)
+url:
+    # configuration URL
+    #configuration: "up/configuration"
+    # update URL
+    #update: "up/world/{world}/{timestamp}"
+    # sendmessage URL
+    #sendmessage: "up/sendmessage"
+    # login URL
+    #login: "up/login"
+    # register URL
+    #register: "up/register"
+    # tiles base URL
+    #tiles: "tiles/"
+    # markers base URL
+    #markers: "tiles/"
+    # Snapshot cache size, in chunks
+snapshotcachesize: 500
+# Snapshot cache uses soft references (true), else weak references (false)
+soft-ref-cache: true
+
+# Player enter/exit title messages for map markers
+#
+# Processing period - how often to check player positions vs markers - default is 1000ms (1 second)
+#enterexitperiod: 1000
+# Title message fade in time, in ticks (0.05 second intervals) - default is 10 (1/2 second)
+#titleFadeIn: 10
+# Title message stay time, in ticks (0.05 second intervals) - default is 70 (3.5 seconds)
+#titleStay: 70
+# Title message fade out time, in ticks (0.05 seocnd intervals) - default is 20 (1 second)
+#titleFadeOut: 20
+# Enter/exit messages use on screen titles (true - default), if false chat messages are sent instead
+#enterexitUseTitle: true
+# Set true if new enter messages should supercede pending exit messages (vs being queued in order), default false
+#enterReplacesExits: true
+
+# Published public URL for Dynmap server (allows users to use 'dynmap url' command to get public URL usable to access server
+# If not set, 'dynmap url' will not return anything.  URL should be fully qualified (e.g. https://mc.westeroscraft.com/)
+#publicURL: http://my.greatserver.com/dynmap
+
+# Send this message if the player does not have permission to use the command
+noPermissionMsg: "You don't have permission to use this command!"
+
+# Set to true to enable verbose startup messages - can help with debugging map configuration problems
+# Set to false for a much quieter startup log
+verbose: false
+
+# Enables debugging.
+#debuggers:
+#  - class: org.dynmap.debug.LogDebugger
+# Debug: dump blocks missing render data
+dump-missing-blocks: false
+
+# Log4J defense: string substituted for attempts to use macros in web chat
+hackAttemptBlurb: "(IaM5uchA1337Haxr-Ban Me!)"

--- a/neoforge-1.21.1/src/main/resources/pack.mcmeta
+++ b/neoforge-1.21.1/src/main/resources/pack.mcmeta
@@ -1,0 +1,8 @@
+{
+    "pack": {
+        "description": {
+           "text": "Dynmap resources"
+        },
+        "pack_format": 22
+    }
+}

--- a/neoforge-1.21.1/src/main/resources/permissions.yml.example
+++ b/neoforge-1.21.1/src/main/resources/permissions.yml.example
@@ -1,0 +1,27 @@
+#
+# Sample permissions.yml for dynmap - trivial, flat-file based permissions for dynmap features
+# To use, copy this file to dynmap/permissions.yml, and edit appropriate.  File is YAML format.
+#
+# All operators have full permissions to all functions.
+# All users receive the permissions under the 'defaultuser' section
+# Specific users can be given more permissions by defining a section with their name containing their permisssions
+#   All permissions correspond to those documented here (https://github.com/webbukkit/dynmap/wiki/Permissions), but
+#  do NOT have the 'dynmap.' prefix when used here (e.g. 'dynmap.fullrender' permission is just 'fullrender' here).
+#
+defaultuser:
+  - render
+  - show.self
+  - hide.self
+  - sendtoweb
+  - stats
+  - marker.list
+  - marker.listsets
+  - marker.icons
+  - webregister
+  - webchat
+  #- marker.sign
+
+#playername1:
+#  - fullrender
+#  - cancelrender
+#  - radiusrender

--- a/settings.gradle
+++ b/settings.gradle
@@ -95,3 +95,5 @@ project(':forge-1.16.5').projectDir = "$rootDir/forge-1.16.5" as File
 project(':forge-1.15.2').projectDir = "$rootDir/forge-1.15.2" as File
 project(':forge-1.14.4').projectDir = "$rootDir/forge-1.14.4" as File
 
+include ':neoforge-1.21.1'
+project(':neoforge-1.21.1').projectDir = "$rootDir/neoforge-1.21.1" as File


### PR DESCRIPTION
# feat(neoforge): Add NeoForge 1.21.1 support

## What this adds

Adds a new `neoforge-1.21.1` module for NeoForge support on Minecraft 1.21.1. This is a direct port of the `neoforge-1.20.6` module with only the API changes required by NeoForge 21.1.x and Minecraft 1.21.1.

## Changes from neoforge-1.20.6

### Package/Import Changes
- Package rename: `neoforge_1_20_6` → `neoforge_1_21_1`
- Imports: `net.minecraftforge.*` → `net.neoforged.*`
- EventBus: `net.minecraftforge.eventbus.api.*` → `net.neoforged.neoforge.eventbus.api.*`

### API Changes (Required by NeoForge 21.x / MC 1.21.1)

| Location | Old API | New API | Reason |
|----------|---------|---------|--------|
| DynmapPlugin.java L254 | `isSolidRender(EmptyBlockGetter.INSTANCE, BlockPos.ZERO)` | `canOcclude()` | API signature changed in 1.21.1; also fixes Guava LoadingCache deadlock with modernfix/ferritecore |
| DynmapPlugin.java L254 | `propagatesSkylightDown(...)` | `isAir()` | Same as above |
| DynmapPlugin.java L263 | `isSolid()` | `canOcclude()` | Method behavior changed |
| DynmapPlugin.java L706,1555,1689,1849 | `MinecraftForge.EVENT_BUS` | `NeoForge.EVENT_BUS` | NeoForge package restructure |
| DynmapPlugin.java L925-927 | Phase.START check | Removed | NeoForge 21.x: ServerTickEvent is abstract, uses Pre/Post subclasses |
| DynmapPlugin.java L1737,1808,1865 | `getStatus()` | `getPersistedStatus()` | API rename in 1.21.1 |
| DynmapPlugin.java L1862 | `getLastAvailable()` | `getLatestChunk()` | API removed in 1.21.1 |
| NBT.java L21 | `getAllKeys()` | `keySet()` | API rename |
| NBT.java L30-40 | `contains(s, i)` | Manual type checking | `contains(String, int)` behavior changed |
| NBT.java (all getters) | `getByte(s)` etc. | `getByteOr(s, default)` etc. | Null-safe API changes |
| NBT.java L72,76 | `getCompound(s)`/`getList(s,i)` | `getCompoundOrEmpty(s)`/`getListOrEmpty(s)` | API rename |
| NBT.java L96-98 | `obj.get(s).getAsString()` | Null check + `asString().orElse("")` | NPE safety |

### Build Configuration Changes

- `build.gradle`:
  - `net.neoforged.gradle.userdev` version: `7.0.133` → `7.1.20`
  - `net.neoforged:neoforge`: `20.6.62-beta` → `21.1.219`
  - Project name/classifier updated for 1.21.1

- `neoforge.mods.toml`:
  - `loaderVersion`: `[2,)` → `[4,)`
  - NeoForge `versionRange`: `[20.6,)` → `[21.1,)`
  - Minecraft `versionRange`: `[1.20.6,1.21)` → `[1.21.1,1.22)`

## Java 21 Requirement

NeoForge 1.21.1 requires Java 21 — this is a platform requirement, not a code choice. The module is configured for Java 21 toolchain.

## Gradle/Build System Changes

**Gradle Wrapper:** Updated from 8.7 to 8.14.

This is required because NeoForge Gradle userdev 7.1.20 (needed for NeoForge 21.1.x) requires Gradle 8.8+. The dependency chain:

```
NeoForge 21.1.x → userdev 7.1.20 → Gradle 8.8+
```

**fabric-loom:** Updated from 1.6.11 to 1.8.13 in all 10 fabric modules.

fabric-loom 1.6.11 is not compatible with Gradle 8.14. This is a transitive requirement — without updating loom, the existing fabric modules would fail to build after the Gradle upgrade. Verified that fabric-1.20.6 still builds successfully with loom 1.8.13.

Note: `--configure-on-demand` flag is recommended when building to avoid plugin conflicts between multiple NeoForge subproject versions.

## Test Results

Tested on ATM10 5.5 modpack (445 mods):
- Clean server boot
- Dynmap web interface loads
- Map renders correctly
- No errors or warnings related to Dynmap

## Code Style Note

This port aims to be strictly minimal. The one structural change beyond API requirements is the event registration pattern — NeoForge 21.x uses `addListener()` instead of registering annotated inner classes, which required restructuring `ChatHandler` from an inner class to a direct method. All other changes are API-forced.

## AI Assistance Disclosure

This port was developed with AI assistance (Claude, acting as an agent on behalf of the contributor) to deploy a working version for an ATM10 NeoForge server. All changes were reviewed, tested, and verified by the contributor before submission.

---

**Branch:** `neoforge-1.21.1-pr`  
**Base:** `neoforge`  
**Fork:** https://github.com/Cobbert/dynmap
