### PR TITLE
Fix biome colours for mangrove leaves

### DIFF
--- a/DynmapCore/src/main/resources/texture_1.txt
+++ b/DynmapCore/src/main/resources/texture_1.txt
@@ -3279,7 +3279,7 @@ block:id=%melon_stem,patch0=0:melon_stem,blockcolor=foliagebiome,transparency=TR
 [1.19-]block:id=%mangrove_wood,state=axis:x,patch0=0:mangrove_log,stdrot=true
 [1.19-]block:id=%mangrove_wood,state=axis:y,patch0=0:mangrove_log,patch1=0:mangrove_log,patch2=0:mangrove_log,patch3=0:mangrove_log,patch4=0:mangrove_log,patch5=0:mangrove_log,stdrot=true
 [1.19-]block:id=%mangrove_wood,state=axis:z,patch0=0:mangrove_log,stdrot=true
-[1.19-]block:id=%mangrove_leaves,patch0=0:mangrove_leaves,patch1=0:mangrove_leaves,patch2=0:mangrove_leaves,patch3=0:mangrove_leaves,patch4=0:mangrove_leaves,patch5=0:mangrove_leaves,blockcolor=foliage,transparency=SEMITRANSPARENT,stdrot=true
+[1.19-]block:id=%mangrove_leaves,allfaces=2000:mangrove_leaves,stdrot=true,transparency=LEAVES
 [1.19-]block:id=%mangrove_pressure_plate,state=powered:true,patch0=0:mangrove_planks,transparency=TRANSPARENT,stdrot=true
 [1.19-]block:id=%mangrove_pressure_plate,state=powered:false,patch0=0:mangrove_planks,transparency=TRANSPARENT,stdrot=true
 [1.19-]block:id=%mangrove_trapdoor,state=facing:north/half:top/open:true,patch0=0:mangrove_trapdoor,transparency=SEMITRANSPARENT,stdrot=true


### PR DESCRIPTION
I don't think I've seen this mentioned in any issues or on the Discord but it always bugged me how Mangrove leaves didn't have the right biome colour in Mangrove Swamps. Figured out how to fix it in my fork yesterday and this change looks like it follows the contribution guidelines so I thought I'd send it in.

_**NOTE**_ Everything builds fine. I am not too confident with the texture_0/1.txt and model_0/1.txt files and their formatting but I don't believe this breaks anything as it just follows how other leaves (like oak) are added in this texture file. Apologies if I have missed something.

Here are some before and after pics. The right-hand side compares the mangrove leaves (bottom) to oak leaves (top) with a bunch of different biomes(forest, plains, desert, jungle and mangrove in that order).

**Before**
<img width="2393" height="848" alt="before-combined" src="https://github.com/user-attachments/assets/64fd9f2b-1714-4159-a1dc-6761bd0bce60" />


**After**
<img width="2531" height="834" alt="after-combined" src="https://github.com/user-attachments/assets/bc4962c3-d090-4462-b10d-5d944a4b7387" />
