### PR TITLE
Refactor property value retrieval in DynmapPlugin

### DIFF
--- a/fabric-1.14.4/src/main/java/org/dynmap/fabric_1_14_4/DynmapPlugin.java
+++ b/fabric-1.14.4/src/main/java/org/dynmap/fabric_1_14_4/DynmapPlugin.java
@@ -163,6 +163,22 @@ public class DynmapPlugin {
     }
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#name(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.state.property.Property<T> p) {
+        return p.name(bs.get(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -206,7 +222,7 @@ public class DynmapPlugin {
                     if (statename.length() > 0) {
                         statename += ",";
                     }
-                    statename += p.getName() + "=" + bs.get(p).toString();
+                    statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = bs.isFullOpaque(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 15 : (bs.isTranslucent(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 0 : 1);
                 //Log.info("statename=" + bn + "[" + statename + "], lightAtten=" + lightAtten);

--- a/fabric-1.15.2/src/main/java/org/dynmap/fabric_1_15_2/DynmapPlugin.java
+++ b/fabric-1.15.2/src/main/java/org/dynmap/fabric_1_15_2/DynmapPlugin.java
@@ -163,6 +163,22 @@ public class DynmapPlugin {
     }
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#name(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.state.property.Property<T> p) {
+        return p.name(bs.get(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -206,7 +222,7 @@ public class DynmapPlugin {
                     if (statename.length() > 0) {
                         statename += ",";
                     }
-                    statename += p.getName() + "=" + bs.get(p).toString();
+                    statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = bs.isFullOpaque(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 15 : (bs.isTranslucent(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 0 : 1);
                 //Log.info("statename=" + bn + "[" + statename + "], lightAtten=" + lightAtten);

--- a/fabric-1.16.4/src/main/java/org/dynmap/fabric_1_16_4/DynmapPlugin.java
+++ b/fabric-1.16.4/src/main/java/org/dynmap/fabric_1_16_4/DynmapPlugin.java
@@ -161,6 +161,22 @@ public class DynmapPlugin {
     }
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#name(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.state.property.Property<T> p) {
+        return p.name(bs.get(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -204,7 +220,7 @@ public class DynmapPlugin {
                     if (statename.length() > 0) {
                         statename += ",";
                     }
-                    statename += p.getName() + "=" + bs.get(p).toString();
+                    statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = bs.isOpaqueFullCube(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 15 : (bs.isTranslucent(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 0 : 1);
                 //Log.info("statename=" + bn + "[" + statename + "], lightAtten=" + lightAtten);

--- a/fabric-1.17.1/src/main/java/org/dynmap/fabric_1_17_1/DynmapPlugin.java
+++ b/fabric-1.17.1/src/main/java/org/dynmap/fabric_1_17_1/DynmapPlugin.java
@@ -162,6 +162,22 @@ public class DynmapPlugin {
     }
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#name(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.state.property.Property<T> p) {
+        return p.name(bs.get(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -205,7 +221,7 @@ public class DynmapPlugin {
                     if (statename.length() > 0) {
                         statename += ",";
                     }
-                    statename += p.getName() + "=" + bs.get(p).toString();
+                    statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = bs.isOpaqueFullCube(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 15 : (bs.isTranslucent(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 0 : 1);
                 //Log.info("statename=" + bn + "[" + statename + "], lightAtten=" + lightAtten);

--- a/fabric-1.18.2/src/main/java/org/dynmap/fabric_1_18_2/DynmapPlugin.java
+++ b/fabric-1.18.2/src/main/java/org/dynmap/fabric_1_18_2/DynmapPlugin.java
@@ -123,6 +123,22 @@ public class DynmapPlugin {
     public static DynmapBlockState[] stateByID;
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#name(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.state.property.Property<T> p) {
+        return p.name(bs.get(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -166,7 +182,7 @@ public class DynmapPlugin {
                     if (statename.length() > 0) {
                         statename += ",";
                     }
-                    statename += p.getName() + "=" + bs.get(p).toString();
+                    statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = bs.isOpaqueFullCube(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 15 : (bs.isTranslucent(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 0 : 1);
                 //Log.info("statename=" + bn + "[" + statename + "], lightAtten=" + lightAtten);

--- a/fabric-1.19.4/src/main/java/org/dynmap/fabric_1_19_4/DynmapPlugin.java
+++ b/fabric-1.19.4/src/main/java/org/dynmap/fabric_1_19_4/DynmapPlugin.java
@@ -118,6 +118,22 @@ public class DynmapPlugin {
     public static DynmapBlockState[] stateByID;
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#name(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.state.property.Property<T> p) {
+        return p.name(bs.get(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -161,7 +177,7 @@ public class DynmapPlugin {
                     if (statename.length() > 0) {
                         statename += ",";
                     }
-                    statename += p.getName() + "=" + bs.get(p).toString();
+                    statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = bs.isOpaqueFullCube(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 15 : (bs.isTransparent(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 0 : 1);
                 //Log.info("statename=" + bn + "[" + statename + "], lightAtten=" + lightAtten);

--- a/fabric-1.20.6/src/main/java/org/dynmap/fabric_1_20_6/DynmapPlugin.java
+++ b/fabric-1.20.6/src/main/java/org/dynmap/fabric_1_20_6/DynmapPlugin.java
@@ -119,6 +119,22 @@ public class DynmapPlugin {
     public static DynmapBlockState[] stateByID;
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#name(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.state.property.Property<T> p) {
+        return p.name(bs.get(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -161,7 +177,7 @@ public class DynmapPlugin {
                     if (statename.length() > 0) {
                         statename += ",";
                     }
-                    statename += p.getName() + "=" + bs.get(p).toString();
+                    statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = bs.isOpaqueFullCube(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 15 : (bs.isTransparent(EmptyBlockView.INSTANCE, BlockPos.ORIGIN) ? 0 : 1);
                 //Log.info("statename=" + bn + "[" + statename + "], lightAtten=" + lightAtten);

--- a/fabric-1.21.11/src/main/java/org/dynmap/fabric_1_21_11/DynmapPlugin.java
+++ b/fabric-1.21.11/src/main/java/org/dynmap/fabric_1_21_11/DynmapPlugin.java
@@ -119,6 +119,22 @@ public class DynmapPlugin {
     public static DynmapBlockState[] stateByID;
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#name(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.state.property.Property<T> p) {
+        return p.name(bs.get(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -161,7 +177,7 @@ public class DynmapPlugin {
                     if (statename.length() > 0) {
                         statename += ",";
                     }
-                    statename += p.getName() + "=" + bs.get(p).toString();
+                    statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = bs.isOpaqueFullCube() ? 15 : (bs.isTransparent() ? 0 : 1);
                 //Log.info("statename=" + bn + "[" + statename + "], lightAtten=" + lightAtten);

--- a/fabric-1.21.6/src/main/java/org/dynmap/fabric_1_21_7/DynmapPlugin.java
+++ b/fabric-1.21.6/src/main/java/org/dynmap/fabric_1_21_7/DynmapPlugin.java
@@ -119,6 +119,22 @@ public class DynmapPlugin {
     public static DynmapBlockState[] stateByID;
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#name(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.state.property.Property<T> p) {
+        return p.name(bs.get(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -161,7 +177,7 @@ public class DynmapPlugin {
                     if (statename.length() > 0) {
                         statename += ",";
                     }
-                    statename += p.getName() + "=" + bs.get(p).toString();
+                    statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = bs.isOpaqueFullCube() ? 15 : (bs.isTransparent() ? 0 : 1);
                 //Log.info("statename=" + bn + "[" + statename + "], lightAtten=" + lightAtten);

--- a/fabric-1.21.9-10/src/main/java/org/dynmap/fabric_1_21_9_10/DynmapPlugin.java
+++ b/fabric-1.21.9-10/src/main/java/org/dynmap/fabric_1_21_9_10/DynmapPlugin.java
@@ -119,6 +119,22 @@ public class DynmapPlugin {
     public static DynmapBlockState[] stateByID;
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#name(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.state.property.Property<T> p) {
+        return p.name(bs.get(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -161,7 +177,7 @@ public class DynmapPlugin {
                     if (statename.length() > 0) {
                         statename += ",";
                     }
-                    statename += p.getName() + "=" + bs.get(p).toString();
+                    statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = bs.isOpaqueFullCube() ? 15 : (bs.isTransparent() ? 0 : 1);
                 //Log.info("statename=" + bn + "[" + statename + "], lightAtten=" + lightAtten);

--- a/forge-1.14.4/src/main/java/org/dynmap/forge_1_14_4/DynmapPlugin.java
+++ b/forge-1.14.4/src/main/java/org/dynmap/forge_1_14_4/DynmapPlugin.java
@@ -242,7 +242,7 @@ public class DynmapPlugin
                 		statename += ",";
                 	}
                     try {
-                        statename += p.getName() + "=" + bs.get(p).toString();
+                        statename += p.getName() + "=" + p.getName(bs.get(p));
                     } catch (IllegalFormatConversionException e){
                     }
                 }

--- a/forge-1.15.2/src/main/java/org/dynmap/forge_1_15_2/DynmapPlugin.java
+++ b/forge-1.15.2/src/main/java/org/dynmap/forge_1_15_2/DynmapPlugin.java
@@ -254,7 +254,7 @@ public class DynmapPlugin
                 	if (statename.length() > 0) {
                 		statename += ",";
                 	}
-                	statename += p.getName() + "=" + bs.get(p).toString();
+                	statename += p.getName() + "=" + p.getName(bs.get(p));
                 }
                 int lightAtten = bs.isOpaqueCube(EmptyBlockReader.INSTANCE, BlockPos.ZERO) ? 15 : (bs.propagatesSkylightDown(EmptyBlockReader.INSTANCE, BlockPos.ZERO) ? 0 : 1);
                 //Log.info("statename=" + bn + "[" + statename + "], lightAtten=" + lightAtten);

--- a/forge-1.16.5/src/main/java/org/dynmap/forge_1_16_5/DynmapPlugin.java
+++ b/forge-1.16.5/src/main/java/org/dynmap/forge_1_16_5/DynmapPlugin.java
@@ -223,10 +223,23 @@ public class DynmapPlugin
     }
 
     /**
-     * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#getName(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
      */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.state.Property<T> p) {
+        return p.getName(bs.get(p));
+    }
+
     /**
-     * 
+     * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
     	stateByID = new DynmapBlockState[512*32];	// Simple map - scale as needed
@@ -269,7 +282,7 @@ public class DynmapPlugin
                 	if (statename.length() > 0) {
                 		statename += ",";
                 	}
-                	statename += p.getName() + "=" + bs.get(p).toString();
+                	statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = 15;
                 try {	// Workaround for mods with broken block state logic...

--- a/forge-1.17.1/src/main/java/org/dynmap/forge_1_17_1/DynmapPlugin.java
+++ b/forge-1.17.1/src/main/java/org/dynmap/forge_1_17_1/DynmapPlugin.java
@@ -203,6 +203,22 @@ public class DynmapPlugin
     }
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#getName(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.world.level.block.state.properties.Property<T> p) {
+        return p.getName(bs.getValue(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -246,7 +262,7 @@ public class DynmapPlugin
                 	if (statename.length() > 0) {
                 		statename += ",";
                 	}
-                	statename += p.getName() + "=" + bs.getValue(p).toString();
+                	statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = 15;
                 try {	// Workaround for mods with broken block state logic...

--- a/forge-1.18.2/src/main/java/org/dynmap/forge_1_18_2/DynmapPlugin.java
+++ b/forge-1.18.2/src/main/java/org/dynmap/forge_1_18_2/DynmapPlugin.java
@@ -203,6 +203,22 @@ public class DynmapPlugin
     }
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#getName(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.world.level.block.state.properties.Property<T> p) {
+        return p.getName(bs.getValue(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -246,7 +262,7 @@ public class DynmapPlugin
                 	if (statename.length() > 0) {
                 		statename += ",";
                 	}
-                	statename += p.getName() + "=" + bs.getValue(p).toString();
+                	statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = 15;
                 try {	// Workaround for mods with broken block state logic...

--- a/forge-1.19.3/src/main/java/org/dynmap/forge_1_19_3/DynmapPlugin.java
+++ b/forge-1.19.3/src/main/java/org/dynmap/forge_1_19_3/DynmapPlugin.java
@@ -205,6 +205,22 @@ public class DynmapPlugin
     }
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#getName(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.world.level.block.state.properties.Property<T> p) {
+        return p.getName(bs.getValue(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -248,7 +264,7 @@ public class DynmapPlugin
                 	if (statename.length() > 0) {
                 		statename += ",";
                 	}
-                	statename += p.getName() + "=" + bs.getValue(p).toString();
+                	statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = 15;
                 try {	// Workaround for mods with broken block state logic...

--- a/forge-1.20.6/src/main/java/org/dynmap/forge_1_20_6/DynmapPlugin.java
+++ b/forge-1.20.6/src/main/java/org/dynmap/forge_1_20_6/DynmapPlugin.java
@@ -202,6 +202,22 @@ public class DynmapPlugin
     }
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#getName(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.world.level.block.state.properties.Property<T> p) {
+        return p.getName(bs.getValue(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -244,7 +260,7 @@ public class DynmapPlugin
                 	if (statename.length() > 0) {
                 		statename += ",";
                 	}
-                	statename += p.getName() + "=" + bs.getValue(p).toString();
+                	statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = 15;
                 try {	// Workaround for mods with broken block state logic...

--- a/forge-1.21.10/src/main/java/org/dynmap/forge_1_21_10/DynmapPlugin.java
+++ b/forge-1.21.10/src/main/java/org/dynmap/forge_1_21_10/DynmapPlugin.java
@@ -201,6 +201,22 @@ public class DynmapPlugin
     }
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#getName(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.world.level.block.state.properties.Property<T> p) {
+        return p.getName(bs.getValue(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -243,7 +259,7 @@ public class DynmapPlugin
                 	if (statename.length() > 0) {
                 		statename += ",";
                 	}
-                	statename += p.getName() + "=" + bs.getValue(p).toString();
+                	statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = 15;
                 try {	// Workaround for mods with broken block state logic...

--- a/forge-1.21.11/src/main/java/org/dynmap/forge_1_21_11/DynmapPlugin.java
+++ b/forge-1.21.11/src/main/java/org/dynmap/forge_1_21_11/DynmapPlugin.java
@@ -201,6 +201,22 @@ public class DynmapPlugin
     }
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#getName(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.world.level.block.state.properties.Property<T> p) {
+        return p.getName(bs.getValue(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -243,7 +259,7 @@ public class DynmapPlugin
                 	if (statename.length() > 0) {
                 		statename += ",";
                 	}
-                	statename += p.getName() + "=" + bs.getValue(p).toString();
+                	statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = 15;
                 try {	// Workaround for mods with broken block state logic...

--- a/forge-1.21.6/src/main/java/org/dynmap/forge_1_21_6/DynmapPlugin.java
+++ b/forge-1.21.6/src/main/java/org/dynmap/forge_1_21_6/DynmapPlugin.java
@@ -200,6 +200,22 @@ public class DynmapPlugin
     }
 
     /**
+     * Get the name of a property's value within a block state, as it is serialized into
+     * the chunk NBT.
+     *
+     * Property#getName(T) resolves to the serialized name for enum properties, which is what
+     * the chunk palette stores. Calling toString() on the value instead yields the Java
+     * enum constant name. That matches only by coincidence -- as it does for vanilla,
+     * whose constants are uppercased serialized names -- so modded enums whose constant
+     * names differ (e.g. a constant N_E serialized as "ne") fail to resolve at chunk load
+     * and silently render as air.
+     */
+    private static <T extends Comparable<T>> String getPropertyValueName(BlockState bs,
+            net.minecraft.world.level.block.state.properties.Property<T> p) {
+        return p.getName(bs.getValue(p));
+    }
+
+    /**
      * Initialize block states (org.dynmap.blockstate.DynmapBlockState)
      */
     public void initializeBlockStates() {
@@ -242,7 +258,7 @@ public class DynmapPlugin
                 	if (statename.length() > 0) {
                 		statename += ",";
                 	}
-                	statename += p.getName() + "=" + bs.getValue(p).toString();
+                	statename += p.getName() + "=" + getPropertyValueName(bs, p);
                 }
                 int lightAtten = 15;
                 try {	// Workaround for mods with broken block state logic...


### PR DESCRIPTION
# Use serialized property names when building block state names

## Problem

Modded blocks with enum properties whose Java constant names differ from their
serialized names are silently rendered as air. No warning is logged, no texture is
reported missing, and no amount of renderdata will reach them.

`DynmapPlugin.initializeBlockStates()` records a name for every block state:

```java
statename += p.getName() + "=" + bs.getValue(p).toString();
```

For an enum property, `Object#toString()` returns the **Java constant name**. The chunk
NBT palette stores the **serialized name**. `GenericMapChunkCache` builds its lookup key
from the NBT and matches it against the recorded name in
`DynmapBlockState.getStateByNameAndState()`, which lowercases and compares.

Vanilla survives this because vanilla enum constants are just uppercased serialized names
(`NORTH` / `"north"`, `NORTH_SOUTH` / `"north_south"`). Any mod enum where they diverge
does not match.

The failure is silent and permanent for the session:

```java
rslt = AIR;  // Assume miss
...
blk.lookup.put(statename, rslt);  // Cache the lookup
```

`getStateByNameAndState` returns `AIR` rather than `null` on a miss, so the
`if (palette[pi] == null) palette[pi] = getBaseStateByName(pname);` fallback in the
palette loop never fires, and the miss is cached. The block is gone before anything
consults a texture map, which is why it never shows up in the `dump-missing-blocks`
report or the verbose `no texture mapping` output.

## Reproduction

TerraFirmaCraft's `Flow` enum, used by `tfc:fluid/river_water`:

```java
EEE("e"), NEE("nee"), N_E("ne"), NNE("nne"), NNN("n"), NNW("nnw"), N_W("nw"), NWW("nww"),
WWW("w"), SWW("sww"), S_W("sw"), SSW("ssw"), SSS("s"), SSE("sse"), S_E("se"), SEE("see"), ___("none");
```

Lowercased constant name vs serialized name:

| resolves | fails |
|---|---|
| `NEE`→`nee`, `NNE`→`nne`, `NNW`→`nnw`, `NWW`→`nww` | `EEE`→`eee` ≠ `e` |
| `SWW`→`sww`, `SSW`→`ssw`, `SSE`→`sse`, `SEE`→`see` | `N_E`→`n_e` ≠ `ne` |
| | `NNN`→`nnn` ≠ `n` |
| | `___`→`___` ≠ `none` |

Exactly the eight three-letter flow values render. Every one-letter, two-letter and
`none` value becomes air, producing holes in the middle of rivers that follow the flow
field rather than any obvious terrain feature. TFC leaves were affected too, via a
separate enum property, which went unnoticed until this was fixed.

## Fix

Use the property's own name-for-value method, which resolves to the serialized name for
enum properties and to `toString()` for boolean and integer properties, where the old
behaviour was already correct.

- Forge (official / MCP mappings): `Property#getName(T)`
- Fabric (Yarn mappings): `Property#name(T)`

A small generic helper is needed because `bs.getProperties()` yields `Property<?>`, and
two separate uses of the same wildcard in one expression capture independently. The
helper binds the capture once. `net.minecraft.Util#getPropertyName` in vanilla exists for
the same reason.

The Bukkit helpers are unaffected. They already derive state names by parsing
`IBlockData#toString()`, which goes through `StateHolder#toString()` and therefore uses
serialized names.

## Scope

20 files, `forge-1.14.4` through `forge-1.21.11` and `fabric-1.14.4` through
`fabric-1.21.9-10`. `forge-1.14.4` and `forge-1.15.2` iterate a raw `IProperty`, so no
helper is required there and the call is inlined.

## Verification

`forge-1.20` (Minecraft 1.20.1, Forge 47.4.13) built from `v3.7-beta-6` and run on a
TerraFirmaGreg-Modern server. All river water flow states render after a full render;
previously only eight of seventeen did. Other TFC blocks that were silently missing also
came back.

The remaining 19 modules are the same edit against their respective mappings and have not
been individually built. CI coverage on those would be welcome.
